### PR TITLE
add settings for showing release notes after an update

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,12 @@
           "default": "auto",
           "description": "Sets the default view which is presented during the first use.",
           "scope": "window"
+        },
+        "java.update.showReleaseNotes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show Release Notes after an update.",
+          "scope": "window"
         }
       }
     }

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -30,6 +30,12 @@ type ReleaseNotesPresentationHistoryEntry = { version: string, timeStamp: string
 const RELEASE_NOTE_PRESENTATION_HISTORY = "releaseNotesPresentationHistory";
 
 export async function showReleaseNotesOnStart(context: vscode.ExtensionContext) {
+  const config = vscode.workspace.getConfiguration("java.update");
+  const showReleaseNotes = config.get("showReleaseNotes");
+  if (!showReleaseNotes) {
+    return;
+  }
+
   const entries = await getReleaseNotesEntries(context);
   const latest = findLatestReleaseNotes(entries);
   if(latest.version !== getExtensionVersion()) {


### PR DESCRIPTION
This PR adds a new setting `java.update.showReleaseNotes` to allow users to control whether to pop up release notes after an update. 

VS Code's setting `update.showReleaseNotes` is of `application` scope, see https://github.com/microsoft/vscode/blob/f74e473238aca7b79c08be761d99a0232838ca4c/src/vs/platform/update/common/update.config.contribution.ts#L47-L52

`application` scope makes more sense to me, but then it can only be configured in user settings. I don't know whether user settings can be preset in dev containers. Here I use `window` to ensure it can at least be overrided by workspace settings.