### PR TITLE
Add more entries to expose classpath configuration view

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,18 @@
           "command": "java.runtime",
           "group": "overflow_30@10",
           "when": "view == javaProjectExplorer"
+        },
+        {
+          "command": "java.classpathConfiguration",
+          "group": "overflow_30@20",
+          "when": "view == javaProjectExplorer"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "java.classpathConfiguration",
+          "group": "9_configuration@20",
+          "when": "view == javaProjectExplorer && viewItem =~ /java:project(?=.*?\\b\\+unmanagedFolder\\b)(?=.*?\\b\\+uri\\b)/"
         }
       ]
     }

--- a/src/classpath/assets/features/classpathConfiguration/components/ProjectSelector.tsx
+++ b/src/classpath/assets/features/classpathConfiguration/components/ProjectSelector.tsx
@@ -52,7 +52,7 @@ const ProjectSelector = (): JSX.Element | null => {
   return (
     <Row className="setting-section">
       <Col>
-        <span className="setting-section-description">Select the project.</span>
+        <span className="setting-section-description">Select the project folder.</span>
         <Dropdown className="mt-1">
           <Dropdown.Toggle className="dropdown-button flex-vertical-center text-left">
             <span>{projects[activeProjectIndex].name}</span>

--- a/src/welcome/assets/components/NavigationPanel.tsx
+++ b/src/welcome/assets/components/NavigationPanel.tsx
@@ -39,7 +39,8 @@ export default class NavigationPanel extends React.Component {
       actions: [
         { name: "Getting Started", command: "java.gettingStarted" },
         { name: "Tutorial: Running and Debugging", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-debugging"] },
-        { name: "Tutorial: Testing", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-testing"] }
+        { name: "Tutorial: Testing", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-testing"] },
+        { name: "Configure Sources, Dependencies, Output Folder...", command: "java.classpathConfiguration"}
       ]
     },
   ];


### PR DESCRIPTION
Add more entries for the classpath configuration view:
- Student section in welcome page
- overflows of Java Project explorer
- context menu for unmanaged folder node of Java Project explorer

Signed-off-by: Sheng Chen <sheche@microsoft.com>