### PR TITLE
make EXPs independent

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,18 +64,20 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
     });
   }
 
+  // Progression rollout EXP for showing extension guide.
+  const presentExtensionGuideByDefault: boolean = await getExpService()?.isFlightEnabledAsync("presentExtensionGuideByDefault") || false;
+  if (presentExtensionGuideByDefault) {
+    scheduleAction("showExtensionGuide", false, true).then(() => {
+      showExtensionGuide(context);
+    });
+  }
 }
 
 async function presentFirstView(context: vscode.ExtensionContext) {
+  // Progression rollout EXP for showing welcome page.
   const presentWelcomePageByDefault: boolean = await getExpService()?.isFlightEnabledAsync("presentWelcomePageByDefault") || false;
   if (presentWelcomePageByDefault) {
     await showWelcomeWebview(context);
-    return;
-  }
-
-  const presentExtensionGuideByDefault: boolean = await getExpService()?.isFlightEnabledAsync("presentExtensionGuideByDefault") || false;
-  if (presentExtensionGuideByDefault) {
-    showExtensionGuide(context);
     return;
   }
 
@@ -88,10 +90,8 @@ async function presentFirstView(context: vscode.ExtensionContext) {
       await showGettingStartedView(context);
       break;
     case HelpViewType.Overview:
-      await showOverviewPageOnActivation(context);
-      break;
     default:
-      await showWelcomeWebview(context);
+      await showOverviewPageOnActivation(context);
   }
 }
 


### PR DESCRIPTION
Two EXPs:

**Previously**, only control group for "extension guide" EXP had chance to take "Welcome view" EXP. 
E.g. if both EXPs are 50:50, we have 1/2 users poping up extension guide, 1/4 poping up welcome page, 1/4 poping up other first view pages (overview page by default).

What we want are:
* 1/2 poping up extension guide, while the other 1/2 not.
* 1/2 (randomly picked, not same as above) poping up welcome page, and the other 1/2 seeing other pages.

**Now with this PR**:
* Extension guide
  * Treatment group: show it on extension activation (only once globally across sessions).
  * Control group: do not show it.
* Welcome view
  * Treatment group: show welcome page as first view on activation (only once per session).
  * Control group: show whatever page according to value of `java.firstView` setting, overview page by default.
