### PR TITLE
Not to pop up out-dated release note automatically

### DIFF
--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-import { getReleaseNotesEntries, findLatestReleaseNotes, timeToString } from "../utils";
+import { getReleaseNotesEntries, findLatestReleaseNotes, timeToString, getExtensionVersion } from "../utils";
 
 export enum HelpViewType {
   Auto = "auto",
@@ -32,6 +32,9 @@ const RELEASE_NOTE_PRESENTATION_HISTORY = "releaseNotesPresentationHistory";
 export async function showReleaseNotesOnStart(context: vscode.ExtensionContext) {
   const entries = await getReleaseNotesEntries(context);
   const latest = findLatestReleaseNotes(entries);
+  if(latest.version !== getExtensionVersion()) {
+    return; // in case we don't draft release note for a version.
+  }
 
   const history: ReleaseNotesPresentationHistoryEntry[] = context.globalState.get(RELEASE_NOTE_PRESENTATION_HISTORY) || [];
   if (history.some(entry => entry.version === latest.version)) {


### PR DESCRIPTION
Currently latest release notes is for 0.9.0, we should not pop up it on startup. 