### PR TITLE
hide all first views in codespaces

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ import { javaRuntimeCmdHandler } from "../java-runtime";
 import { javaGettingStartedCmdHandler } from "../getting-started";
 import { javaExtGuideCmdHandler } from "../ext-guide";
 import { instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
+import { showWelcomeWebview } from "../welcome";
 
 export function initialize(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand("java.overview", instrumentCommand(context, "java.overview", instrumentCommand(context, "java.helper.overview", overviewCmdHandler))));
@@ -25,4 +26,5 @@ export function initialize(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand("java.gettingStarted", instrumentCommand(context, "java.gettingStarted", javaGettingStartedCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.extGuide", instrumentCommand(context, "java.extGuide", javaExtGuideCmdHandler)));
   context.subscriptions.push(instrumentOperationAsVsCodeCommand("java.webview.runCommand", webviewCmdLinkHandler));
+  context.subscriptions.push(vscode.commands.registerCommand("java.welcome", (args) => showWelcomeWebview(context, args)));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ import { KEY_SHOW_WHEN_USING_JAVA, showOverviewPageOnActivation } from "./overvi
 import { validateJavaRuntime } from "./java-runtime";
 // import { JavaGettingStartedViewSerializer } from "./getting-started";
 import { scheduleAction } from "./utils/scheduler";
-import { showWelcomeWebview, showWelcomePageOnActivation } from "./welcome";
+import { showWelcomeWebview } from "./welcome";
 
 export async function activate(context: vscode.ExtensionContext) {
   syncState(context);
@@ -36,9 +36,16 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
   const config = vscode.workspace.getConfiguration("java.help");
 
   if (config.get("firstView") !== HelpViewType.None) {
-    scheduleAction("showFirstView", true).then(() => {
-      presentFirstView(context);
-    });
+    let showWhenUsingJava = context.globalState.get(KEY_SHOW_WHEN_USING_JAVA);
+    if (showWhenUsingJava === undefined) {
+      showWhenUsingJava = vscode.env.uiKind === vscode.UIKind.Desktop;
+    }
+
+    if (showWhenUsingJava) {
+      scheduleAction("showFirstView", true).then(() => {
+        presentFirstView(context);
+      });
+    }
   }
 
   if (config.get("showReleaseNotes")) {
@@ -53,7 +60,6 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
     });
   }
 
-  context.subscriptions.push(vscode.commands.registerCommand("java.welcome", (args) => showWelcomeWebview(context, args)));
 }
 
 async function presentFirstView(context: vscode.ExtensionContext) {
@@ -75,7 +81,7 @@ async function presentFirstView(context: vscode.ExtensionContext) {
       await showOverviewPageOnActivation(context);
       break;
     default:
-      await showWelcomePageOnActivation(context);
+      await showWelcomeWebview(context);
   }
 }
 

--- a/src/overview/index.ts
+++ b/src/overview/index.ts
@@ -92,16 +92,9 @@ async function initializeOverviewView(context: vscode.ExtensionContext, webviewP
 }
 
 export async function showOverviewPageOnActivation(context: vscode.ExtensionContext) {
-  let showWhenUsingJava = context.globalState.get(KEY_SHOW_WHEN_USING_JAVA);
-  if (showWhenUsingJava === undefined) {
-    showWhenUsingJava = vscode.env.uiKind === vscode.UIKind.Desktop;
-  }
-
-  if (showWhenUsingJava) {
     let overviewLastShowTime = context.globalState.get(KEY_OVERVIEW_LAST_SHOW_TIME);
     let showInBackground = overviewLastShowTime !== undefined;
     vscode.commands.executeCommand("java.overview", showInBackground);
-  }
 }
 
 export class OverviewViewSerializer implements vscode.WebviewPanelSerializer {

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -73,18 +73,6 @@ export async function showWelcomeWebview(context: vscode.ExtensionContext, args?
     context.globalState.update(KEY_IS_WELCOME_PAGE_VIEWED, true);
 }
 
-export async function showWelcomePageOnActivation(context: vscode.ExtensionContext) {
-    let showWhenUsingJava = context.globalState.get(KEY_SHOW_WHEN_USING_JAVA);
-    if (showWhenUsingJava === undefined) {
-        showWhenUsingJava = true;
-    }
-
-    if (showWhenUsingJava) {
-        vscode.commands.executeCommand("java.welcome");
-    }
-
-}
-
 const setWelcomeVisibility = instrumentSimpleOperation("setWelcomeVisibility", (context: vscode.ExtensionContext, visibility: boolean) => {
     context.globalState.update(KEY_SHOW_WHEN_USING_JAVA, visibility);
 });


### PR DESCRIPTION
part of #540 

Previously only Overview page (one option of first views) was hidden in Codespaces. Now this policy applies to all first views.