### PR TITLE
Add create MicroProfile Starter for VS Code links in overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Spring Tools 4 (ST4) is also available in Visual Studio Code. It understands Spr
 
 To use ST4, install [📦 Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack). Please also check out the [User Guide](https://github.com/spring-projects/sts4/wiki) to make the most of it.
 
+### Eclipse MicroProfile
+
+[📦 MicroProfile Starter for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-starter-vscode-ext) provides support for generating a starter MicroProfile Maven project using the Eclipse MicroProfile Starter project by the MicroProfile community.  You can quickly generate a project by choosing a MicroProfile version, a server runtime, and specifications such as CDI, Config, Health Check, Metrics, and more.
+
+
 ### Quarkus
 
 [📦 Quarkus Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus) is a feature-packed extension tailored for Quarkus application

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -26,6 +26,14 @@ export async function createSpringBootProjectCmdHandler(context: vscode.Extensio
   await vscode.commands.executeCommand("spring.initializr.createProject");
 }
 
+export async function createMicroProfileStarterProjectCmdHandler(context: vscode.ExtensionContext) {
+  if (!await validateAndRecommendExtension("microProfile-community.mp-starter-vscode-ext", "MicroProfile Starter for Visual Studio Code is recommended to generate starter projects for Eclipse MicroProfile.", true)) {
+    return;
+  }
+
+  await vscode.commands.executeCommand("extension.microProfileStarter");
+}
+
 export async function createQuarkusProjectCmdHandler(context: vscode.ExtensionContext) {
   if (!await validateAndRecommendExtension("redhat.vscode-quarkus", "Quarkus Tools for Visual Studio Code is recommended to help create Quarkus projects and for an all-in-one Quarkus application development experience.", true)) {
     return;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@
 import * as vscode from "vscode";
 
 import { instrumentCommand } from "../utils";
-import { createMavenProjectCmdHandler, createSpringBootProjectCmdHandler, createQuarkusProjectCmdHandler, showExtensionCmdHandler, openUrlCmdHandler, showReleaseNotesHandler, installExtensionCmdHandler } from "./handler";
+import { createMavenProjectCmdHandler, createSpringBootProjectCmdHandler, createQuarkusProjectCmdHandler, showExtensionCmdHandler, openUrlCmdHandler, showReleaseNotesHandler, installExtensionCmdHandler, createMicroProfileStarterProjectCmdHandler } from "./handler";
 import { overviewCmdHandler } from "../overview";
 import { javaRuntimeCmdHandler } from "../java-runtime";
 import { javaGettingStartedCmdHandler } from "../getting-started";
@@ -13,6 +13,7 @@ export function initialize(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand("java.overview", instrumentCommand(context, "java.overview", instrumentCommand(context, "java.helper.overview", overviewCmdHandler))));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.createMavenProject", instrumentCommand(context, "java.helper.createMavenProject", createMavenProjectCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.createSpringBootProject", instrumentCommand(context, "java.helper.createSpringBootProject", createSpringBootProjectCmdHandler)));
+  context.subscriptions.push(vscode.commands.registerCommand("java.helper.createMicroProfileStarterProject", instrumentCommand(context, "java.helper.createMicroProfileStarterProject", createMicroProfileStarterProjectCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.createQuarkusProject", instrumentCommand(context, "java.helper.createQuarkusProject", createQuarkusProjectCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.showExtension", instrumentCommand(context, "java.helper.showExtension", showExtensionCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.openUrl", instrumentCommand(context, "java.helper.openUrl", openUrlCmdHandler)));

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -121,6 +121,9 @@
               <a href="command:java.helper.createSpringBootProject" title="Create a project with Spring Initializr">Create a Spring Boot project...</a>
             </div>
             <div>
+              <a href="command:java.helper.createMicroProfileStarterProject" title="Create a project with MicroProfile Starter for Visual Studio Code">Create a MicroProfile project...</a>
+            </div>
+            <div>
               <a href="command:java.helper.createQuarkusProject" title="Create a project with Quarkus Tools for Visual Studio Code">Create a Quarkus project...</a>
             </div>
             <!-- <a href="command:java.helper.createJavaFile">Create a standalone Java file...</a><br> -->
@@ -206,6 +209,9 @@
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fazure%2Fdocker%22" title="Learn how to work with Docker in VS Code">Docker in VS Code</a>
             </div>
             <div>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3DMicroProfile-Community.mp-starter-vscode-ext%26ssr%3Dfalse%23overview%22" title="Marketplace link for MicroProfile Starter for VS Code">MicroProfile Starter for VS Code</a>
+            </div>
+            <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22" title="Marketplace link for Quarkus Tools for VS Code">Quarkus Tools for VS Code</a>
             </div>
             <div ext="ms-kubernetes-tools.vscode-kubernetes-tools" displayName="Kubernetes">
@@ -213,6 +219,9 @@
             </div>
             <div ext="ms-azuretools.vscode-docker" displayName="Docker">
               <a href="#" title="Install Docker extension...">Install Docker Extension</a>
+            </div>
+            <div ext="MicroProfile-Community.mp-starter-vscode-ext" displayName="MicroProfile">
+              <a href="#" title="Install MicroProfile Starter extension...">Install MicroProfile Starter Extension</a>
             </div>
             <div ext="redhat.vscode-quarkus" displayName="Quarkus">
               <a href="#" title="Install Quarkus extension...">Install Quarkus Extension</a>


### PR DESCRIPTION
This PR adds links about [MicroProfile Starter for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-starter-vscode-ext) to the Java overview page:
![image](https://user-images.githubusercontent.com/26146482/69383123-d2341100-0c86-11ea-9011-2189932b0b82.png)

There are 3 new links: "Create a MicroProfile project...", "MicroProfile Starter for VS Code", and "Install MicroProfile Starter Extension".

Please let me know if anything should be changed.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>