### PR TITLE
Add Open Liberty Tools for VS Code links in overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Spring Tools 4 (ST4) is also available in Visual Studio Code. It understands Spr
 
 To use ST4, install [📦 Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack). Please also check out the [User Guide](https://github.com/spring-projects/sts4/wiki) to make the most of it.
 
+### Open Liberty
+
+You can use [📦 Open Liberty Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) to develop your cloud-native Java applications on Open Liberty. This extension provides tools for you to develop and manage your Open Liberty projects in VS Code. It has an explorer view for you to run Liberty in development mode and manage the available projects in your workspace.
+
 ### Quarkus
 
 [📦 Quarkus Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus) is a feature-packed extension tailored for Quarkus application

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ Spring Tools 4 (ST4) is also available in Visual Studio Code. It understands Spr
 
 To use ST4, install [📦 Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack). Please also check out the [User Guide](https://github.com/spring-projects/sts4/wiki) to make the most of it.
 
-### Open Liberty
-
-You can use [📦 Open Liberty Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) to develop your cloud-native Java applications on Open Liberty. This extension provides tools for you to develop and manage your Open Liberty projects in VS Code. It has an explorer view for you to run Liberty in development mode and manage the available projects in your workspace.
-
 ### Quarkus
 
 [📦 Quarkus Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus) is a feature-packed extension tailored for Quarkus application
 development within Visual Studio Code. You can quickly get started by using the extension's 
 project generation and project debugging feature. The extension also provides amazing
 language features (completion, hover, validation etc.) for your project's application.properties file.
+
+### Open Liberty
+
+You can use [📦 Open Liberty Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) to develop your cloud-native Java applications on Open Liberty. This extension provides tools for you to develop and manage your Open Liberty projects in VS Code. It has an explorer view for you to run Liberty in development mode and manage the available projects in your workspace.
 
 ### Containers and Microservices
 

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -206,10 +206,10 @@
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fazure%2Fdocker%22" title="Learn how to work with Docker in VS Code">Docker in VS Code</a>
             </div>
             <div>
-              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3DOpen-Liberty.liberty-dev-vscode-ext%26ssr%3Dfalse%23overview%22" title="Marketplace link for Open Liberty Tools in VS Code">Open Liberty Tools for VS Code</a>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22" title="Marketplace link for Quarkus Tools for VS Code">Quarkus Tools for VS Code</a>
             </div>
             <div>
-              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22" title="Marketplace link for Quarkus Tools for VS Code">Quarkus Tools for VS Code</a>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3DOpen-Liberty.liberty-dev-vscode-ext%26ssr%3Dfalse%23overview%22" title="Marketplace link for Open Liberty Tools in VS Code">Open Liberty Tools for VS Code</a>
             </div>
             <div ext="ms-kubernetes-tools.vscode-kubernetes-tools" displayName="Kubernetes">
               <a href="#" title="Install Kubernetes extension...">Install Kubernetes Extension</a>
@@ -217,11 +217,11 @@
             <div ext="ms-azuretools.vscode-docker" displayName="Docker">
               <a href="#" title="Install Docker extension...">Install Docker Extension</a>
             </div>
-            <div ext="open-liberty.liberty-dev-vscode-ext" displayName="Open Liberty Tools">
-              <a href="#" title="Install Open Liberty Tools extension...">Install Open Liberty Extension</a>
-            </div>
             <div ext="redhat.vscode-quarkus" displayName="Quarkus">
               <a href="#" title="Install Quarkus extension...">Install Quarkus Extension</a>
+            </div>
+            <div ext="open-liberty.liberty-dev-vscode-ext" displayName="Open Liberty Tools">
+              <a href="#" title="Install Open Liberty Tools extension...">Install Open Liberty Extension</a>
             </div>
           </div>
         </div>

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -206,6 +206,9 @@
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fazure%2Fdocker%22" title="Learn how to work with Docker in VS Code">Docker in VS Code</a>
             </div>
             <div>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3DOpen-Liberty.liberty-dev-vscode-ext%26ssr%3Dfalse%23overview%22" title="Marketplace link for Open Liberty Tools in VS Code">Open Liberty Tools for VS Code</a>
+            </div>
+            <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22" title="Marketplace link for Quarkus Tools for VS Code">Quarkus Tools for VS Code</a>
             </div>
             <div ext="ms-kubernetes-tools.vscode-kubernetes-tools" displayName="Kubernetes">
@@ -213,6 +216,9 @@
             </div>
             <div ext="ms-azuretools.vscode-docker" displayName="Docker">
               <a href="#" title="Install Docker extension...">Install Docker Extension</a>
+            </div>
+            <div ext="open-liberty.liberty-dev-vscode-ext" displayName="Open Liberty Tools">
+              <a href="#" title="Install Open Liberty Tools extension...">Install Open Liberty Extension</a>
             </div>
             <div ext="redhat.vscode-quarkus" displayName="Quarkus">
               <a href="#" title="Install Quarkus extension...">Install Quarkus Extension</a>


### PR DESCRIPTION
This PR adds links about [Open Liberty Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) to the Java overview page:
![image](https://user-images.githubusercontent.com/26146482/69558259-e96c4a80-0f75-11ea-8f1f-7b646db321ea.png)

There are two new links: "Open Liberty Tools for VS Code" and "Install Open Liberty Extension".

Please let me know if anything should be changed.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>