### PR TITLE
Updated Content Security Policy to be more strict

### DIFF
--- a/src/getting-started/assets/index.html
+++ b/src/getting-started/assets/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'unsafe-inline'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'">
   <title>Java Getting Started</title>
 </head>
 

--- a/src/java-runtime/assets/index.html
+++ b/src/java-runtime/assets/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'unsafe-inline'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'">
   <title>Configure Java Runtime</title>
 </head>
 

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'">
   <title>Java Overview</title>
 </head>
 


### PR DESCRIPTION
This PR fixes microsoft/vscode-java-pack#171. As no resources are being used by the extension right now, so default source can be none. Later if the extension needs some image, script or style then the policy can be updated.