### PR TITLE
fix webview command to execute

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -26,5 +26,5 @@ export function initialize(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand("java.gettingStarted", instrumentCommand(context, "java.gettingStarted", javaGettingStartedCmdHandler)));
   context.subscriptions.push(vscode.commands.registerCommand("java.extGuide", instrumentCommand(context, "java.extGuide", javaExtGuideCmdHandler)));
   context.subscriptions.push(instrumentOperationAsVsCodeCommand("java.webview.runCommand", webviewCmdLinkHandler));
-  context.subscriptions.push(vscode.commands.registerCommand("java.welcome", (args) => showWelcomeWebview(context, args)));
+  context.subscriptions.push(vscode.commands.registerCommand("java.welcome", (options) => showWelcomeWebview(context, options)));
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -58,5 +58,10 @@ export async function webviewCmdLinkHandler(obj: { webview: string, identifier: 
     webview,
     identifier
   });
-  await vscode.commands.executeCommand(command, args);
+
+  if (args !== undefined) {
+    await vscode.commands.executeCommand(command, ...args);
+  } else {
+    await vscode.commands.executeCommand(command);
+  }
 }

--- a/src/welcome/assets/utils.ts
+++ b/src/welcome/assets/utils.ts
@@ -9,6 +9,15 @@ export function encodeCommandUri(command: string, args?: string[]) {
   return ret;
 }
 
+/**
+ * URL for webview commands. 
+ * By executing the retured command, telemetry is sent before finally executing {command} {args}.
+ * 
+ * @param identifier will be record in telemetry
+ * @param command command to execute
+ * @param args must be an array, if provided
+ * @returns 
+ */
 export function encodeCommandUriWithTelemetry(identifier: string, command: string, args?: any[]) {
   const helperCommand = "java.webview.runCommand";
   const wrappedArgs = {

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -10,9 +10,9 @@ const KEY_SHOW_WHEN_USING_JAVA = "showWhenUsingJava";
 const KEY_IS_WELCOME_PAGE_VIEWED = "isWelcomePageViewed";
 let welcomeView: vscode.WebviewPanel | undefined;
 
-export async function showWelcomeWebview(context: vscode.ExtensionContext, args?: any[]) {
+export async function showWelcomeWebview(context: vscode.ExtensionContext, options?: any) {
     if (welcomeView) {
-        const firstTimeRun = args?.[0]?.firstTimeRun;
+        const firstTimeRun = options?.firstTimeRun;
         if (firstTimeRun === undefined) {
             welcomeView.reveal();
         } else {
@@ -37,7 +37,7 @@ export async function showWelcomeWebview(context: vscode.ExtensionContext, args?
             retainContextWhenHidden: true
         }
     );
-    let firstTimeRun = args?.[0]?.firstTimeRun || context.globalState.get(KEY_IS_WELCOME_PAGE_VIEWED) !== true;
+    let firstTimeRun = options?.firstTimeRun || context.globalState.get(KEY_IS_WELCOME_PAGE_VIEWED) !== true;
     await initializeWelcomeView(context, welcomeView, firstTimeRun, onDidDisposeWebviewPanel);
 }
 


### PR DESCRIPTION
Previously, **array of args** was wrongly passed as **the first arg** in `webviewCmdLinkHandler`.