### PR TITLE
fix: wrong state of checkbox on welcome page

### DIFF
--- a/src/welcome/assets/index.ts
+++ b/src/welcome/assets/index.ts
@@ -13,10 +13,3 @@ window.addEventListener("message", event => {
         ReactDOM.render(React.createElement(GetStartedPage, data.props), document.getElementById("content"));
     }
   });
-  
-
-function render() {
-    ReactDOM.render(React.createElement(GetStartedPage), document.getElementById("content"));
-}
-
-render();


### PR DESCRIPTION
Previously the page was renderred twice:
1) on startup (no props passed)
2) on message

Thus, `showWhenUsingJava` was undefined in the first time, making the checkbox always checked by default, because the component was re-used in the second time.