### PR TITLE
Add create Quarkus Tools for VS code links in overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Spring Tools 4 (ST4) is also available in Visual Studio Code. It understands Spr
 
 To use ST4, install [📦 Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack). Please also check out the [User Guide](https://github.com/spring-projects/sts4/wiki) to make the most of it.
 
+### Quarkus
+
+[📦 Quarkus Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus) is a feature-packed extension tailored for Quarkus application
+development within Visual Studio Code. You can quickly get started by using the extension's 
+project generation and project debugging feature. The extension also provides amazing
+language features (completion, hover, validation etc.) for your project's application.properties file.
+
 ### Containers and Microservices
 
 You can use [📦 Docker](https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker) extension to build docker images and work with image registries.

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -26,6 +26,15 @@ export async function createSpringBootProjectCmdHandler(context: vscode.Extensio
   await vscode.commands.executeCommand("spring.initializr.createProject");
 }
 
+export async function createQuarkusProjectCmdHandler(context: vscode.ExtensionContext) {
+  if (!await validateAndRecommendExtension("redhat.vscode-quarkus", "Quarkus Tools for Visual Studio Code is recommended to help create Quarkus projects and for an all-in-one Quarkus application development experience.", true)) {
+    return;
+  }
+
+  await vscode.commands.executeCommand("quarkusTools.createProject");
+}
+
+
 export async function showExtensionCmdHandler(context: vscode.ExtensionContext, operationId: string, extensionName: string) {
   sendInfo(operationId, { extName: extensionName });
   vscode.commands.executeCommand("extension.open", extensionName);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@
 import * as vscode from "vscode";
 
 import { instrumentCommand } from "../utils";
-import { createMavenProjectCmdHandler, createSpringBootProjectCmdHandler, showExtensionCmdHandler, openUrlCmdHandler, showReleaseNotesHandler, installExtensionCmdHandler } from "./handler";
+import { createMavenProjectCmdHandler, createSpringBootProjectCmdHandler, createQuarkusProjectCmdHandler, showExtensionCmdHandler, openUrlCmdHandler, showReleaseNotesHandler, installExtensionCmdHandler } from "./handler";
 import { overviewCmdHandler } from "../overview";
 import { javaRuntimeCmdHandler } from "../java-runtime";
 import { javaGettingStartedCmdHandler } from "../getting-started";
@@ -13,6 +13,7 @@ export function initialize(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand("java.overview", instrumentCommand(context, "java.overview", instrumentCommand(context, "java.helper.overview", overviewCmdHandler))));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.createMavenProject", instrumentCommand(context, "java.helper.createMavenProject", createMavenProjectCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.createSpringBootProject", instrumentCommand(context, "java.helper.createSpringBootProject", createSpringBootProjectCmdHandler)));
+  context.subscriptions.push(vscode.commands.registerCommand("java.helper.createQuarkusProject", instrumentCommand(context, "java.helper.createQuarkusProject", createQuarkusProjectCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.showExtension", instrumentCommand(context, "java.helper.showExtension", showExtensionCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.openUrl", instrumentCommand(context, "java.helper.openUrl", openUrlCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.showReleaseNotes", instrumentCommand(context, "java.showReleaseNotes", showReleaseNotesHandler)));

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -120,6 +120,9 @@
             <div>
               <a href="command:java.helper.createSpringBootProject" title="Create a project with Spring Initializr">Create a Spring Boot project...</a>
             </div>
+            <div>
+              <a href="command:java.helper.createQuarkusProject" title="Create a project with Quarkus Tools for Visual Studio Code">Create a Quarkus project...</a>
+            </div>
             <!-- <a href="command:java.helper.createJavaFile">Create a standalone Java file...</a><br> -->
           </div>
         </div>
@@ -202,11 +205,17 @@
             <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fazure%2Fdocker%22" title="Learn how to work with Docker in VS Code">Docker in VS Code</a>
             </div>
+            <div>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22" title="Marketplace link for Quarkus Tools for VS Code">Quarkus Tools for VS Code</a>
+            </div>
             <div ext="ms-kubernetes-tools.vscode-kubernetes-tools" displayName="Kubernetes">
               <a href="#" title="Install Kubernetes extension...">Install Kubernetes Extension</a>
             </div>
             <div ext="ms-azuretools.vscode-docker" displayName="Docker">
               <a href="#" title="Install Docker extension...">Install Docker Extension</a>
+            </div>
+            <div ext="redhat.vscode-quarkus" displayName="Quarkus">
+              <a href="#" title="Install Quarkus extension...">Install Quarkus Extension</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Hi, this PR adds links about [Quarkus Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus) to the Java overview page:
![image](https://user-images.githubusercontent.com/20326645/67499189-a6554980-f64e-11e9-8494-edefcbf33585.png)

There are two new links: "Create a Quarkus project..." and "Quarkus Tools for VS Code".

Information about the Quarkus extension was added to the readme.

Please let me know if anything should change. Thank you.



Signed-off-by: David Kwon <dakwon@redhat.com>