### PR TITLE
only pop up tour page for the first time

### DIFF
--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -7,6 +7,7 @@ import { loadTextFromFile } from "../utils";
 import { instrumentSimpleOperation } from "vscode-extension-telemetry-wrapper";
 
 const KEY_SHOW_WHEN_USING_JAVA = "showWhenUsingJava";
+const KEY_IS_WELCOME_PAGE_VIEWED = "isWelcomePageViewed";
 let welcomeView: vscode.WebviewPanel | undefined;
 
 export async function showWelcomeWebview(context: vscode.ExtensionContext, args?: any[]) {
@@ -61,12 +62,7 @@ export async function showWelcomeWebview(context: vscode.ExtensionContext, args?
         }
     })));
 
-    let firstTimeRun;
-    if (args?.[0]?.firstTimeRun) {
-        firstTimeRun = args[0].firstTimeRun;
-    } else {
-        firstTimeRun = true;
-    }
+    let firstTimeRun = args?.[0]?.firstTimeRun || context.globalState.get(KEY_IS_WELCOME_PAGE_VIEWED) !== true;
     welcomeView.webview.postMessage({
         command: "renderWelcomePage",
         props: {
@@ -74,6 +70,7 @@ export async function showWelcomeWebview(context: vscode.ExtensionContext, args?
             firstTimeRun
         }
     });
+    context.globalState.update(KEY_IS_WELCOME_PAGE_VIEWED, true);
 }
 
 export async function showWelcomePageOnActivation(context: vscode.ExtensionContext) {


### PR DESCRIPTION
part of #540 

There are two cases that we render tour page:
1. When it's the first time user open "welcome page", it render the tour page. 
2. When user explicitly click "take a tour", where `firstTimeRun` is passed as an arg.
