### PR TITLE
Donot show welcome page by default on web & sync state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,9 +160,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.32.0.tgz",
-      "integrity": "sha512-fpHR6iE38V3+2ezMwopt726uRYKK9c89OQDO+t8VEUXNJCaYvnMFbHYgxXvQ/jOvP2ZanlL6r6joRZlsUowzoA==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
       "dev": true
     },
     "@types/winreg": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "vscjava",
   "preview": true,
   "engines": {
-    "vscode": "^1.32.0"
+    "vscode": "^1.52.0"
   },
   "aiKey": "b4a8a622-6ac7-4cf8-83aa-f325e1890795",
   "icon": "logo.png",
@@ -128,7 +128,7 @@
     "@types/request": "^2.48.5",
     "@types/request-promise-native": "^1.0.17",
     "@types/semver": "^5.5.0",
-    "@types/vscode": "1.32.0",
+    "@types/vscode": "1.52.0",
     "@types/winreg": "^1.2.30",
     "arch": "^2.1.2",
     "autoprefixer": "^8.5.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,12 +9,13 @@ import { initialize as initCommands } from "./commands";
 import { initialize as initRecommendations } from "./recommendation";
 import { initialize as initMisc, showReleaseNotesOnStart, HelpViewType } from "./misc";
 import { initialize as initExp, getExpService } from "./exp";
-import { showOverviewPageOnActivation } from "./overview";
+import { KEY_SHOW_WHEN_USING_JAVA, showOverviewPageOnActivation } from "./overview";
 import { validateJavaRuntime } from "./java-runtime";
 // import { JavaGettingStartedViewSerializer } from "./getting-started";
 import { scheduleAction } from "./utils/scheduler";
 
 export async function activate(context: vscode.ExtensionContext) {
+  syncState(context);
   initializeTelemetry(context);
   await instrumentOperation("activation", initializeExtension)(context);
 }
@@ -88,6 +89,10 @@ async function showGettingStartedView(context: vscode.ExtensionContext, _isForce
 
   await vscode.commands.executeCommand("java.gettingStarted");
   context.globalState.update("isGettingStartedPresented", true);
+}
+
+function syncState(_context: vscode.ExtensionContext): void {
+  _context.globalState.setKeysForSync([KEY_SHOW_WHEN_USING_JAVA]);
 }
 
 function initializeTelemetry(_context: vscode.ExtensionContext) {

--- a/src/overview/index.ts
+++ b/src/overview/index.ts
@@ -10,7 +10,7 @@ import { getExtensionContext } from "../utils";
 import { loadTextFromFile } from "../utils";
 
 let overviewView: vscode.WebviewPanel | undefined;
-const KEY_SHOW_WHEN_USING_JAVA = "showWhenUsingJava";
+export const KEY_SHOW_WHEN_USING_JAVA = "showWhenUsingJava";
 const KEY_OVERVIEW_LAST_SHOW_TIME = "overviewLastShowTime";
 
 const toggleOverviewVisibilityOperation = instrumentOperation("toggleOverviewVisibility", (operationId: string, context: vscode.ExtensionContext, visibility: boolean) => {
@@ -94,7 +94,7 @@ async function initializeOverviewView(context: vscode.ExtensionContext, webviewP
 export async function showOverviewPageOnActivation(context: vscode.ExtensionContext) {
   let showWhenUsingJava = context.globalState.get(KEY_SHOW_WHEN_USING_JAVA);
   if (showWhenUsingJava === undefined) {
-    showWhenUsingJava = true;
+    showWhenUsingJava = vscode.env.uiKind === vscode.UIKind.Desktop;
   }
 
   if (showWhenUsingJava) {


### PR DESCRIPTION
This is Sandeep Somavarapu, developer from VS Code team. We are working on improving Codespaces user experience in Web. When a codespace using a repository that has Java extension pack is created, then showing the Java overview page is noisy. This PR has following changes:

- By default, show overview page only on Desktop and not in Web.
- Synchronise the user state when unchecked the option to show overview page