### PR TITLE
Update command to create spring boot projects

### DIFF
--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -22,7 +22,7 @@ export async function createSpringBootProjectCmdHandler(context: vscode.Extensio
     return;
   }
 
-  await vscode.commands.executeCommand('spring.initializr.maven-project');
+  await vscode.commands.executeCommand('spring.initializr.createProject');
 }
 
 export async function showExtensionCmdHandler(context: vscode.ExtensionContext, operationId: string, extensionName: string) {


### PR DESCRIPTION
The command `spring.initializr.createProject` serves as an entry to create a Spring Boot projects. It allows users to select between Maven and Gradle, and executes the procedure accordingly.

![pack-spring-create](https://user-images.githubusercontent.com/2351748/51588615-b43f3800-1f1f-11e9-91a8-4c2f30b2151a.gif)
