### PR TITLE
Adjust overview page layout and add twitter link

### DIFF
--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -12,7 +12,7 @@
       <div class="col">
         <h1>Java Overview</h1>
       </div>
-   </div>
+    </div>
     <div class="row">
       <div class="col">
         <div class="row mb-3">

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -12,7 +12,7 @@
       <div class="col">
         <h1>Java Overview</h1>
       </div>
-    </div>
+   </div>
     <div class="row">
       <div class="col">
         <div class="row mb-3">
@@ -29,7 +29,7 @@
         </div>
         <div class="row mb-3">
           <div class="col">
-            <h3 class="font-weight-light">Help</h3>
+            <h3 class="font-weight-light">Documentation</h3>
             <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Flanguages%2Fjava%22" title="Learn how to work with Java code in VS Code">Java in VS Code Tutorial</a>
             </div>
@@ -38,9 +38,6 @@
             </div>
             <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-debugging%23_run-junit-tests%22" title="Learn how to work with JUnit test cases in VS Code">Run JUnit Tests</a>
-            </div>
-            <div>
-              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fgithub.com%2FMicrosoft%2Fvscode-java-pack%2Fissues%22" title="Report issues or request features">🙋 Questions & Issues</a>
             </div>
           </div>
         </div>
@@ -114,6 +111,17 @@
             </div>
             <div ext="peterjausovec.vscode-docker">
               <a href="command:java.helper.showExtension?%22peterjausovec.vscode-docker%22" title="Install Docker extension...">Install Docker Extension</a>
+            </div>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <h3 class="font-weight-light">Help</h3>
+            <div>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fgithub.com%2FMicrosoft%2Fvscode-java-pack%2Fissues%22" title="Report issues or request features">Questions & Issues</a>
+            </div>
+            <div>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Ftwitter.com%2Fintent%2Ftweet%3Fvia%3Dcode%26hashtags%3DJava%252CHappyCoding%22" title="Tweet us your feedback">Twitter</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The new page looks like this.

<img width="674" alt="screen shot 2018-12-01 at 12 31 52 pm" src="https://user-images.githubusercontent.com/16755094/49324247-1e151400-f565-11e8-8cc0-302b65164c85.png">
