### PR TITLE
Add survey prompt logic

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { initialize as initCommands } from "./commands";
 import { initialize as initRecommendations } from "./recommendation";
 import { initialize as initMisc, showReleaseNotesOnStart, HelpViewType } from "./misc";
 import { initialize as initExp, getExpService } from "./exp";
+import { initialize as initSurvey } from "./survey"
 import { showOverviewPageOnActivation } from "./overview";
 import { validateJavaRuntime } from "./java-runtime";
 // import { JavaGettingStartedViewSerializer } from "./getting-started";
@@ -25,6 +26,7 @@ async function initializeExtension(operationId: string, context: vscode.Extensio
   initRecommendations(context);
   initMisc(context);
   initExp(context);
+  initSurvey(context);
 
   // disable webview serializer because of https://github.com/microsoft/vscode/issues/80185
   // context.subscriptions.push(vscode.window.registerWebviewPanelSerializer("java.overview", new OverviewViewSerializer()));

--- a/src/survey/constants.ts
+++ b/src/survey/constants.ts
@@ -2,34 +2,34 @@
 // Licensed under the MIT license.
 
 export const BannerActions = {
-    bannerLabelYes: 'Take Survey',
-    bannerLabelNo: 'Don\'t show again',
-    remindLater: 'Remind Me later'
+  bannerLabelYes: 'Take Survey',
+  bannerLabelNo: 'Don\'t show again',
+  remindLater: 'Remind Me later'
 }
 
 export const SurveyBanner = {
-    message: 'Do you mind taking a quick feedback survey about the Java extension pack?',
-    action: [
-        BannerActions.bannerLabelYes,
-        BannerActions.bannerLabelNo,
-        BannerActions.remindLater
-    ],
-    FIRST_STAGE_URL: 'https://www.microsoft.com',
-    SECOND_STAGE_URL: 'https://www.microsoft.com',
-    THIRD_STAGE_URL: 'https://www.microsoft.com',
+  message: 'Do you mind taking a quick feedback survey about the Java extension pack?',
+  action: [
+    BannerActions.bannerLabelYes,
+    BannerActions.bannerLabelNo,
+    BannerActions.remindLater
+  ],
+  FIRST_STAGE_URL: 'https://www.microsoft.com',
+  SECOND_STAGE_URL: 'https://www.microsoft.com',
+  THIRD_STAGE_URL: 'https://www.microsoft.com',
 }
 
 export enum SurveyKeys {
-    FIRST_ACTIVATION_TIME = 'packFirstActicationTime',
-    DISABLED_SURVEY_UNTIL = 'packDisableSurveyUntil',
-    DO_NOT_SHOW_AGAIN = 'packDoNotShowSurveyAgain'
+  FIRST_ACTIVATION_TIME = 'packFirstActicationTime',
+  DISABLED_SURVEY_UNTIL = 'packDisableSurveyUntil',
+  DO_NOT_SHOW_AGAIN = 'packDoNotShowSurveyAgain'
 }
 
 export enum SurveyTimespan {
-    FIRST_DAY = 1000 * 60 * 60 * 24, // 1 day
-    SURVEY_DISABLE_TIME = 1000 * 60 * 60 * 24 * 3, // 3 days
-    FIRST_STAGE = 1000 * 60 * 60 * 24 * 7, // 1 week
-    SECOND_STAGE = 1000 * 60 * 60 * 24 * 21 // 3 weeks
+  FIRST_DAY = 1000 * 60 * 60 * 24, // 1 day
+  SURVEY_DISABLE_TIME = 1000 * 60 * 60 * 24 * 3, // 3 days
+  FIRST_STAGE = 1000 * 60 * 60 * 24 * 7, // 1 week
+  SECOND_STAGE = 1000 * 60 * 60 * 24 * 21 // 3 weeks
 }
 
 export const PROBABILITY = 0.1;

--- a/src/survey/constants.ts
+++ b/src/survey/constants.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+export const BannerActions = {
+    bannerLabelYes: 'Take Survey',
+    bannerLabelNo: 'Don\'t show again',
+    remindLater: 'Remind Me later'
+}
+
+export const SurveyBanner = {
+    message: 'Do you mind taking a quick feedback survey about the Java extension pack?',
+    action: [
+        BannerActions.bannerLabelYes,
+        BannerActions.bannerLabelNo,
+        BannerActions.remindLater
+    ],
+    FIRST_STAGE_URL: 'https://www.microsoft.com',
+    SECOND_STAGE_URL: 'https://www.microsoft.com',
+    THIRD_STAGE_URL: 'https://www.microsoft.com',
+}
+
+export enum SurveyKeys {
+    FIRST_ACTIVATION_TIME = 'packFirstActicationTime',
+    DISABLED_SURVEY_UNTIL = 'packDisableSurveyUntil',
+    DO_NOT_SHOW_AGAIN = 'packDoNotShowSurveyAgain'
+}
+
+export enum SurveyTimespan {
+    FIRST_DAY = 1000 * 60 * 60 * 24, // 1 day
+    SURVEY_DISABLE_TIME = 1000 * 60 * 60 * 24 * 3, // 3 days
+    FIRST_STAGE = 1000 * 60 * 60 * 24 * 7, // 1 week
+    SECOND_STAGE = 1000 * 60 * 60 * 24 * 21 // 3 weeks
+}
+
+export const PROBABILITY = 0.1;

--- a/src/survey/index.ts
+++ b/src/survey/index.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import { sendInfo } from "vscode-extension-telemetry-wrapper";
+import { BannerActions, SurveyBanner, SurveyKeys, SurveyTimespan, PROBABILITY } from './constants'
+
+function getActivationTime(context: vscode.ExtensionContext): number {
+    return context.globalState.get(
+        SurveyKeys.FIRST_ACTIVATION_TIME, 
+        0
+    );
+}
+
+function getDoNotShowAgain(context: vscode.ExtensionContext): boolean {
+    return context.globalState.get(
+        SurveyKeys.DO_NOT_SHOW_AGAIN, 
+        false
+    );
+}
+
+function getDisableTimeUntil(context: vscode.ExtensionContext): number {
+    return context.globalState.get(
+        SurveyKeys.DISABLED_SURVEY_UNTIL,
+        0  
+    );
+}
+
+function saveFirstActivationTime(context: vscode.ExtensionContext, currentTime: number) {
+    let activationTime = getActivationTime(context);
+    if (!activationTime) {
+        context.globalState.update(
+            SurveyKeys.FIRST_ACTIVATION_TIME, 
+            currentTime
+        );
+    }
+}
+
+function shouldShowSurvey(context: vscode.ExtensionContext, currentTime: number): boolean {
+    if (currentTime - getActivationTime(context) < SurveyTimespan.FIRST_DAY) {
+        return false;
+    }
+    if (getDoNotShowAgain(context)) {
+        return false;
+    }
+    let disableTimeUntil = getDisableTimeUntil(context);
+    if (disableTimeUntil && currentTime < disableTimeUntil) {
+        return false;
+    }
+    // randomly sample 10% users
+    if (Math.random() > PROBABILITY) {
+        return false;
+    }
+    return true;
+}
+
+function openURL(URL: string) {
+    const uri = vscode.Uri.parse(URL);
+    vscode.env.openExternal(uri);
+}
+
+function disableSeed() {
+    // vary disable time with half day randomly
+    return Math.random() * SurveyTimespan.FIRST_DAY - SurveyTimespan.FIRST_DAY / 2;
+}
+
+function lauchSurvey(context: vscode.ExtensionContext, currentTime: number) {
+    // show different survey according to user's stage
+    let firstStageEnd = getActivationTime(context) + SurveyTimespan.FIRST_STAGE;
+    let secondStageEnd = getActivationTime(context) + SurveyTimespan.SECOND_STAGE;
+
+    if (currentTime <= firstStageEnd) {
+        openURL(SurveyBanner.FIRST_STAGE_URL);
+        context.globalState.update(
+            SurveyKeys.DISABLED_SURVEY_UNTIL,
+            firstStageEnd
+        );
+    }
+    else if (currentTime > firstStageEnd && currentTime <= secondStageEnd) {
+        openURL(SurveyBanner.SECOND_STAGE_URL);
+        context.globalState.update(
+            SurveyKeys.DISABLED_SURVEY_UNTIL,
+            secondStageEnd
+        );
+    }
+    else {
+        openURL(SurveyBanner.THIRD_STAGE_URL);
+        // disable survey for 12 weeks
+        context.globalState.update(
+            SurveyKeys.DISABLED_SURVEY_UNTIL,
+            currentTime + SurveyTimespan.FIRST_STAGE * 12
+        );
+    }
+}
+
+async function showSurveyBanner(context: vscode.ExtensionContext, currentTime: number) {
+    let answer = await vscode.window.showInformationMessage(SurveyBanner.message, ...SurveyBanner.action);
+  
+    sendInfo("", {
+        infoType: "surveyChoice",
+        choiceForSurvey: answer || "ignored",
+    });
+
+    if (!answer) {
+        return;
+    }
+    if (answer === BannerActions.bannerLabelYes) {
+        lauchSurvey(context, currentTime);
+    }
+    else if (answer === BannerActions.bannerLabelNo) {
+        context.globalState.update(
+            SurveyKeys.DO_NOT_SHOW_AGAIN,
+            true
+        );
+    }
+    else {
+        context.globalState.update(
+            SurveyKeys.DISABLED_SURVEY_UNTIL,
+            currentTime + SurveyTimespan.SURVEY_DISABLE_TIME + disableSeed()
+        );
+    }
+}
+
+export function initialize(context: vscode.ExtensionContext) {
+    let currentTime = new Date().getTime();
+    saveFirstActivationTime(context, currentTime);
+    if (shouldShowSurvey(context, currentTime)) {
+        showSurveyBanner(context, currentTime);
+    }
+}

--- a/src/survey/index.ts
+++ b/src/survey/index.ts
@@ -6,125 +6,121 @@ import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { BannerActions, SurveyBanner, SurveyKeys, SurveyTimespan, PROBABILITY } from './constants'
 
 function getActivationTime(context: vscode.ExtensionContext): number {
-    return context.globalState.get(
-        SurveyKeys.FIRST_ACTIVATION_TIME, 
-        0
-    );
+  return context.globalState.get(
+    SurveyKeys.FIRST_ACTIVATION_TIME,
+    0
+  );
 }
 
 function getDoNotShowAgain(context: vscode.ExtensionContext): boolean {
-    return context.globalState.get(
-        SurveyKeys.DO_NOT_SHOW_AGAIN, 
-        false
-    );
+  return context.globalState.get(
+    SurveyKeys.DO_NOT_SHOW_AGAIN,
+    false
+  );
 }
 
 function getDisableTimeUntil(context: vscode.ExtensionContext): number {
-    return context.globalState.get(
-        SurveyKeys.DISABLED_SURVEY_UNTIL,
-        0  
-    );
+  return context.globalState.get(
+    SurveyKeys.DISABLED_SURVEY_UNTIL,
+    0  
+  );
 }
 
 function saveFirstActivationTime(context: vscode.ExtensionContext, currentTime: number) {
-    let activationTime = getActivationTime(context);
-    if (!activationTime) {
-        context.globalState.update(
-            SurveyKeys.FIRST_ACTIVATION_TIME, 
-            currentTime
-        );
-    }
+  let activationTime = getActivationTime(context);
+  if (!activationTime) {
+    context.globalState.update(
+      SurveyKeys.FIRST_ACTIVATION_TIME,
+      currentTime
+    );
+  }
 }
 
 function shouldShowSurvey(context: vscode.ExtensionContext, currentTime: number): boolean {
-    if (currentTime - getActivationTime(context) < SurveyTimespan.FIRST_DAY) {
-        return false;
-    }
-    if (getDoNotShowAgain(context)) {
-        return false;
-    }
-    let disableTimeUntil = getDisableTimeUntil(context);
-    if (disableTimeUntil && currentTime < disableTimeUntil) {
-        return false;
-    }
-    // randomly sample 10% users
-    if (Math.random() > PROBABILITY) {
-        return false;
-    }
-    return true;
+  if (currentTime - getActivationTime(context) < SurveyTimespan.FIRST_DAY) {
+    return false;
+  }
+  if (getDoNotShowAgain(context)) {
+    return false;
+  }
+  let disableTimeUntil = getDisableTimeUntil(context);
+  if (disableTimeUntil && currentTime < disableTimeUntil) {
+    return false;
+  }
+  // randomly sample 10% users
+  if (Math.random() > PROBABILITY) {
+    return false;
+  }
+  return true;
 }
 
 function openURL(URL: string) {
-    const uri = vscode.Uri.parse(URL);
-    vscode.env.openExternal(uri);
+  const uri = vscode.Uri.parse(URL);
+  vscode.env.openExternal(uri);
 }
 
 function disableSeed() {
-    // vary disable time with half day randomly
-    return Math.random() * SurveyTimespan.FIRST_DAY - SurveyTimespan.FIRST_DAY / 2;
+  // vary disable time with half day randomly
+  return Math.random() * SurveyTimespan.FIRST_DAY - SurveyTimespan.FIRST_DAY / 2;
 }
 
 function lauchSurvey(context: vscode.ExtensionContext, currentTime: number) {
-    // show different survey according to user's stage
-    let firstStageEnd = getActivationTime(context) + SurveyTimespan.FIRST_STAGE;
-    let secondStageEnd = getActivationTime(context) + SurveyTimespan.SECOND_STAGE;
+  // show different survey according to user's stage
+  let firstStageEnd = getActivationTime(context) + SurveyTimespan.FIRST_STAGE;
+  let secondStageEnd = getActivationTime(context) + SurveyTimespan.SECOND_STAGE;
 
-    if (currentTime <= firstStageEnd) {
-        openURL(SurveyBanner.FIRST_STAGE_URL);
-        context.globalState.update(
-            SurveyKeys.DISABLED_SURVEY_UNTIL,
-            firstStageEnd
-        );
-    }
-    else if (currentTime > firstStageEnd && currentTime <= secondStageEnd) {
-        openURL(SurveyBanner.SECOND_STAGE_URL);
-        context.globalState.update(
-            SurveyKeys.DISABLED_SURVEY_UNTIL,
-            secondStageEnd
-        );
-    }
-    else {
-        openURL(SurveyBanner.THIRD_STAGE_URL);
-        // disable survey for 12 weeks
-        context.globalState.update(
-            SurveyKeys.DISABLED_SURVEY_UNTIL,
-            currentTime + SurveyTimespan.FIRST_STAGE * 12
-        );
-    }
+  if (currentTime <= firstStageEnd) {
+    openURL(SurveyBanner.FIRST_STAGE_URL);
+    context.globalState.update(
+      SurveyKeys.DISABLED_SURVEY_UNTIL,
+      firstStageEnd
+    );
+  } else if (currentTime > firstStageEnd && currentTime <= secondStageEnd) {
+    openURL(SurveyBanner.SECOND_STAGE_URL);
+    context.globalState.update(
+      SurveyKeys.DISABLED_SURVEY_UNTIL,
+      secondStageEnd
+    );
+  } else {
+    openURL(SurveyBanner.THIRD_STAGE_URL);
+    // disable survey for 12 weeks
+    context.globalState.update(
+      SurveyKeys.DISABLED_SURVEY_UNTIL,
+      currentTime + SurveyTimespan.FIRST_STAGE * 12
+    );
+  }
 }
 
 async function showSurveyBanner(context: vscode.ExtensionContext, currentTime: number) {
-    let answer = await vscode.window.showInformationMessage(SurveyBanner.message, ...SurveyBanner.action);
+  let answer = await vscode.window.showInformationMessage(SurveyBanner.message, ...SurveyBanner.action);
   
-    sendInfo("", {
-        infoType: "surveyChoice",
-        choiceForSurvey: answer || "ignored",
-    });
+  sendInfo("", {
+    infoType: "surveyChoice",
+    choiceForSurvey: answer || "ignored",
+  });
 
-    if (!answer) {
-        return;
-    }
-    if (answer === BannerActions.bannerLabelYes) {
-        lauchSurvey(context, currentTime);
-    }
-    else if (answer === BannerActions.bannerLabelNo) {
-        context.globalState.update(
-            SurveyKeys.DO_NOT_SHOW_AGAIN,
-            true
-        );
-    }
-    else {
-        context.globalState.update(
-            SurveyKeys.DISABLED_SURVEY_UNTIL,
-            currentTime + SurveyTimespan.SURVEY_DISABLE_TIME + disableSeed()
-        );
-    }
+  if (!answer) {
+    return;
+  }
+  if (answer === BannerActions.bannerLabelYes) {
+    lauchSurvey(context, currentTime);
+  } else if (answer === BannerActions.bannerLabelNo) {
+    context.globalState.update(
+      SurveyKeys.DO_NOT_SHOW_AGAIN,
+      true
+    );
+  } else {
+    context.globalState.update(
+      SurveyKeys.DISABLED_SURVEY_UNTIL,
+      currentTime + SurveyTimespan.SURVEY_DISABLE_TIME + disableSeed()
+    );
+  }
 }
 
 export function initialize(context: vscode.ExtensionContext) {
-    let currentTime = new Date().getTime();
-    saveFirstActivationTime(context, currentTime);
-    if (shouldShowSurvey(context, currentTime)) {
-        showSurveyBanner(context, currentTime);
-    }
+  let currentTime = new Date().getTime();
+  saveFirstActivationTime(context, currentTime);
+  if (shouldShowSurvey(context, currentTime)) {
+    showSurveyBanner(context, currentTime);
+  }
 }


### PR DESCRIPTION
This PR added survey prompt logic for Java extension pack.

First, 10% users were randomly picked for showing survey. Then, user's usage was divided into 3 stages according to their first activation time (0 to 7, 7 to 21, 21 days or later), and different questionnaire will be shown in different stage.

If user finished the survey, it won't be prompt in current stage (or 12weeks in final stage). If user choose "don't show again", the survey won't prompt. If user choose "remind me later", the survey will be disabled for 2.5 to 3.5 days randomly.