### PR TITLE
Add a link to getting started view from the overview page

### DIFF
--- a/src/assets/vscode.scss
+++ b/src/assets/vscode.scss
@@ -7,7 +7,7 @@ $link-hover-decoration: none !default;
 $list-group-bg: var(--vscode-notifications-background) !default;
 $list-group-active-color: var(--vscode-notifications-foreground) !default;
 $list-group-active-bg: var(--vscode-notifications-border) !default;
-$list-group-hover-bg: $list-group-bg;
+$list-group-hover-bg: var(--vscode-list-hoverBackground) !default;
 $list-group-action-active-bg: $list-group-bg;
 $list-group-border-color: var(--vscode-notifications-background) !default;
 $list-group-action-color: var(--vscode-notifications-foreground) !default;

--- a/src/getting-started/assets/index.ts
+++ b/src/getting-started/assets/index.ts
@@ -26,3 +26,13 @@ $("a[data-toggle='tab']").on("shown.bs.tab", e => {
     tabId: e.target.id
   });
 });
+
+// Handle the message inside the webview
+window.addEventListener('message', event => {
+  const message = event.data;
+  switch (message.command) {
+      case 'tabActivated':
+        ($(message.tabId) as any).tab("show");
+        break;
+  }
+});

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -35,20 +35,6 @@
         </div>
         <div class="row mb-3">
           <div class="col">
-            <h3 class="font-weight-light">Documentation</h3>
-            <div>
-              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Flanguages%2Fjava%22" title="Learn how to work with Java code in VS Code">Java in VS Code Tutorial</a>
-            </div>
-            <div>
-              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-debugging%22" title="Learn how to debug Java apps in VS Code">Debugging Tutorial</a>
-            </div>
-            <div>
-              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-debugging%23_run-junit-tests%22" title="Learn how to work with JUnit test cases in VS Code">Run JUnit Tests</a>
-            </div>
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
             <h3 class="font-weight-light">Key Bindings</h3>
             <div ext="k--kato.intellij-idea-keybindings" displayName="IntelliJ IDEA Key Bindings">
               <a href="#" title="Use IntelliJ IDEA hot keys in VS Code...">Use IntelliJ IDEA Key Bindings</a>
@@ -157,6 +143,27 @@
             </div>
             <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Ftwitter.com%2Fintent%2Ftweet%3Fvia%3Dcode%26hashtags%3DJava%252CHappyCoding%22" title="Tweet us your feedback">Twitter</a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="row mb-3">
+          <div class="col">
+            <h3 class="font-weight-light">Learn</h3>
+            <div class="list-group">
+              <button id="gettingStartedBtn" class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2" title="Open Java Getting Started View">
+                  <p class="mb-1">Java Getting Started</p>
+                  <small>Learn 1 min <a href="command:java.gettingStarted?%22%23quick-start-tab%22">Quick Start</a> tutorial, common shortcuts for <a href="command:java.gettingStarted?%22%23code-editing-tab%22">Code Editing</a> and <a href="command:java.gettingStarted?%22%23debugging-tab%22">Debugging</a>, and <a href="command:java.gettingStarted?%22%23faq-tab%22">FAQ</a>.</small>
+              </button>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-debugging%22" class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2" title="Open Java Debugging Tutorial">
+                <p class="mb-1">Debugging Tutorial</p>
+                <small>Learn how to debug Java apps in VS Code.</small>
+              </a>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-testing%22" class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2" title="Open Java Testing Tutorial">
+                <p class="mb-1">Run JUnit Tests</p>
+                <small>Learn how to work with JUnit test cases in VS Code.</small>
+              </a>
             </div>
           </div>
         </div>

--- a/src/overview/assets/index.ts
+++ b/src/overview/assets/index.ts
@@ -57,3 +57,9 @@ function installExtension(extName: string, displayName: string) {
 $("div[ext]").click(function () {
   installExtension($(this).attr("ext") || "", $(this).attr("displayName") || "");
 });
+
+$("#gettingStartedBtn").click(function () {
+  vscode.postMessage({
+    command: "java.gettingStarted"
+  });
+});

--- a/src/overview/index.ts
+++ b/src/overview/index.ts
@@ -81,6 +81,8 @@ async function initializeOverviewView(context: vscode.ExtensionContext, webviewP
       toggleOverviewVisibilityOperation(context, e.visibility);
     } else if (e.command === "installExtension") {
       await vscode.commands.executeCommand("java.helper.installExtension", e.extName, e.displayName);
+    } else if (e.command === "java.gettingStarted") {
+      await vscode.commands.executeCommand("java.gettingStarted");
     }
   }));
 }


### PR DESCRIPTION
When you install vscode-java-pack extension from VS Code, it only popups the Overview page at the first startup. This PR will add the Getting Started view to Overview page to enhance the feature visibility. Below is the UX adjustment on Overview page:
- Add a new column for **Learn**.
- Add a row to jump to Java Getting Started webview.

Below is a screencast:
![overview](https://user-images.githubusercontent.com/14052197/97157235-cb751e80-17b2-11eb-9172-b3a6f7b72d95.gif)

