### PR TITLE
Use Java language extension to get Java Home

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,12 +95,14 @@
     "webpack-cli": "^3.3.1"
   },
   "extensionPack": [
-    "redhat.java",
     "vscjava.vscode-java-debug",
     "vscjava.vscode-java-test",
     "vscjava.vscode-maven",
     "vscjava.vscode-java-dependency",
     "VisualStudioExptTeam.vscodeintellicode"
+  ],
+  "extensionDependencies": [
+    "redhat.java"
   ],
   "dependencies": {
     "semver": "^5.7.0",

--- a/src/java-runtime/index.ts
+++ b/src/java-runtime/index.ts
@@ -2,79 +2,23 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-import * as cp from "child_process";
-import * as path from "path";
-import expandTilde = require("expand-tilde");
-import * as pathExists from "path-exists";
 import * as request from "request-promise-native";
-import findJavaHome = require("find-java-home");
 import architecture = require("arch");
 
-const isWindows = process.platform.indexOf("win") === 0;
-const JAVAC_FILENAME = path.join("bin", "javac" + (isWindows ? ".exe" : "")) ;
-const JAVA_FILENAME = path.join("bin", "java" + (isWindows ? ".exe" : ""));
-
-async function getJavaVersion(javaHome: string | undefined): Promise<number> {
-  if (!javaHome) {
-    return Promise.resolve(0);
-  }
-
-  return new Promise<number>((resolve, reject) => {
-    cp.execFile(path.resolve(javaHome, JAVA_FILENAME),["-version"], {}, (err, stdout, stderr) => {
-      const regex = /version "(\d+)\.(\d+).*"/g;
-      const match = regex.exec(stderr);
-      if (!match) {
-        resolve(0);
-        return;
-      }
-
-      let major = parseInt(match[1]), minor = parseInt(match[2]);
-      if (major === 1) {
-        resolve(minor);
-      }
-
-      resolve(major);
-    });
-  });
-}
-
-async function findPossibleJdkInstallations(): Promise<{[location : string] : string | undefined}> {
-  return new Promise<{[location : string] : string | undefined}>((resolve, reject) => {
-    const javaHomeEntries: {[location : string] : string | undefined} = {
-      "java.home": vscode.workspace.getConfiguration().get("java.home", undefined),
-      "JDK_HOME": process.env["JDK_HOME"],
-      "JAVA_HOME": process.env["JAVA_HOME"],
-      "java.other": undefined
-    };
-
-    findJavaHome({allowJre: false}, (err, home) => {
-      if (!err) {
-        javaHomeEntries.other = home;
-      }
-
-      resolve(javaHomeEntries);
-    });
-  });
-}
-
-async function validateJdkInstallation(javaHome: string | undefined) {
-  if (!javaHome) {
+export async function validateJavaRuntime(): Promise<boolean> {
+  const extension = vscode.extensions.getExtension("redhat.java");
+  if (!extension) {
     return false;
   }
-
-  javaHome = expandTilde(javaHome);
-  return await pathExists(path.resolve(javaHome, JAVAC_FILENAME));
-}
-
-export async function validateJavaRuntime() {
-  const jdkEntries = await findPossibleJdkInstallations();
-  for (const key in jdkEntries) {
-    if (jdkEntries.hasOwnProperty(key)) {
-      const entry = jdkEntries[key];
-      if (await validateJdkInstallation(entry) && await getJavaVersion(entry) >= 8) {
-        return true;
+  try {
+      const extensionApi = await extension.activate();
+      // If the extension API loads, and requirement is set,
+      // a JDK compatible with the Java Language extension is guaranteed.
+      // No need to check the version
+      if (extensionApi && extensionApi.javaRequirement) {
+          return true;
       }
-    }
+  } catch (ex) {
   }
 
   return false;


### PR DESCRIPTION
This means the extension and its checking will always match what the language extension requires.

There is one downside with this, in that this does require the redhat extension to fully start up. This can delay loading of this extension, as that requires model syncing, but maybe I can work with that extension to fix that issue.

Either this or #144  will fix JDK parsing. Which one the owners would prefer is up to them, I will close the not merged one.