### PR TITLE
Settings to reduce popups

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,15 +78,23 @@
           "enum": [
             "auto",
             "overview",
-            "gettingStarted"
+            "gettingStarted",
+            "none"
           ],
           "enumDescriptions": [
             "Automatically pick the first experience view",
             "Present the Java Overview page",
-            "Present the Java Getting Started page"
+            "Present the Java Getting Started page",
+            "Do not show any view"
           ],
           "default": "auto",
           "description": "Sets the default view which is presented during the first use.",
+          "scope": "window"
+        },
+        "java.help.showReleaseNotes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show Java Extension Pack release notes on startup.",
           "scope": "window"
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,13 +31,19 @@ async function initializeExtension(operationId: string, context: vscode.Extensio
   // context.subscriptions.push(vscode.window.registerWebviewPanelSerializer("java.runtime", new JavaRuntimeViewSerializer()));
   // context.subscriptions.push(vscode.window.registerWebviewPanelSerializer("java.gettingStarted", new JavaGettingStartedViewSerializer()));
 
-  scheduleAction("showFirstView", true).then(() => {
-    presentFirstView(context);
-  });
+  const config = vscode.workspace.getConfiguration("java.help");
 
-  scheduleAction("showReleaseNotes").then(() => {
-    showReleaseNotesOnStart(context);
-  });
+  if (config.get("firstView") !== HelpViewType.None) {
+    scheduleAction("showFirstView", true).then(() => {
+      presentFirstView(context);
+    });
+  }
+
+  if (config.get("showReleaseNotes")) {
+    scheduleAction("showReleaseNotes").then(() => {
+      showReleaseNotesOnStart(context);
+    });
+  }
 
   if (!await validateJavaRuntime()) {
     scheduleAction("showJdkState", true, true).then(() => {
@@ -55,11 +61,15 @@ async function presentFirstView(context: vscode.ExtensionContext) {
 
   const config = vscode.workspace.getConfiguration("java.help");
   const firstView = config.get("firstView");
-  if (firstView === HelpViewType.GettingStarted) {
-    await showGettingStartedView(context);
-  } else {
-    await showOverviewPageOnActivation(context);
-  }
+  switch (firstView) {
+    case HelpViewType.None:
+      break;
+    case HelpViewType.GettingStarted:  
+      await showGettingStartedView(context);
+      break;
+    default:
+      await showOverviewPageOnActivation(context);
+    }
 }
 
 async function showExtensionGuide(context: vscode.ExtensionContext) {

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -8,6 +8,7 @@ export enum HelpViewType {
   Auto = "auto",
   Overview = "overview",
   GettingStarted = "gettingStarted",
+  None = "none",
 }
 
 function showInfoButton() {
@@ -15,10 +16,14 @@ function showInfoButton() {
   const firstView = config.get("firstView");
 
   let infoButton = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
-  if (firstView === HelpViewType.GettingStarted) {
-    infoButton.command = "java.gettingStarted";
-  } else {
-    infoButton.command = "java.overview";
+  switch (firstView) {
+    case HelpViewType.None:
+      return;
+    case HelpViewType.GettingStarted:
+      infoButton.command = "java.gettingStarted";
+      break;
+    default:
+      infoButton.command = "java.overview";
   }
 
   infoButton.text = "$(info)";


### PR DESCRIPTION
Fixes #469 

Settings not to show at startup:
 - overview/getting started page
 - release notes

'none' enum value is added for `firstView`... maybe instead of it another boolean on/off first view would be better - let me know please