### PR TITLE
Upgrade to find-java-home@1.0.0 to support OracleJDK recognition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,15 +50,6 @@
       "integrity": "sha512-17h/6MRHoetV2QVUVnUfrmaFCXNIFJ3uDJmXlklX2xDtlEb1W0OXLgP+qwND2Ibg/PtQfQi0vx19KGuPayjLiw==",
       "dev": true
     },
-    "@types/find-java-home": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@types/find-java-home/-/find-java-home-0.2.0.tgz",
-      "integrity": "sha512-L57tuVvN7MZVck0snGZhBkM4eNBWg5fVtgXb6YeCsBrlBr1+bIw0YCfNQZGSffLAHuomFMwSlMq1MsuQCS5+Og==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/form-data": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
@@ -2504,9 +2495,9 @@
       }
     },
     "find-java-home": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-0.2.0.tgz",
-      "integrity": "sha512-nq5PFOHxE1VSEbdDVkLoA2bAcRnG4ETqJO8ipFq3glIWA52hdWCXYX3emuUyMAQfaqFU4Ea85gqcgaPmOApEPA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-1.0.0.tgz",
+      "integrity": "sha512-eqC9OCUT3stF1zfDJ/g0Uz9XFPi5X+2ZAv84Y+itA2x5scCe6GCF585re8YjjoJeIOipjNMRMM7s2E3ige+6+w==",
       "dev": true,
       "requires": {
         "which": "~1.0.5",
@@ -2790,7 +2781,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2950,6 +2942,7 @@
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2968,6 +2961,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3068,6 +3062,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3153,7 +3148,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3189,6 +3185,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3252,12 +3249,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   "devDependencies": {
     "@types/bytes": "^3.0.0",
     "@types/expand-tilde": "^2.0.0",
-    "@types/find-java-home": "^0.2.0",
     "@types/jquery": "^3.3.29",
     "@types/node": "^8.10.46",
     "@types/path-exists": "^3.0.0",
@@ -81,7 +80,7 @@
     "bytes": "^3.1.0",
     "css-loader": "^0.28.11",
     "expand-tilde": "^2.0.2",
-    "find-java-home": "^0.2.0",
+    "find-java-home": "^1.0.0",
     "html-webpack-inline-source-plugin": "0.0.10",
     "html-webpack-plugin": "^3.2.0",
     "jquery": "^3.4.0",


### PR DESCRIPTION
See https://github.com/jsdevel/node-find-java-home/issues/19

And the fix has been shipped in `find-java-home@1.0.0`