### PR TITLE
Set the correct vscode engine compatibiltiy

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "vscjava",
   "preview": true,
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.26.0"
   },
   "icon": "logo.png",
   "galleryBanner": {


### PR DESCRIPTION
vscode engine should be set to `^1.26` because older VS Code versions does not support `extensionPack` property

@akaroml Please have this change before publishing the extension