### PR TITLE
Fix wrong state when reloading webview

### DIFF
--- a/src/classpath/assets/features/classpathConfiguration/ClasspathConfigurationView.tsx
+++ b/src/classpath/assets/features/classpathConfiguration/ClasspathConfigurationView.tsx
@@ -14,6 +14,7 @@ import Exception from "./components/Exception";
 import { ClasspathViewException, ProjectInfo } from "../../../types";
 import { catchException, listProjects, loadClasspath } from "./classpathConfigurationViewSlice";
 import JdkRuntime from "./components/JdkRuntime";
+import { onWillListProjects } from "../../utils";
 
 const ClasspathConfigurationView = (): JSX.Element => {
   const projects: ProjectInfo[] = useSelector((state: any) => state.classpathConfig.projects);
@@ -67,6 +68,7 @@ const ClasspathConfigurationView = (): JSX.Element => {
 
   useEffect(() => {
     window.addEventListener("message", onInitialize);
+    onWillListProjects();
     return () => window.removeEventListener("message", onInitialize);
   }, []);
 

--- a/src/classpath/assets/features/classpathConfiguration/components/Exception.tsx
+++ b/src/classpath/assets/features/classpathConfiguration/components/Exception.tsx
@@ -26,14 +26,14 @@ const Exception = (): JSX.Element | null => {
     case ClasspathViewException.JavaExtensionNotInstalled:
       content = (
         <div>
-          <span>The required extension <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.openJavaLanguageSupportMarketPlace", "extension.open", ["redhat.java"])}>Language Support for Java(TM) by Red Hat</a> is not installed or it's disabled. Please <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.installJavaLanguageSupport", "workbench.extensions.installExtension", ["redhat.java"])}>install</a> it in Visual Studio Code and re-open the page after installation.</span>
+          <span>The required extension <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.openJavaLanguageSupportMarketPlace", "extension.open", ["redhat.java"])}>Language Support for Java(TM) by Red Hat</a> is not installed or it's disabled. Please <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.installJavaLanguageSupport", "workbench.extensions.installExtension", ["redhat.java"])}>install</a> it in Visual Studio Code and <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.reloadWebview", "workbench.action.webview.reloadWebviewAction")}>reload</a> the page after installation.</span>
         </div>
       );
       break;
     case ClasspathViewException.StaleJavaExtension:
       content = (
         <div>
-          <span>The version of required extension <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.openJavaLanguageSupportMarketPlace", "extension.open", ["redhat.java"])}>Language Support for Java(TM) by Red Hat</a> is too stale. Please <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.installJavaLanguageSupport", "workbench.extensions.installExtension", ["redhat.java"])}>update</a> it and re-open the page.</span>
+          <span>The version of required extension <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.openJavaLanguageSupportMarketPlace", "extension.open", ["redhat.java"])}>Language Support for Java(TM) by Red Hat</a> is too stale. Please <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.installJavaLanguageSupport", "workbench.extensions.installExtension", ["redhat.java"])}>update</a> it and <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.reloadWebview", "workbench.action.webview.reloadWebviewAction")}>reload</a> the page.</span>
         </div>
       );
       break;

--- a/src/classpath/assets/utils.ts
+++ b/src/classpath/assets/utils.ts
@@ -9,6 +9,12 @@ export const WEBVIEW_ID = "java.classpathConfiguration";
 declare function acquireVsCodeApi(): any;
 const vscode = acquireVsCodeApi && acquireVsCodeApi();
 
+export function onWillListProjects() {
+  vscode.postMessage({
+    command: "onWillListProjects",
+  });
+}
+
 export function onWillLoadProjectClasspath(uri: string) {
   vscode.postMessage({
     command: "onWillLoadProjectClasspath",


### PR DESCRIPTION
#581

This PR did following changes:
1. call `listProjects()` when the component is mounted
2. At the beginning of `listProjects()`, check the requirement in case that user installs/update `Java Language Support` and reload the webview
2. Register the webview listeners early than parsing the html content

Signed-off-by: Sheng Chen <sheche@microsoft.com>