### PR TITLE
retire info button from status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation } f
 import { initialize as initUtils } from "./utils";
 import { initialize as initCommands } from "./commands";
 import { initialize as initRecommendations } from "./recommendation";
-import { initialize as initMisc, showReleaseNotesOnStart, HelpViewType } from "./misc";
+import { showReleaseNotesOnStart, HelpViewType } from "./misc";
 import { initialize as initExp, getExpService } from "./exp";
 import { KEY_SHOW_WHEN_USING_JAVA, OverviewViewSerializer, showOverviewPageOnActivation } from "./overview";
 import { JavaRuntimeViewSerializer, validateJavaRuntime } from "./java-runtime";
@@ -27,7 +27,6 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
   initUtils(context);
   initCommands(context);
   initRecommendations(context);
-  initMisc(context);
   initExp(context);
 
   // webview serializers to restore pages

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -11,26 +11,6 @@ export enum HelpViewType {
   None = "none",
 }
 
-function showInfoButton() {
-  const config = vscode.workspace.getConfiguration("java.help");
-  const firstView = config.get("firstView");
-
-  let infoButton = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
-  switch (firstView) {
-    case HelpViewType.None:
-      return;
-    case HelpViewType.GettingStarted:
-      infoButton.command = "java.gettingStarted";
-      break;
-    default:
-      infoButton.command = "java.overview";
-  }
-
-  infoButton.text = "$(info)";
-  infoButton.tooltip = "Learn more about Java features";
-  infoButton.show();
-}
-
 type ReleaseNotesPresentationHistoryEntry = { version: string, timeStamp: string };
 const RELEASE_NOTE_PRESENTATION_HISTORY = "releaseNotesPresentationHistory";
 
@@ -54,8 +34,4 @@ export async function showReleaseNotesOnStart(context: vscode.ExtensionContext) 
   });
 
   context.globalState.update(RELEASE_NOTE_PRESENTATION_HISTORY, history);
-}
-
-export function initialize(_context: vscode.ExtensionContext) {
-  showInfoButton();
 }


### PR DESCRIPTION
This PR removes below button.
![image](https://user-images.githubusercontent.com/2351748/111581968-1f7daf80-87f5-11eb-9517-cec0a281f105.png)
