### PR TITLE
Bug fix: Clicking the blank place in Overview page will trigger a command

### DIFF
--- a/src/overview/assets/index.ts
+++ b/src/overview/assets/index.ts
@@ -54,6 +54,6 @@ function installExtension(extName: string, displayName: string) {
   });
 }
 
-$("div[ext]").click(function () {
-  installExtension($(this).attr("ext") || "", $(this).attr("displayName") || "");
+$("div[ext] > a").click(function () {
+  installExtension($(this.parentElement).attr("ext") || "", $(this.parentElement).attr("displayName") || "");
 });


### PR DESCRIPTION
Root Cause: The Overview page makes the div element to be clickable, so as to the blank space in the whole line being clickable.