### PR TITLE
support to reload runtime webview

### DIFF
--- a/src/java-runtime/assets/jdk.installation.tsx
+++ b/src/java-runtime/assets/jdk.installation.tsx
@@ -8,7 +8,7 @@ import { JdkData } from "../types";
 export type JdkRquestHandler = (jdkVersion: string, jvmImpl: string) => void;
 
 export interface JdkInstallationPanelProps {
-  jdkData: JdkData;
+  jdkData?: JdkData;
   onRequestJdk: JdkRquestHandler;
 }
 
@@ -63,7 +63,7 @@ export class JdkInstallationPanel extends React.Component<JdkInstallationPanelPr
       }
     }
 
-    this.props.onRequestJdk(newState.jdkVersion, newState.jvmImpl);
+    this.props?.onRequestJdk(newState.jdkVersion, newState.jvmImpl);
     this.setState(newState);
   }
 

--- a/src/java-runtime/assets/vscode.api.ts
+++ b/src/java-runtime/assets/vscode.api.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 declare function acquireVsCodeApi(): any;
 const vscode = acquireVsCodeApi();
 
@@ -37,5 +40,11 @@ export function openBuildScript(rootUri: string, scriptFile: string) {
     command: "openBuildScript",
     rootUri,
     scriptFile
+  });
+}
+
+export function onWillListRuntimes() {
+  vscode.postMessage({
+    command: "onWillListRuntimes"
   });
 }

--- a/src/java-runtime/index.ts
+++ b/src/java-runtime/index.ts
@@ -49,6 +49,15 @@ async function initializeJavaRuntimeView(context: vscode.ExtensionContext, webvi
   context.subscriptions.push(webviewPanel.onDidDispose(onDisposeCallback));
   context.subscriptions.push(webviewPanel.webview.onDidReceiveMessage(async (e) => {
     switch (e.command) {
+      case "onWillListRuntimes": {
+        suggestOpenJdk().then(jdkInfo => {
+          applyJdkInfo(jdkInfo);
+        });
+        findJavaRuntimeEntries().then(data => {
+          showJavaRuntimeEntries(data);
+        });
+        break;
+      }
       case "requestJdkInfo": {
         let jdkInfo = await suggestOpenJdk(e.jdkVersion, e.jvmImpl);
         applyJdkInfo(jdkInfo);
@@ -132,14 +141,6 @@ async function initializeJavaRuntimeView(context: vscode.ExtensionContext, webvi
       args: args,
     });
   }
-
-  suggestOpenJdk().then(jdkInfo => {
-    applyJdkInfo(jdkInfo);
-  });
-
-  findJavaRuntimeEntries().then(data => {
-    showJavaRuntimeEntries(data);
-  });
 
   // refresh webview with latest source levels when classpath (project info) changes
   const javaExt = vscode.extensions.getExtension("redhat.java");


### PR DESCRIPTION
To fix #581 

Below was to render JDK download/installation panel.
```
        suggestOpenJdk().then(jdkInfo => {
          applyJdkInfo(jdkInfo);
        });
```

Below was to render JDK configuration panel.
```
        findJavaRuntimeEntries().then(data => {
          showJavaRuntimeEntries(data);
        });
```

Now renderer first issues a message `onWillListRuntimes`, and main process respond to the message and render above panels accordingly.
