### PR TITLE
Add release notes section in Overview

### DIFF
--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -212,6 +212,17 @@
         </div>
         <div class="row mb-3">
           <div class="col">
+            <h3 class="font-weight-light">Release Notes</h3>
+            <div>
+              <a href="command:java.showReleaseNotes?%220.6.0%22" title="February 2019 Release Notes">February 2019</a>
+            </div>
+            <div>
+              <a href="command:java.showReleaseNotes?%220.5.0%22" title="November 2018 Release Notes">November 2018</a>
+            </div>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
             <h3 class="font-weight-light">Help</h3>
             <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fgithub.com%2FMicrosoft%2Fvscode-java-pack%2Fissues%22" title="Report issues or request features">Questions & Issues</a>


### PR DESCRIPTION
"Release Notes" section is added on top of "Help" section.
![image](https://user-images.githubusercontent.com/16755094/55473242-c258b580-5640-11e9-8e55-d03b59e37509.png)
