### PR TITLE
Add MicroProfile extension pack and Starter links in overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Spring Tools 4 (ST4) is also available in Visual Studio Code. It understands Spr
 
 To use ST4, install [📦 Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack). Please also check out the [User Guide](https://github.com/spring-projects/sts4/wiki) to make the most of it.
 
+### Eclipse MicroProfile
+
+The [📦 MicroProfile Extension Pack](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack) is a collection of extensions that can help develop your Java microservices using [Eclipse MicroProfile](https://microprofile.io/). You can quickly generate a MicroProfile project and utilize development tools for runtimes such as [Open Liberty](https://microprofile.io/) and [Quarkus](https://quarkus.io/).
+
 ### Quarkus
 
 [📦 Quarkus Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus) is a feature-packed extension tailored for Quarkus application

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -34,6 +34,14 @@ export async function createQuarkusProjectCmdHandler(context: vscode.ExtensionCo
   await vscode.commands.executeCommand("quarkusTools.createProject");
 }
 
+export async function createMicroProfileStarterProjectCmdHandler(context: vscode.ExtensionContext) {
+  if (!await validateAndRecommendExtension("microProfile-community.mp-starter-vscode-ext", "MicroProfile Starter for Visual Studio Code is recommended to generate starter projects for Eclipse MicroProfile.", true)) {
+    return;
+  }
+
+  await vscode.commands.executeCommand("extension.microProfileStarter");
+}
+
 
 export async function showExtensionCmdHandler(context: vscode.ExtensionContext, operationId: string, extensionName: string) {
   sendInfo(operationId, { extName: extensionName });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@
 import * as vscode from "vscode";
 
 import { instrumentCommand } from "../utils";
-import { createMavenProjectCmdHandler, createSpringBootProjectCmdHandler, createQuarkusProjectCmdHandler, showExtensionCmdHandler, openUrlCmdHandler, showReleaseNotesHandler, installExtensionCmdHandler } from "./handler";
+import { createMavenProjectCmdHandler, createSpringBootProjectCmdHandler, createQuarkusProjectCmdHandler, createMicroProfileStarterProjectCmdHandler, showExtensionCmdHandler, openUrlCmdHandler, showReleaseNotesHandler, installExtensionCmdHandler } from "./handler";
 import { overviewCmdHandler } from "../overview";
 import { javaRuntimeCmdHandler } from "../java-runtime";
 import { javaGettingStartedCmdHandler } from "../getting-started";
@@ -14,6 +14,7 @@ export function initialize(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.createMavenProject", instrumentCommand(context, "java.helper.createMavenProject", createMavenProjectCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.createSpringBootProject", instrumentCommand(context, "java.helper.createSpringBootProject", createSpringBootProjectCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.createQuarkusProject", instrumentCommand(context, "java.helper.createQuarkusProject", createQuarkusProjectCmdHandler)));
+  context.subscriptions.push(vscode.commands.registerCommand("java.helper.createMicroProfileStarterProject", instrumentCommand(context, "java.helper.createMicroProfileStarterProject", createMicroProfileStarterProjectCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.showExtension", instrumentCommand(context, "java.helper.showExtension", showExtensionCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.helper.openUrl", instrumentCommand(context, "java.helper.openUrl", openUrlCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.showReleaseNotes", instrumentCommand(context, "java.showReleaseNotes", showReleaseNotesHandler)));

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -123,6 +123,9 @@
             <div>
               <a href="command:java.helper.createQuarkusProject" title="Create a project with Quarkus Tools for Visual Studio Code">Create a Quarkus project...</a>
             </div>
+            <div>
+              <a href="command:java.helper.createMicroProfileStarterProject" title="Create a project with MicroProfile Starter for Visual Studio Code">Create a MicroProfile project...</a>
+            </div>
             <!-- <a href="command:java.helper.createJavaFile">Create a standalone Java file...</a><br> -->
           </div>
         </div>
@@ -206,6 +209,8 @@
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fazure%2Fdocker%22" title="Learn how to work with Docker in VS Code">Docker in VS Code</a>
             </div>
             <div>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3DMicroProfile-Community.vscode-microprofile-pack%26ssr%3Dfalse%23overview%22" title="Marketplace link for MicroProfile Extension Pack">MicroProfile Extension Pack for VS Code</a>
+            <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22" title="Marketplace link for Quarkus Tools for VS Code">Quarkus Tools for VS Code</a>
             </div>
             <div ext="ms-kubernetes-tools.vscode-kubernetes-tools" displayName="Kubernetes">
@@ -213,6 +218,9 @@
             </div>
             <div ext="ms-azuretools.vscode-docker" displayName="Docker">
               <a href="#" title="Install Docker extension...">Install Docker Extension</a>
+            </div>
+            <div ext="MicroProfile-Community.vscode-microprofile-pack" displayName="MicroProfile Extension Pack">
+              <a href="#" title="Install MicroProfile extension pack...">Install MicroProfile Extension Pack</a>
             </div>
             <div ext="redhat.vscode-quarkus" displayName="Quarkus">
               <a href="#" title="Install Quarkus extension...">Install Quarkus Extension</a>


### PR DESCRIPTION
This PR adds links about [MicroProfile Extension Pack](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack) and the [MicroProfile Starter Extension](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-starter-vscode-ext) to the Java overview page:
<img width="422" alt="Screen Shot 2020-02-07 at 11 44 39 AM" src="https://user-images.githubusercontent.com/26146482/74051439-f1992b00-49a5-11ea-9370-376129293c10.png">

There are three new links:
- "Create a MicroProfile project..."
- "MicroProfile Extension Pack for VS Code"
- "Install MicroProfile Extension Pack"

Please let me know if anything should be changed.
This pull request would replace #260 and #261.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>