### PR TITLE
Rename to Extension Pack for MicroProfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To use ST4, install [📦 Spring Boot Extension Pack](https://marketplace.visual
 
 ### Eclipse MicroProfile
 
-The [📦 MicroProfile Extension Pack](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack) is a collection of extensions that can help develop your Java microservices using [Eclipse MicroProfile](https://microprofile.io/). You can quickly generate a MicroProfile project and utilize development tools for runtimes such as [Open Liberty](https://openliberty.io/) and [Quarkus](https://quarkus.io/).
+The [📦 Extension Pack for MicroProfile](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.vscode-microprofile-pack) is a collection of extensions that can help develop your Java microservices using [Eclipse MicroProfile](https://microprofile.io/). You can quickly generate a MicroProfile project and utilize development tools for runtimes such as [Open Liberty](https://openliberty.io/) and [Quarkus](https://quarkus.io/).
 
 ### Quarkus
 

--- a/src/ext-guide/assets/index.html
+++ b/src/ext-guide/assets/index.html
@@ -127,7 +127,7 @@
                             <div class="form-check">
                               <input class="form-check-input" type="checkbox" value="microprofile-community.vscode-microprofile-pack" id="chk.microprofile-community.vscode-microprofile-pack">
                               <label class="form-check-label" for="chk.microprofile-community.vscode-microprofile-pack">
-                                MicroProfile Extension Pack
+                                Extension Pack for MicroProfile
                               </label>
                             </div>
                           </td>

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -102,7 +102,7 @@
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fazure%2Fdocker%22" title="Learn how to work with Docker in VS Code">Docker in VS Code</a>
             </div>
             <div>
-              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3DMicroProfile-Community.vscode-microprofile-pack%26ssr%3Dfalse%23overview%22" title="Marketplace link for MicroProfile Extension Pack">MicroProfile Extension Pack for VS Code</a>
+              <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3DMicroProfile-Community.vscode-microprofile-pack%26ssr%3Dfalse%23overview%22" title="Marketplace link for Extension Pack for MicroProfile">Extension Pack for MicroProfile in VS Code</a>
             </div>
             <div>
               <a href="command:java.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22" title="Marketplace link for Quarkus Tools for VS Code">Quarkus Tools for VS Code</a>
@@ -113,8 +113,8 @@
             <div ext="ms-azuretools.vscode-docker" displayName="Docker">
               <a href="#" title="Install Docker extension...">Install Docker Extension</a>
             </div>
-            <div ext="MicroProfile-Community.vscode-microprofile-pack" displayName="MicroProfile Extension Pack">
-              <a href="#" title="Install MicroProfile extension pack...">Install MicroProfile Extension Pack</a>
+            <div ext="MicroProfile-Community.vscode-microprofile-pack" displayName="Extension Pack for MicroProfile">
+              <a href="#" title="Install Extension Pack for MicroProfile...">Install Extension Pack for MicroProfile</a>
             </div>
             <div ext="redhat.vscode-quarkus" displayName="Quarkus">
               <a href="#" title="Install Quarkus extension...">Install Quarkus Extension</a>


### PR DESCRIPTION
The "MicroProfile Extension Pack" has been renamed to "Extension Pack for MicroProfile". This PR updates the appropriate references.

<img src="https://user-images.githubusercontent.com/26146482/104512001-8dbab180-55bb-11eb-9745-19ec45abd851.png" width="400" />


Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>