### PR TITLE
feat: Add ability to modify the formatter profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -272,6 +272,12 @@
       "integrity": "sha1-kdZxDlNtNFucmwF8V0z2qNpkxRg=",
       "dev": true
     },
+    "@types/xmldom": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.30.tgz",
+      "integrity": "sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -960,7 +966,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1207,7 +1213,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -1651,7 +1657,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -1664,7 +1670,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2034,7 +2040,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -2082,7 +2088,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
@@ -3227,7 +3233,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -3753,7 +3759,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -3786,7 +3792,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -3939,7 +3945,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -3965,7 +3971,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -4264,7 +4270,7 @@
           "dependencies": {
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -4325,7 +4331,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4504,13 +4510,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -4661,7 +4667,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -5328,7 +5334,7 @@
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "requires": {
@@ -5616,7 +5622,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -5760,7 +5766,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -7534,6 +7540,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -290,6 +290,7 @@
     "@types/vscode": "1.52.0",
     "@types/winreg": "^1.2.30",
     "@types/xmldom": "^0.1.30",
+    "axios": "^0.21.1",
     "arch": "^2.1.2",
     "autoprefixer": "^8.5.1",
     "bootstrap": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -289,6 +289,7 @@
     "@types/semver": "^5.5.0",
     "@types/vscode": "1.52.0",
     "@types/winreg": "^1.2.30",
+    "@types/xmldom": "^0.1.30",
     "arch": "^2.1.2",
     "autoprefixer": "^8.5.1",
     "bootstrap": "^4.5.2",
@@ -321,7 +322,8 @@
     "url-loader": "^4.1.1",
     "vscode-tas-client": "^0.1.22",
     "webpack": "^4.44.1",
-    "webpack-cli": "^3.3.12"
+    "webpack-cli": "^3.3.12",
+    "xmldom": "^0.6.0"
   },
   "extensionPack": [
     "redhat.java",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { ClassPathConfigurationViewSerializer } from "./classpath/classpathConfi
 import { TreatmentVariables } from "./exp/TreatmentVariables";
 import { MarkdownPreviewSerializer } from "./classpath/markdownPreviewProvider";
 import { initFormatterSettingsEditorProvider } from "./formatter-settings";
+import { initRemoteProfileProvider } from "./formatter-settings/RemoteProfileProvider";
 
 export async function activate(context: vscode.ExtensionContext) {
   syncState(context);
@@ -29,6 +30,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 async function initializeExtension(_operationId: string, context: vscode.ExtensionContext) {
   initFormatterSettingsEditorProvider(context);
+  initRemoteProfileProvider(context);
   initUtils(context);
   initCommands(context);
   initRecommendations(context);

--- a/src/formatter-settings/FormatterConstants.ts
+++ b/src/formatter-settings/FormatterConstants.ts
@@ -6,6 +6,9 @@ import { Category, ExampleKind, JavaFormatterSetting, ValueKind } from "./types"
 export namespace JavaConstants {
     export const JAVA_CORE_FORMATTER_ID = "org.eclipse.jdt.core.formatter";
     export const CURRENT_FORMATTER_SETTINGS_VERSION = "21";
+    export const SETTINGS_URL_KEY = "format.settings.url";
+    export const SETTINGS_PROFILE_KEY = "format.settings.profile";
+    export const MINIMUM_JAVA_EXTENSION_VERSION: string = "0.77.0";
 }
 
 export namespace VSCodeSettings {

--- a/src/formatter-settings/FormatterConverter.ts
+++ b/src/formatter-settings/FormatterConverter.ts
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { SupportedSettings } from "./FormatterConstants";
+
+export namespace FormatterConverter {
+    export function webView2ProfileConvert(id: string, value: string | undefined): string | undefined {
+        switch (id) {
+            case SupportedSettings.INSERT_SPACE_BEFORE_FIRST_INITIALIZER:
+            case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENTS:
+            case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_PAREN_IN_CAST:
+            case SupportedSettings.INSERT_SPACE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_SPACE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_NEW_LINE_IN_CONTROL_STATEMENTS:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_ANNOTATION:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_TYPE_DECLARATION:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_METHOD_BODY:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_ENUM_DECLARATION:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_ENUM_CONSTANT:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_ANONYMOUS_TYPE_DECLARATION:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_ANNOTATION_DECLARATION:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_ANNOTATION_ON_ENUM_CONSTANT:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_ANNOTATION_ON_PACKAGE:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_ANNOTATION_ON_PARAMETER:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_CATCH_IN_TRY_STATEMENT:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_ELSE_IN_IF_STATEMENT:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_FINALLY_IN_TRY_STATEMENT:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_WHILE_IN_DO_STATEMENT:
+                switch (value) {
+                    case "true":
+                        return "insert";
+                    case "false":
+                        return "do not insert";
+                    default:
+                        return undefined;
+                }
+            case SupportedSettings.KEEP_TYPE_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_RECORD_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_RECORD_CONSTRUCTOR_ON_ONE_LINE:
+            case SupportedSettings.KEEP_METHOD_BODY_ON_ONE_LINE:
+            case SupportedSettings.KEEP_ENUM_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_ENUM_CONSTANT_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_ANONYMOUS_TYPE_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_ANNOTATION_DECLARATION_ON_ONE_LINE:
+                switch (value) {
+                    case "never":
+                        return "one_line_never";
+                    case "if empty":
+                        return "one_line_if_empty";
+                    case "if at most one item":
+                        return "one_line_if_single_item";
+                    default:
+                        return undefined;
+                }
+        }
+        return value;
+    }
+
+    export function profile2WebViewConvert(id: string, value: string | undefined): string | undefined {
+        switch (id) {
+            case SupportedSettings.INSERT_SPACE_BEFORE_FIRST_INITIALIZER:
+            case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENTS:
+            case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_PAREN_IN_CAST:
+            case SupportedSettings.INSERT_SPACE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_SPACE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_NEW_LINE_IN_CONTROL_STATEMENTS:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_ANNOTATION:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_TYPE_DECLARATION:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_METHOD_BODY:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_ENUM_DECLARATION:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_ENUM_CONSTANT:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_ANONYMOUS_TYPE_DECLARATION:
+            case SupportedSettings.INSERT_NEW_LINE_IN_EMPTY_ANNOTATION_DECLARATION:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_ANNOTATION_ON_ENUM_CONSTANT:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_ANNOTATION_ON_PACKAGE:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_ANNOTATION_ON_PARAMETER:
+            case SupportedSettings.INSERT_NEW_LINE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_CATCH_IN_TRY_STATEMENT:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_ELSE_IN_IF_STATEMENT:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_FINALLY_IN_TRY_STATEMENT:
+            case SupportedSettings.INSERT_NEW_LINE_BEFORE_WHILE_IN_DO_STATEMENT:
+                switch (value) {
+                    case "insert":
+                        return "true";
+                    case "do not insert":
+                        return "false";
+                    default:
+                        return undefined;
+                }
+            case SupportedSettings.KEEP_TYPE_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_RECORD_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_RECORD_CONSTRUCTOR_ON_ONE_LINE:
+            case SupportedSettings.KEEP_METHOD_BODY_ON_ONE_LINE:
+            case SupportedSettings.KEEP_ENUM_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_ENUM_CONSTANT_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_ANONYMOUS_TYPE_DECLARATION_ON_ONE_LINE:
+            case SupportedSettings.KEEP_ANNOTATION_DECLARATION_ON_ONE_LINE:
+                switch (value) {
+                    case "one_line_never":
+                        return "never";
+                    case "one_line_if_empty":
+                        return "if empty";
+                    case "one_line_if_single_item":
+                        return "if at most one item";
+                    default:
+                        return undefined;
+                }
+            case SupportedSettings.PUT_EMPTY_STATEMENT_ON_NEW_LINE:
+            case SupportedSettings.COMMENT_INDENTPARAMETERDESCRIPTION:
+            case SupportedSettings.COMMENT_INDENT_PARAMETER_DESCRIPTION:
+            case SupportedSettings.COMMENT_FORMATHEADER:
+            case SupportedSettings.COMMENT_FORMAT_HEADER:
+            case SupportedSettings.COMMENT_FORMATTER_COMMENT:
+            case SupportedSettings.COMMENT_FORMATTER_COMMENT_CORE:
+            case SupportedSettings.COMMENT_FORMAT_BLOCK_COMMENTS:
+            case SupportedSettings.FORMAT_LINE_COMMENTS:
+            case SupportedSettings.COMMENT_COUNT_LINE_LENGTH_FROM_STARTING_POSITION:
+            case SupportedSettings.COMMENT_CLEARBLANKLINES:
+            case SupportedSettings.COMMENT_CLEAR_BLANK_LINES:
+            case SupportedSettings.COMMENT_CLEAR_BLANK_LINES_IN_JAVADOC_COMMENT:
+            case SupportedSettings.COMMENT_CLEAR_BLANK_LINES_IN_BLOCK_COMMENT:
+            case SupportedSettings.COMMENT_ON_OFF_TAGS:
+            case SupportedSettings.INSERT_SPACE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_SPACE_BEFORE_FIRST_INITIALIZER:
+            case SupportedSettings.INSERT_SPACE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER:
+            case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_PAREN_IN_CAST:
+            case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENTS:
+                if (value === "true" || value === "false") {
+                    return value;
+                }
+                return undefined;
+        }
+        return value;
+    } 
+}

--- a/src/formatter-settings/FormatterConverter.ts
+++ b/src/formatter-settings/FormatterConverter.ts
@@ -33,6 +33,8 @@ export namespace FormatterConverter {
                         return "insert";
                     case "false":
                         return "do not insert";
+                    case "":
+                        return "";
                     default:
                         return undefined;
                 }
@@ -51,6 +53,8 @@ export namespace FormatterConverter {
                         return "one_line_if_empty";
                     case "if at most one item":
                         return "one_line_if_single_item";
+                    case "":
+                        return "";
                     default:
                         return undefined;
                 }
@@ -87,6 +91,8 @@ export namespace FormatterConverter {
                         return "true";
                     case "do not insert":
                         return "false";
+                    case "":
+                        return "";
                     default:
                         return undefined;
                 }
@@ -105,6 +111,8 @@ export namespace FormatterConverter {
                         return "if empty";
                     case "one_line_if_single_item":
                         return "if at most one item";
+                    case "":
+                        return "";
                     default:
                         return undefined;
                 }
@@ -128,7 +136,7 @@ export namespace FormatterConverter {
             case SupportedSettings.INSERT_SPACE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER:
             case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_PAREN_IN_CAST:
             case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENTS:
-                if (value === "true" || value === "false") {
+                if (value === "true" || value === "false" || value === "") {
                     return value;
                 }
                 return undefined;

--- a/src/formatter-settings/FormatterConverter.ts
+++ b/src/formatter-settings/FormatterConverter.ts
@@ -33,6 +33,7 @@ export namespace FormatterConverter {
                         return "insert";
                     case "false":
                         return "do not insert";
+                    // We regard an empty string as a valid value and may write it to the profile
                     case "":
                         return "";
                     default:
@@ -53,6 +54,7 @@ export namespace FormatterConverter {
                         return "one_line_if_empty";
                     case "if at most one item":
                         return "one_line_if_single_item";
+                    // We regard an empty string as a valid value and may write it to the profile
                     case "":
                         return "";
                     default:
@@ -91,6 +93,7 @@ export namespace FormatterConverter {
                         return "true";
                     case "do not insert":
                         return "false";
+                    // We regard an empty string as a valid value and show it in the webview
                     case "":
                         return "";
                     default:
@@ -111,6 +114,7 @@ export namespace FormatterConverter {
                         return "if empty";
                     case "one_line_if_single_item":
                         return "if at most one item";
+                    // We regard an empty string as a valid value and show it in the webview
                     case "":
                         return "";
                     default:
@@ -136,6 +140,7 @@ export namespace FormatterConverter {
             case SupportedSettings.INSERT_SPACE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER:
             case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_PAREN_IN_CAST:
             case SupportedSettings.INSERT_SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENTS:
+                // We regard an empty string as a valid value and show it in the webview
                 if (value === "true" || value === "false" || value === "") {
                     return value;
                 }

--- a/src/formatter-settings/RemoteProfileProvider.ts
+++ b/src/formatter-settings/RemoteProfileProvider.ts
@@ -2,22 +2,19 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-import { downloadFile, getVersion } from "./utils";
+import { downloadFile } from "./utils";
 
 export class RemoteProfileProvider implements vscode.TextDocumentContentProvider {
 
     public static scheme = "formatter";
 
-    constructor (private readonly context: vscode.ExtensionContext) {
-    }
-
     async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
         const originalUri: vscode.Uri = uri.with({ scheme: "https" });
-        return await downloadFile(originalUri.toString(), await getVersion(this.context));
+        return await downloadFile(originalUri.toString());
     } 
 }
 
 export function initRemoteProfileProvider(context: vscode.ExtensionContext) {
-    const remoteProfileProvider = new RemoteProfileProvider(context);
+    const remoteProfileProvider = new RemoteProfileProvider();
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(RemoteProfileProvider.scheme, remoteProfileProvider));
 }

--- a/src/formatter-settings/RemoteProfileProvider.ts
+++ b/src/formatter-settings/RemoteProfileProvider.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+import { downloadFile, getVersion } from "./utils";
+
+class RemoteProfileProvider implements vscode.TextDocumentContentProvider {
+
+    public static scheme = "formatter";
+
+    constructor (private readonly context: vscode.ExtensionContext) {
+    }
+
+    async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+        const originalUri: vscode.Uri = uri.with({ scheme: "https" });
+        return await downloadFile(originalUri.toString(), await getVersion(this.context));
+    } 
+}
+
+export let remoteProfileProvider: RemoteProfileProvider;
+
+export function initRemoteProfileProvider(context: vscode.ExtensionContext) {
+    remoteProfileProvider = new RemoteProfileProvider(context);
+    context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(RemoteProfileProvider.scheme, remoteProfileProvider));
+}

--- a/src/formatter-settings/RemoteProfileProvider.ts
+++ b/src/formatter-settings/RemoteProfileProvider.ts
@@ -4,7 +4,7 @@
 import * as vscode from "vscode";
 import { downloadFile, getVersion } from "./utils";
 
-class RemoteProfileProvider implements vscode.TextDocumentContentProvider {
+export class RemoteProfileProvider implements vscode.TextDocumentContentProvider {
 
     public static scheme = "formatter";
 
@@ -17,9 +17,7 @@ class RemoteProfileProvider implements vscode.TextDocumentContentProvider {
     } 
 }
 
-export let remoteProfileProvider: RemoteProfileProvider;
-
 export function initRemoteProfileProvider(context: vscode.ExtensionContext) {
-    remoteProfileProvider = new RemoteProfileProvider(context);
+    const remoteProfileProvider = new RemoteProfileProvider(context);
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(RemoteProfileProvider.scheme, remoteProfileProvider));
 }

--- a/src/formatter-settings/assets/features/formatterSettings/FormatterSettingView.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/FormatterSettingView.tsx
@@ -5,16 +5,19 @@ import React, { useEffect } from "react";
 import { Col, Container, Nav, Row } from "react-bootstrap";
 import { useSelector, useDispatch } from "react-redux";
 import { Dispatch } from "@reduxjs/toolkit";
-import { applyFormatResult, changeActiveCategory, loadProfileSetting, loadVSCodeSetting } from "./formatterSettingViewSlice";
+import { applyFormatResult, changeActiveCategory, changeReadOnlyState, loadProfileSetting, loadVSCodeSetting } from "./formatterSettingViewSlice";
 import { highlight } from "./components/Highlight";
 import { Category, ExampleKind } from "../../../types";
 import Setting from "./components/Setting";
 import { renderWhitespace } from "../../whitespace";
-import { onWillChangeExampleKind, onWillInitialize } from "../../utils";
+import { onWillChangeExampleKind, onWillDownloadAndUse, onWillInitialize } from "../../utils";
 
 const FormatterSettingsView = (): JSX.Element => {
   const activeCategory: Category = useSelector((state: any) => state.formatterSettings.activeCategory);
   const contentText: string = useSelector((state: any) => state.formatterSettings.formattedContent);
+  const readOnly: boolean = useSelector((state: any) => state.formatterSettings.readOnly);
+  const title: string = "Java Formatter Settings" + (readOnly ? " (Read Only)" : "");
+
   const dispatch: Dispatch<any> = useDispatch();
   const onClickNaviBar = (element: any) => {
     const activeCategory: Category = Number(element);
@@ -75,6 +78,8 @@ const FormatterSettingsView = (): JSX.Element => {
       dispatch(loadProfileSetting(event.data));
     } else if (event.data.command === "loadVSCodeSetting") {
       dispatch(loadVSCodeSetting(event.data));
+    } else if (event.data.command === "changeReadOnlyState") {
+      dispatch(changeReadOnlyState(event.data));
     }
   };
 
@@ -90,10 +95,9 @@ const FormatterSettingsView = (): JSX.Element => {
 
   return (
     <Container className="root d-flex flex-column">
-      <Row>
-        <Col className="setting-header">
-          <h2 className="mb-0">Java Formatter Settings</h2>
-        </Col>
+      <Row className="setting-header">
+        <Col><h2 className="mb-0">{title}</h2></Col>
+        <Col>{readOnly && (<div><a className="btn btn-primary float-right" role="button" title="Download and edit profile" onClick={() => onWillDownloadAndUse()}>Edit</a></div>)}</Col>
       </Row>
       <Row className="flex-grow-1 d-flex flex-nowrap view-body">
         <Col className="flex-grow-0">{naviBar}</Col>

--- a/src/formatter-settings/assets/features/formatterSettings/FormatterSettingView.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/FormatterSettingView.tsx
@@ -18,8 +18,8 @@ const FormatterSettingsView = (): JSX.Element => {
   const dispatch: Dispatch<any> = useDispatch();
   const onClickNaviBar = (element: any) => {
     const activeCategory: Category = Number(element);
-    let exampleKind: ExampleKind = ExampleKind.INDENTATION_EXAMPLE;
     dispatch(changeActiveCategory(activeCategory));
+    let exampleKind: ExampleKind = ExampleKind.INDENTATION_EXAMPLE;
     switch (activeCategory) {
       case Category.BlankLine:
         exampleKind = ExampleKind.BLANKLINE_EXAMPLE;

--- a/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
@@ -30,6 +30,7 @@ const Setting = (): JSX.Element => {
     if (!value || value === "") {
       value = "0";
     }
+    value = Number(value);
     onWillChangeSetting(id, value);
   };
 

--- a/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
@@ -37,7 +37,7 @@ const Setting = (): JSX.Element => {
   };
 
   const generateSetting = (setting: JavaFormatterSetting) => {
-    if (!setting.name || !setting.id || !setting.value) {
+    if (!setting.name || !setting.id) {
       return null;
     }
     const candidates = [];

--- a/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
@@ -25,9 +25,7 @@ const Setting = (): JSX.Element => {
   };
 
   const handleChangeInput = (e: any) => {
-    const id = e.target.id;
-    let value = e.target.value;
-    onWillChangeSetting(id, value);
+    onWillChangeSetting(e.target.id, e.target.value);
   };
 
   const handleSelect = (setting: JavaFormatterSetting, entry: string) => {

--- a/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
@@ -27,10 +27,6 @@ const Setting = (): JSX.Element => {
   const handleChangeInput = (e: any) => {
     const id = e.target.id;
     let value = e.target.value;
-    if (!value || value === "") {
-      value = "0";
-    }
-    value = Number(value);
     onWillChangeSetting(id, value);
   };
 

--- a/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
@@ -17,6 +17,7 @@ const Setting = (): JSX.Element => {
   const vscodeSettings: JavaFormatterSetting[] = useSelector((state: any) => state.formatterSettings.vscodeSettings);
   const activeCategory: Category = useSelector((state: any) => state.formatterSettings.activeCategory);
   const detectIndentation: boolean = useSelector((state: any) => state.formatterSettings.detectIndentation);
+  const readOnly: boolean = useSelector((state: any) => state.formatterSettings.readOnly);
 
   const handleChangeCheckbox = (e: any) => {
     const id = e.target.id;
@@ -47,7 +48,7 @@ const Setting = (): JSX.Element => {
         return (
           <div className="setting-section" key={`${setting.id}`} onClick={() => handleClick(setting.exampleKind)}>
             <Form.Check type="checkbox" className="pl-0" id={`${setting.id}`} >
-              <Form.Check.Input type="checkbox" checked={setting.value === "true"} onChange={handleChangeCheckbox} />
+              <Form.Check.Input type="checkbox" checked={setting.value === "true"} onChange={handleChangeCheckbox} disabled={readOnly} />
               <Form.Check.Label className="setting-section-description">
                 <Icon className="codicon" icon={checkIcon} />
                 <div className="setting-section-description-checkbox">{setting.name}.</div>
@@ -74,7 +75,7 @@ const Setting = (): JSX.Element => {
           <div className="setting-section" key={`${setting.id}`} onClick={() => handleClick(setting.exampleKind)}>
             <span className="setting-section-description">{setting.name}.</span>
             <Dropdown className="mt-1">
-              <Dropdown.Toggle className="dropdown-button flex-vertical-center text-left">
+              <Dropdown.Toggle className="dropdown-button flex-vertical-center text-left" disabled={readOnly}>
                 <span>{setting.value}</span>
                 <Icon className="codicon" icon={chevronDownIcon} />
               </Dropdown.Toggle>
@@ -88,7 +89,7 @@ const Setting = (): JSX.Element => {
         return (
           <div className="setting-section" key={`${setting.id}`} onClick={() => handleClick(setting.exampleKind)}>
             <Form.Label className="setting-section-description my-0">{setting.name}.</Form.Label>
-            <Form.Control className="pl-1 mt-1" type="number" id={setting.id} value={setting.value} onChange={handleChangeInput}></Form.Control>
+            <Form.Control className="pl-1 mt-1" type="number" id={setting.id} value={setting.value} onChange={handleChangeInput} disabled={readOnly}></Form.Control>
           </div>
         );
       default:

--- a/src/formatter-settings/assets/features/formatterSettings/formatterSettingViewSlice.ts
+++ b/src/formatter-settings/assets/features/formatterSettings/formatterSettingViewSlice.ts
@@ -13,6 +13,7 @@ export const formatterSettingsViewSlice = createSlice({
     vscodeSettings: [] as JavaFormatterSetting[],
     detectIndentation: false,
     formattedContent: "",
+    readOnly: false,
   },
   reducers: {
     changeActiveCategory: (state, action) => {
@@ -34,6 +35,9 @@ export const formatterSettingsViewSlice = createSlice({
     applyFormatResult: (state, action) => {
       state.formattedContent = action.payload.content;
     },
+    changeReadOnlyState: (state, action) => {
+      state.readOnly = Boolean(action.payload.value);
+    },
   },
 });
 
@@ -42,6 +46,7 @@ export const {
   loadProfileSetting,
   loadVSCodeSetting,
   applyFormatResult,
+  changeReadOnlyState,
 } = formatterSettingsViewSlice.actions;
 
 export default formatterSettingsViewSlice.reducer;

--- a/src/formatter-settings/assets/style.scss
+++ b/src/formatter-settings/assets/style.scss
@@ -153,6 +153,9 @@ $enable-rounded: false;
     box-shadow: none !important;
     border: 1px solid var(--vscode-focusBorder) !important;
   }
+  &:disabled {
+    opacity: 0.67 !important;
+  }
 }
 
 .setting-nav .nav-link {

--- a/src/formatter-settings/assets/utils.ts
+++ b/src/formatter-settings/assets/utils.ts
@@ -26,3 +26,9 @@ export function onWillChangeSetting(id: string, value: any) {
     value: value,
   });
 }
+
+export function onWillDownloadAndUse() {
+  vscode.postMessage({
+    command: "onWillDownloadAndUse"
+  });
+}

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -91,6 +91,7 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
                     break;
                 case "onWillChangeSetting":
                     const settingValue: string | undefined = FormatterConverter.webView2ProfileConvert(e.id, e.value.toString());
+                    // "" represents an empty inputbox, we regard it as a valid value.
                     if (settingValue === undefined) {
                         return;
                     }

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -10,6 +10,7 @@ import { XMLSerializer } from "xmldom";
 import { loadTextFromFile } from "../utils";
 import { Example, getSupportedVSCodeSettings, JavaConstants, SupportedSettings, VSCodeSettings } from "./FormatterConstants";
 import { FormatterConverter } from "./FormatterConverter";
+import { RemoteProfileProvider } from "./RemoteProfileProvider";
 import { DOMElement, ExampleKind, ProfileContent } from "./types";
 import { addDefaultProfile, downloadFile, getProfilePath, getTargetPath, getVersion, getVSCodeSetting, isRemote, openFormatterSettings, parseProfile } from "./utils";
 export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEditorProvider {
@@ -56,7 +57,7 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
         if (!await this.checkProfileSettings() || !this.settingsUrl) {
             return;
         }
-        const filePath = this.readOnly ? vscode.Uri.parse(this.settingsUrl).with({ scheme: "formatter" }) : vscode.Uri.file(this.profilePath);
+        const filePath = this.readOnly ? vscode.Uri.parse(this.settingsUrl).with({ scheme: RemoteProfileProvider.scheme }) : vscode.Uri.file(this.profilePath);
         vscode.commands.executeCommand("vscode.openWith", filePath, "java.formatterSettingsEditor");
     }
 

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -6,18 +6,16 @@ import * as fse from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
 import { instrumentOperation, sendError, sendInfo, setUserError } from "vscode-extension-telemetry-wrapper";
-import { DOMParser, XMLSerializer } from "xmldom";
+import { XMLSerializer } from "xmldom";
 import { loadTextFromFile } from "../utils";
-import { Example, getDefaultValue, getSupportedProfileSettings, getSupportedVSCodeSettings, JavaConstants, SupportedSettings, VSCodeSettings } from "./FormatterConstants";
+import { Example, getSupportedVSCodeSettings, JavaConstants, SupportedSettings, VSCodeSettings } from "./FormatterConstants";
 import { FormatterConverter } from "./FormatterConverter";
-import { DOMElement, ExampleKind, JavaFormatterSetting } from "./types";
-import { getProfilePath, getVSCodeSetting, isRemote, getTargetProfilePath } from "./utils";
+import { DOMElement, ExampleKind, ProfileContent } from "./types";
+import { getProfilePath, getVSCodeSetting, isRemote, getTargetProfilePath, parseProfile } from "./utils";
 export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEditorProvider {
 
     public static readonly viewType = "java.formatterSettingsEditor";
     private exampleKind: ExampleKind = ExampleKind.INDENTATION_EXAMPLE;
-    private supportedProfileSettings: Map<string, JavaFormatterSetting> = getSupportedProfileSettings(20);
-    private supportedVSCodeSettings: Map<string, JavaFormatterSetting> = getSupportedVSCodeSettings();
     private profileElements: Map<string, DOMElement> = new Map<string, DOMElement>();
     private profileSettings: Map<string, string> = new Map<string, string>();
     private lastElement: DOMElement | undefined;
@@ -25,57 +23,64 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
     private checkedRequirement: boolean = false;
     private checkedProfile: boolean = false;
     private diagnosticCollection: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection();
+    private settingsUrl: string | undefined = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_URL_KEY);
+    private webviewPanel: vscode.WebviewPanel | undefined;
 
     constructor(private readonly context: vscode.ExtensionContext) {
         vscode.workspace.onDidChangeConfiguration(e => {
-            if (e.affectsConfiguration(`java.${JavaConstants.SETTINGS_URL_KEY}`) || e.affectsConfiguration(`java.${JavaConstants.SETTINGS_PROFILE_KEY}`)) {
+            if (e.affectsConfiguration(`java.${JavaConstants.SETTINGS_URL_KEY}`)) {
+                this.checkedProfile = false;
+                this.settingsUrl = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_URL_KEY);
+            } else if (e.affectsConfiguration(`java.${JavaConstants.SETTINGS_PROFILE_KEY}`)) {
                 this.checkedProfile = false;
             }
+        });
+        vscode.workspace.onDidChangeTextDocument(async (e: vscode.TextDocumentChangeEvent) => {
+            if (!this.settingsUrl || e.document.uri.toString() !== vscode.Uri.file(await getProfilePath(this.settingsUrl)).toString()) {
+                return;
+            }
+            await this.parseProfileAndUpdate(e.document);
         });
     }
 
     public async showFormatterSettingsEditor(): Promise<void> {
-        if (!await this.checkProfile()) {
+        if (!await this.checkProfile() || !this.settingsUrl) {
             return;
         }
-        const settingsUrl = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_URL_KEY);
-        if (!settingsUrl) {
-            return;
-        }
-        const filePath = vscode.Uri.file(await getProfilePath(settingsUrl));
+        const filePath = vscode.Uri.file(await getProfilePath(this.settingsUrl));
         vscode.commands.executeCommand("vscode.openWith", filePath, "java.formatterSettingsEditor");
     }
 
     public async resolveCustomTextEditor(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel, _token: vscode.CancellationToken): Promise<void> {
 
+        // restrict one webviewpanel only
+        if (this.webviewPanel) {
+            vscode.commands.executeCommand("vscode.open", document.uri);
+            webviewPanel.dispose();
+            return;
+        } else {
+            this.webviewPanel = webviewPanel;
+        }
+        
         webviewPanel.webview.options = {
             enableScripts: true,
             enableCommandUris: true,
         };
+        this.webviewPanel.onDidDispose(() => {
+            this.webviewPanel = undefined;
+        })
         const resourceUri = this.context.asAbsolutePath("./out/assets/formatter-settings/index.html");
-        webviewPanel.webview.html = await loadTextFromFile(resourceUri);
-        const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(async (e: vscode.TextDocumentChangeEvent) => {
-            if (e.document.uri.toString() !== document.uri.toString()) {
-                return;
-            }
-            const diagnostics = this.updateProfileSettings(e.document, webviewPanel);
-            this.diagnosticCollection.set(e.document.uri, diagnostics);
-            await this.updateVSCodeSettings(webviewPanel);
-            this.format(webviewPanel);
-        });
-        webviewPanel.onDidDispose(() => {
-            changeDocumentSubscription.dispose();
-        });
-        webviewPanel.webview.onDidReceiveMessage(async (e) => {
+        this.webviewPanel.webview.html = await loadTextFromFile(resourceUri);
+        this.webviewPanel.webview.onDidReceiveMessage(async (e) => {
             switch (e.command) {
                 case "onWillInitialize":
-                    if (!await this.initialize(document, webviewPanel)) {
-                        webviewPanel.dispose();
+                    if (!await this.initialize(document)) {
+                        this.webviewPanel?.dispose();
                     }
                     break;
                 case "onWillChangeExampleKind":
                     this.exampleKind = e.exampleKind;
-                    this.format(webviewPanel);
+                    this.format();
                     break;
                 case "onWillChangeSetting":
                     const settingValue: string | undefined = FormatterConverter.webView2ProfileConvert(e.id, e.value.toString());
@@ -130,7 +135,7 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
         return true;
     }
 
-    private async initialize(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel): Promise<boolean> {
+    private async initialize(document: vscode.TextDocument): Promise<boolean> {
         if (!await this.checkRequirement()) {
             return false;
         }
@@ -140,24 +145,40 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
         this.exampleKind = ExampleKind.INDENTATION_EXAMPLE;
         const onDidChangeSetting: vscode.Disposable = vscode.workspace.onDidChangeConfiguration(async (e) => {
             if (e.affectsConfiguration(`java.${JavaConstants.SETTINGS_URL_KEY}`) || e.affectsConfiguration(`java.${JavaConstants.SETTINGS_PROFILE_KEY}`)) {
-                this.onChangeProfile(webviewPanel);
+                this.onChangeProfile();
             } else if (e.affectsConfiguration(VSCodeSettings.TAB_SIZE) || e.affectsConfiguration(VSCodeSettings.INSERT_SPACES) || e.affectsConfiguration(VSCodeSettings.DETECT_INDENTATION)) {
-                await this.updateVSCodeSettings(webviewPanel);
-                this.format(webviewPanel);
+                await this.updateVSCodeSettings();
+                this.format();
             }
         });
-        webviewPanel.onDidDispose(() => {
+        this.webviewPanel?.onDidDispose(() => {
             onDidChangeSetting.dispose();
         });
-        const diagnostics = this.updateProfileSettings(document, webviewPanel);
-        this.diagnosticCollection.set(document.uri, diagnostics);
-        await this.updateVSCodeSettings(webviewPanel);
-        this.format(webviewPanel);
+        await this.parseProfileAndUpdate(document);
         return true;
     }
 
-    private onChangeProfile(webviewPanel: vscode.WebviewPanel): void {
-        if (webviewPanel.visible) {
+    private async parseProfileAndUpdate(document: vscode.TextDocument): Promise<void> {
+        const content: ProfileContent = parseProfile(document);
+        this.diagnosticCollection.set(document.uri, content.diagnostics);
+        if (this.webviewPanel) {
+            this.profileElements = content.profileElements || this.profileElements;
+            this.profileSettings = content.profileSettings || this.profileSettings;
+            this.lastElement = content.lastElement || this.lastElement;
+            this.settingsVersion = content.settingsVersion;
+            if (content.supportedProfileSettings) {
+                this.webviewPanel.webview.postMessage({
+                    command: "loadProfileSetting",
+                    setting: Array.from(content.supportedProfileSettings.values()),
+                });
+            }
+            await this.updateVSCodeSettings();
+            this.format();
+        }
+    }
+
+    private onChangeProfile(): void {
+        if (this.webviewPanel?.visible) {
             vscode.window.showInformationMessage(`Formatter Profile settings have been changed, do you want to reload this editor?`,
                 "Yes", "No").then(async (result) => {
                     if (result === "Yes") {
@@ -167,79 +188,9 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
         }
     }
 
-    private updateProfileSettings(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel): vscode.Diagnostic[] {
-        this.profileElements.clear();
-        this.profileSettings.clear();
-        this.lastElement = undefined;
-        this.diagnosticCollection.clear();
-        const diagnostics: vscode.Diagnostic[] = [];
-        const documentDOM = new DOMParser().parseFromString(document.getText());
-        this.settingsVersion = documentDOM.documentElement.getAttribute("version") || this.settingsVersion;
-        const profiles = documentDOM.documentElement.getElementsByTagName("profile");
-        if (!profiles || profiles.length === 0) {
-            diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)), "No valid profiles found."));
-            return diagnostics;
-        }
-        const settingsProfileName: string | undefined = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_PROFILE_KEY);
-        for (let i = 0; i < profiles.length; i++) {
-            if (!settingsProfileName || settingsProfileName === profiles[i].getAttribute("name")) {
-                if (profiles[i].getAttribute("kind") !== "CodeFormatterProfile") {
-                    continue;
-                }
-                this.settingsVersion = profiles[i].getAttribute("version") || this.settingsVersion;
-                const settings = profiles[i].getElementsByTagName("setting");
-                for (let j = 0; j < settings.length; j++) {
-                    const setting: DOMElement = settings[j] as DOMElement;
-                    const settingContent: string = new XMLSerializer().serializeToString(setting);
-                    const id = setting.getAttribute("id");
-                    if (!id) {
-                        diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no 'id' property.", vscode.DiagnosticSeverity.Error));
-                        continue;
-                    }
-                    const value = settings[j].getAttribute("value");
-                    if (!value) {
-                        diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no 'value' property.", vscode.DiagnosticSeverity.Error));
-                        continue;
-                    }
-                    this.profileElements.set(id, setting);
-                    this.profileSettings.set(id, value);
-                    this.lastElement = setting;
-                }
-                break;
-            }
-        }
-        if (!this.profileElements.size) {
-            diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)), "No valid settings found in the profile."));
-            return diagnostics;
-        }
-        this.supportedProfileSettings = getSupportedProfileSettings(Number(this.settingsVersion));
-        for (const setting of this.supportedProfileSettings.values()) {
-            const element = this.profileElements.get(setting.id);
-            const value = this.profileSettings.get(setting.id);
-            if (!element || !value) {
-                continue;
-            }
-            const webViewValue: string | undefined = FormatterConverter.profile2WebViewConvert(setting.id, value);
-            if (!webViewValue) {
-                const elementContent = new XMLSerializer().serializeToString(element);
-                const elementRange = new vscode.Range(new vscode.Position(element.lineNumber - 1, element.columnNumber - 1), new vscode.Position(element.lineNumber - 1, element.columnNumber - 1 + elementContent.length));
-                diagnostics.push(new vscode.Diagnostic(elementRange, `Invalid value in id: "${setting.id}", "${value}" is not supported.`, vscode.DiagnosticSeverity.Error));
-                this.profileSettings.delete(setting.id);
-                setting.value = FormatterConverter.profile2WebViewConvert(setting.id, getDefaultValue(setting.id))!;
-                continue;
-            }
-            setting.value = webViewValue;
-        }
-        webviewPanel.webview.postMessage({
-            command: "loadProfileSetting",
-            setting: Array.from(this.supportedProfileSettings.values()),
-        });
-        return diagnostics;
-    }
-
-    private async updateVSCodeSettings(webviewPanel: vscode.WebviewPanel): Promise<void> {
-        this.supportedVSCodeSettings = getSupportedVSCodeSettings();
-        for (const setting of this.supportedVSCodeSettings.values()) {
+    private async updateVSCodeSettings(): Promise<void> {
+        const supportedVSCodeSettings = getSupportedVSCodeSettings();
+        for (const setting of supportedVSCodeSettings.values()) {
             switch (setting.id) {
                 case SupportedSettings.TABULATION_CHAR:
                     setting.value = (await getVSCodeSetting(VSCodeSettings.INSERT_SPACES, true) === false) ? "tab" : "space";
@@ -256,16 +207,16 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
                     return;
             }
         }
-        webviewPanel.webview.postMessage({
+        this.webviewPanel?.webview.postMessage({
             command: "loadVSCodeSetting",
-            setting: Array.from(this.supportedVSCodeSettings.values()),
+            setting: Array.from(supportedVSCodeSettings.values()),
         });
     }
 
-    private async format(webviewPanel: vscode.WebviewPanel): Promise<void> {
+    private async format(): Promise<void> {
         const content = await vscode.commands.executeCommand<string>("java.execute.workspaceCommand", "java.edit.stringFormatting", Example.getExample(this.exampleKind), JSON.stringify([...this.profileSettings]), this.settingsVersion);
-        if (webviewPanel && webviewPanel.webview) {
-            webviewPanel.webview.postMessage({
+        if (this.webviewPanel?.webview) {
+            this.webviewPanel.webview.postMessage({
                 command: "formattedContent",
                 content: content,
             });
@@ -285,14 +236,14 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
             cloneElement.setAttribute("value", value);
             const edit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
             edit.insert(document.uri, new vscode.Position(cloneElement.lineNumber - 1, cloneElement.columnNumber - 1 + originalString.length), ((document.eol === vscode.EndOfLine.LF) ? "\n" : "\r\n") + " ".repeat(cloneElement.columnNumber - 1) + new XMLSerializer().serializeToString(cloneElement));
-            vscode.workspace.applyEdit(edit);
+            await vscode.workspace.applyEdit(edit);
         } else {
             // edit a current setting in the profile
             const originalSetting: string = new XMLSerializer().serializeToString(profileElement);
             profileElement.setAttribute("value", value);
             const edit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
             edit.replace(document.uri, new vscode.Range(new vscode.Position(profileElement.lineNumber - 1, profileElement.columnNumber - 1), new vscode.Position(profileElement.lineNumber - 1, profileElement.columnNumber - 1 + originalSetting.length)), new XMLSerializer().serializeToString(profileElement));
-            vscode.workspace.applyEdit(edit);
+            await vscode.workspace.applyEdit(edit);
         }
     }
 
@@ -300,9 +251,8 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
         if (this.checkedProfile) {
             return true;
         }
-        const settingsUrl = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_URL_KEY);
         this.checkedProfile = await instrumentOperation("formatter.checkProfileSetting", async (operationId: string) => {
-            if (!settingsUrl) {
+            if (!this.settingsUrl) {
                 sendInfo(operationId, { formatterProfile: "undefined" });
                 await vscode.window.showInformationMessage("No active Formatter Profile found, do you want to create a default one?",
                     "Yes", "No").then((result) => {
@@ -312,12 +262,12 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
                     });
                 return false;
             } else {
-                if (isRemote(settingsUrl)) {
+                if (isRemote(this.settingsUrl)) {
                     // Will handle remote profile in the next PR
                     sendInfo(operationId, { formatterProfile: "remote" });
                     return false;
                 }
-                const profilePath = await getProfilePath(settingsUrl);
+                const profilePath = await getProfilePath(this.settingsUrl);
                 if (!(await fse.pathExists(profilePath))) {
                     sendInfo(operationId, { formatterProfile: "notExist" });
                     await vscode.window.showInformationMessage("The active formatter profile does not exist, please check it in the Settings and try again.",

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -1,29 +1,52 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as vscode from "vscode";
+import compareVersions from "compare-versions";
+import * as fse from "fs-extra";
 import * as path from "path";
+import * as vscode from "vscode";
+import { instrumentOperation, sendError, sendInfo, setUserError } from "vscode-extension-telemetry-wrapper";
+import { DOMParser, XMLSerializer } from "xmldom";
 import { loadTextFromFile } from "../utils";
-import { Example, getSupportedProfileSettings, getSupportedVSCodeSettings, JavaConstants } from "./FormatterConstants";
-import { ExampleKind, JavaFormatterSetting } from "./types";
+import { Example, getDefaultValue, getSupportedProfileSettings, getSupportedVSCodeSettings, JavaConstants, SupportedSettings, VSCodeSettings } from "./FormatterConstants";
+import { FormatterConverter } from "./FormatterConverter";
+import { DOMElement, ExampleKind, JavaFormatterSetting } from "./types";
+import { getProfilePath, getVSCodeSetting, isRemote, getTargetProfilePath } from "./utils";
 export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEditorProvider {
 
     public static readonly viewType = "java.formatterSettingsEditor";
     private exampleKind: ExampleKind = ExampleKind.INDENTATION_EXAMPLE;
     private supportedProfileSettings: Map<string, JavaFormatterSetting> = getSupportedProfileSettings(20);
     private supportedVSCodeSettings: Map<string, JavaFormatterSetting> = getSupportedVSCodeSettings();
+    private profileElements: Map<string, DOMElement> = new Map<string, DOMElement>();
+    private profileSettings: Map<string, string> = new Map<string, string>();
+    private lastElement: DOMElement | undefined;
+    private settingsVersion: string = JavaConstants.CURRENT_FORMATTER_SETTINGS_VERSION;
+    private checkedRequirement: boolean = false;
+    private checkedProfile: boolean = false;
+    private diagnosticCollection: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection();
 
     constructor(private readonly context: vscode.ExtensionContext) {
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration(`java.${JavaConstants.SETTINGS_URL_KEY}`) || e.affectsConfiguration(`java.${JavaConstants.SETTINGS_PROFILE_KEY}`)) {
+                this.checkedProfile = false;
+            }
+        });
     }
 
-    public async showFormatterSettingsEditor() {
-        // Use a fake profile
-        const defaultProfile: string = path.join(this.context.extensionPath, "webview-resources", "java-formatter.xml");
-        const resource = vscode.Uri.file(defaultProfile);
-        vscode.commands.executeCommand("vscode.openWith", resource, "java.formatterSettingsEditor");
+    public async showFormatterSettingsEditor(): Promise<void> {
+        if (!await this.checkProfile()) {
+            return;
+        }
+        const settingsUrl = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_URL_KEY);
+        if (!settingsUrl) {
+            return;
+        }
+        const filePath = vscode.Uri.file(await getProfilePath(settingsUrl));
+        vscode.commands.executeCommand("vscode.openWith", filePath, "java.formatterSettingsEditor");
     }
 
-    public async resolveCustomTextEditor(_document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel, _token: vscode.CancellationToken): Promise<void> {
+    public async resolveCustomTextEditor(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel, _token: vscode.CancellationToken): Promise<void> {
 
         webviewPanel.webview.options = {
             enableScripts: true,
@@ -31,57 +54,216 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
         };
         const resourceUri = this.context.asAbsolutePath("./out/assets/formatter-settings/index.html");
         webviewPanel.webview.html = await loadTextFromFile(resourceUri);
-        this.exampleKind = ExampleKind.INDENTATION_EXAMPLE;
+        const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(async (e: vscode.TextDocumentChangeEvent) => {
+            if (e.document.uri.toString() !== document.uri.toString()) {
+                return;
+            }
+            const diagnostics = this.updateProfileSettings(e.document, webviewPanel);
+            this.diagnosticCollection.set(e.document.uri, diagnostics);
+            await this.updateVSCodeSettings(webviewPanel);
+            this.format(webviewPanel);
+        });
+        webviewPanel.onDidDispose(() => {
+            changeDocumentSubscription.dispose();
+        });
         webviewPanel.webview.onDidReceiveMessage(async (e) => {
             switch (e.command) {
                 case "onWillInitialize":
-                    // use default values temporarily
-                    webviewPanel.webview.postMessage({
-                        command: "loadProfileSetting",
-                        setting: Array.from(this.supportedProfileSettings.values()),
-                    });
-                    webviewPanel.webview.postMessage({
-                        command: "loadVSCodeSetting",
-                        setting: Array.from(this.supportedVSCodeSettings.values()),
-                    });
-                    this.formatWithProfileSettings(webviewPanel);
+                    if (!await this.initialize(document, webviewPanel)) {
+                        webviewPanel.dispose();
+                    }
                     break;
                 case "onWillChangeExampleKind":
                     this.exampleKind = e.exampleKind;
-                    this.formatWithProfileSettings(webviewPanel);
+                    this.format(webviewPanel);
                     break;
                 case "onWillChangeSetting":
-                    // modify the settings in memory temporarily
-                    for (const entry of this.supportedProfileSettings.entries()) {
-                        if (entry[0] === e.id) {
-                            entry[1].value = e.value;
-                            break;
-                        }
+                    const settingValue: string | undefined = FormatterConverter.webView2ProfileConvert(e.id, e.value.toString());
+                    if (!settingValue) {
+                        return;
                     }
-                    for (const entry of this.supportedVSCodeSettings.entries()) {
-                        if (entry[0] === e.id) {
-                            entry[1].value = e.value;
-                            break;
+                    if (SupportedSettings.indentationSettings.includes(e.id)) {
+                        const config = vscode.workspace.getConfiguration(undefined, { languageId: "java" });
+                        if (e.id === SupportedSettings.TABULATION_CHAR) {
+                            const targetValue = (settingValue === "tab") ? false : true;
+                            await config.update(VSCodeSettings.INSERT_SPACES, targetValue, undefined, true);
+                        } else if (e.id === SupportedSettings.TABULATION_SIZE) {
+                            await config.update(VSCodeSettings.TAB_SIZE, Number(settingValue), undefined, true);
                         }
+                        this.profileSettings.set(e.id, settingValue);
+                    } else if (e.id === VSCodeSettings.DETECT_INDENTATION) {
+                        const config = vscode.workspace.getConfiguration(undefined, { languageId: "java" });
+                        await config.update(VSCodeSettings.DETECT_INDENTATION, (settingValue === "true"), undefined, true);
+                    } else {
+                        await this.modifyProfile(e.id, settingValue, document);
                     }
-                    webviewPanel.webview.postMessage({
-                        command: "loadProfileSetting",
-                        setting: Array.from(this.supportedProfileSettings.values()),
-                    });
-                    webviewPanel.webview.postMessage({
-                        command: "loadVSCodeSetting",
-                        setting: Array.from(this.supportedVSCodeSettings.values()),
-                    });
                     break;
                 default:
                     break;
             }
         });
+        await this.checkRequirement();
     }
 
-    private async formatWithProfileSettings(webviewPanel: vscode.WebviewPanel) {
-        // use default settings temporarily
-        const content = await vscode.commands.executeCommand<string>("java.execute.workspaceCommand", "java.edit.stringFormatting", Example.getExample(this.exampleKind), JSON.stringify([]), JavaConstants.CURRENT_FORMATTER_SETTINGS_VERSION);
+    private async checkRequirement(): Promise<boolean> {
+        if (this.checkedRequirement) {
+            return true;
+        }
+        const javaExt = vscode.extensions.getExtension("redhat.java");
+        if (!javaExt) {
+            vscode.window.showErrorMessage("The extension 'redhat.java' is not installed. Please install it and run this command again.");
+            const err: Error = new Error("The extension 'redhat.java' is not installed.");
+            setUserError(err);
+            sendError(err);
+            return false;
+        }
+        const javaExtVersion: string = javaExt.packageJSON.version;
+        if (compareVersions(javaExtVersion, JavaConstants.MINIMUM_JAVA_EXTENSION_VERSION) < 0) {
+            vscode.window.showErrorMessage(`The extension version of 'redhat.java' is too stale. Please install at least ${JavaConstants.MINIMUM_JAVA_EXTENSION_VERSION} and run this command again.`);
+            const err: Error = new Error(`The extension version of 'redhat.java' (${javaExtVersion}) is too stale.`);
+            setUserError(err);
+            sendError(err);
+            return false;
+        }
+        await javaExt.activate();
+        this.checkedRequirement = true;
+        return true;
+    }
+
+    private async initialize(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel): Promise<boolean> {
+        if (!await this.checkRequirement()) {
+            return false;
+        }
+        if (!await this.checkProfile()) {
+            return false;
+        }
+        this.exampleKind = ExampleKind.INDENTATION_EXAMPLE;
+        const onDidChangeSetting: vscode.Disposable = vscode.workspace.onDidChangeConfiguration(async (e) => {
+            if (e.affectsConfiguration(`java.${JavaConstants.SETTINGS_URL_KEY}`) || e.affectsConfiguration(`java.${JavaConstants.SETTINGS_PROFILE_KEY}`)) {
+                this.onChangeProfile(webviewPanel);
+            } else if (e.affectsConfiguration(VSCodeSettings.TAB_SIZE) || e.affectsConfiguration(VSCodeSettings.INSERT_SPACES) || e.affectsConfiguration(VSCodeSettings.DETECT_INDENTATION)) {
+                await this.updateVSCodeSettings(webviewPanel);
+                this.format(webviewPanel);
+            }
+        });
+        webviewPanel.onDidDispose(() => {
+            onDidChangeSetting.dispose();
+        });
+        const diagnostics = this.updateProfileSettings(document, webviewPanel);
+        this.diagnosticCollection.set(document.uri, diagnostics);
+        await this.updateVSCodeSettings(webviewPanel);
+        this.format(webviewPanel);
+        return true;
+    }
+
+    private onChangeProfile(webviewPanel: vscode.WebviewPanel): void {
+        if (webviewPanel.visible) {
+            vscode.window.showInformationMessage(`Formatter Profile settings have been changed, do you want to reload this editor?`,
+                "Yes", "No").then(async (result) => {
+                    if (result === "Yes") {
+                        vscode.commands.executeCommand("workbench.action.webview.reloadWebviewAction");
+                    }
+                });
+        }
+    }
+
+    private updateProfileSettings(document: vscode.TextDocument, webviewPanel: vscode.WebviewPanel): vscode.Diagnostic[] {
+        this.profileElements.clear();
+        this.profileSettings.clear();
+        this.lastElement = undefined;
+        this.diagnosticCollection.clear();
+        const diagnostics: vscode.Diagnostic[] = [];
+        const documentDOM = new DOMParser().parseFromString(document.getText());
+        this.settingsVersion = documentDOM.documentElement.getAttribute("version") || this.settingsVersion;
+        const profiles = documentDOM.documentElement.getElementsByTagName("profile");
+        if (!profiles || profiles.length === 0) {
+            diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)), "No valid profiles found."));
+            return diagnostics;
+        }
+        const settingsProfileName: string | undefined = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_PROFILE_KEY);
+        for (let i = 0; i < profiles.length; i++) {
+            if (!settingsProfileName || settingsProfileName === profiles[i].getAttribute("name")) {
+                if (profiles[i].getAttribute("kind") !== "CodeFormatterProfile") {
+                    continue;
+                }
+                this.settingsVersion = profiles[i].getAttribute("version") || this.settingsVersion;
+                const settings = profiles[i].getElementsByTagName("setting");
+                for (let j = 0; j < settings.length; j++) {
+                    const setting: DOMElement = settings[j] as DOMElement;
+                    const settingContent: string = new XMLSerializer().serializeToString(setting);
+                    const id = setting.getAttribute("id");
+                    if (!id) {
+                        diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no 'id' property.", vscode.DiagnosticSeverity.Error));
+                        continue;
+                    }
+                    const value = settings[j].getAttribute("value");
+                    if (!value) {
+                        diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no 'value' property.", vscode.DiagnosticSeverity.Error));
+                        continue;
+                    }
+                    this.profileElements.set(id, setting);
+                    this.profileSettings.set(id, value);
+                    this.lastElement = setting;
+                }
+                break;
+            }
+        }
+        if (!this.profileElements.size) {
+            diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)), "No valid settings found in the profile."));
+            return diagnostics;
+        }
+        this.supportedProfileSettings = getSupportedProfileSettings(Number(this.settingsVersion));
+        for (const setting of this.supportedProfileSettings.values()) {
+            const element = this.profileElements.get(setting.id);
+            const value = this.profileSettings.get(setting.id);
+            if (!element || !value) {
+                continue;
+            }
+            const webViewValue: string | undefined = FormatterConverter.profile2WebViewConvert(setting.id, value);
+            if (!webViewValue) {
+                const elementContent = new XMLSerializer().serializeToString(element);
+                const elementRange = new vscode.Range(new vscode.Position(element.lineNumber - 1, element.columnNumber - 1), new vscode.Position(element.lineNumber - 1, element.columnNumber - 1 + elementContent.length));
+                diagnostics.push(new vscode.Diagnostic(elementRange, `Invalid value in id: "${setting.id}", "${value}" is not supported.`, vscode.DiagnosticSeverity.Error));
+                this.profileSettings.delete(setting.id);
+                setting.value = FormatterConverter.profile2WebViewConvert(setting.id, getDefaultValue(setting.id))!;
+                continue;
+            }
+            setting.value = webViewValue;
+        }
+        webviewPanel.webview.postMessage({
+            command: "loadProfileSetting",
+            setting: Array.from(this.supportedProfileSettings.values()),
+        });
+        return diagnostics;
+    }
+
+    private async updateVSCodeSettings(webviewPanel: vscode.WebviewPanel): Promise<void> {
+        this.supportedVSCodeSettings = getSupportedVSCodeSettings();
+        for (const setting of this.supportedVSCodeSettings.values()) {
+            switch (setting.id) {
+                case SupportedSettings.TABULATION_CHAR:
+                    setting.value = (await getVSCodeSetting(VSCodeSettings.INSERT_SPACES, true) === false) ? "tab" : "space";
+                    this.profileSettings.set(setting.id, setting.value);
+                    break;
+                case SupportedSettings.TABULATION_SIZE:
+                    setting.value = String(await getVSCodeSetting(VSCodeSettings.TAB_SIZE, 4));
+                    this.profileSettings.set(setting.id, setting.value);
+                    break;
+                case VSCodeSettings.DETECT_INDENTATION:
+                    setting.value = String(await getVSCodeSetting(VSCodeSettings.DETECT_INDENTATION, true));
+                    break;
+                default:
+                    return;
+            }
+        }
+        webviewPanel.webview.postMessage({
+            command: "loadVSCodeSetting",
+            setting: Array.from(this.supportedVSCodeSettings.values()),
+        });
+    }
+
+    private async format(webviewPanel: vscode.WebviewPanel): Promise<void> {
+        const content = await vscode.commands.executeCommand<string>("java.execute.workspaceCommand", "java.edit.stringFormatting", Example.getExample(this.exampleKind), JSON.stringify([...this.profileSettings]), this.settingsVersion);
         if (webviewPanel && webviewPanel.webview) {
             webviewPanel.webview.postMessage({
                 command: "formattedContent",
@@ -89,11 +271,86 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
             });
         }
     }
+
+    private async modifyProfile(id: string, value: string, document: vscode.TextDocument): Promise<void> {
+        const profileElement = this.profileElements.get(id);
+        if (!profileElement) {
+            // add a new setting not exist in the profile
+            if (!this.lastElement) {
+                return;
+            }
+            const cloneElement = this.lastElement.cloneNode() as DOMElement;
+            const originalString: string = new XMLSerializer().serializeToString(cloneElement);
+            cloneElement.setAttribute("id", id);
+            cloneElement.setAttribute("value", value);
+            const edit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+            edit.insert(document.uri, new vscode.Position(cloneElement.lineNumber - 1, cloneElement.columnNumber - 1 + originalString.length), ((document.eol === vscode.EndOfLine.LF) ? "\n" : "\r\n") + " ".repeat(cloneElement.columnNumber - 1) + new XMLSerializer().serializeToString(cloneElement));
+            vscode.workspace.applyEdit(edit);
+        } else {
+            // edit a current setting in the profile
+            const originalSetting: string = new XMLSerializer().serializeToString(profileElement);
+            profileElement.setAttribute("value", value);
+            const edit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+            edit.replace(document.uri, new vscode.Range(new vscode.Position(profileElement.lineNumber - 1, profileElement.columnNumber - 1), new vscode.Position(profileElement.lineNumber - 1, profileElement.columnNumber - 1 + originalSetting.length)), new XMLSerializer().serializeToString(profileElement));
+            vscode.workspace.applyEdit(edit);
+        }
+    }
+
+    private async checkProfile(): Promise<boolean> {
+        if (this.checkedProfile) {
+            return true;
+        }
+        const settingsUrl = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_URL_KEY);
+        this.checkedProfile = await instrumentOperation("formatter.checkProfileSetting", async (operationId: string) => {
+            if (!settingsUrl) {
+                sendInfo(operationId, { formatterProfile: "undefined" });
+                await vscode.window.showInformationMessage("No active Formatter Profile found, do you want to create a default one?",
+                    "Yes", "No").then((result) => {
+                        if (result === "Yes") {
+                            this.addDefaultProfile();
+                        }
+                    });
+                return false;
+            } else {
+                if (isRemote(settingsUrl)) {
+                    // Will handle remote profile in the next PR
+                    sendInfo(operationId, { formatterProfile: "remote" });
+                    return false;
+                }
+                const profilePath = await getProfilePath(settingsUrl);
+                if (!(await fse.pathExists(profilePath))) {
+                    sendInfo(operationId, { formatterProfile: "notExist" });
+                    await vscode.window.showInformationMessage("The active formatter profile does not exist, please check it in the Settings and try again.",
+                        "Open Settings", "Generate a default profile").then((result) => {
+                            if (result === "Open Settings") {
+                                vscode.commands.executeCommand("workbench.action.openSettings", JavaConstants.SETTINGS_URL_KEY);
+                                if (vscode.workspace.workspaceFolders?.length) {
+                                    vscode.commands.executeCommand("workbench.action.openWorkspaceSettings");
+                                }
+                            } else if (result === "Generate a default profile") {
+                                this.addDefaultProfile();
+                            }
+                        });
+                    return false;
+                }
+                sendInfo(operationId, { formatterProfile: "valid" });
+                return true;
+            }
+        })();
+        return this.checkedProfile;
+    }
+
+    private async addDefaultProfile(): Promise<void> {
+        const defaultProfile: string = path.join(this.context.extensionPath, "webview-resources", "java-formatter.xml");
+        const profilePath = await getTargetProfilePath(this.context);
+        await fse.copy(defaultProfile, profilePath);
+        vscode.commands.executeCommand("vscode.openWith", vscode.Uri.file(profilePath), "java.formatterSettingsEditor");
+    }
 }
 
 export let javaFormatterSettingsEditorProvider: JavaFormatterSettingsEditorProvider;
 
 export function initFormatterSettingsEditorProvider(context: vscode.ExtensionContext) {
     javaFormatterSettingsEditorProvider = new JavaFormatterSettingsEditorProvider(context);
-    context.subscriptions.push(vscode.window.registerCustomEditorProvider(JavaFormatterSettingsEditorProvider.viewType, javaFormatterSettingsEditorProvider, { webviewOptions: {enableFindWidget: true, retainContextWhenHidden: true}}));
+    context.subscriptions.push(vscode.window.registerCustomEditorProvider(JavaFormatterSettingsEditorProvider.viewType, javaFormatterSettingsEditorProvider, { webviewOptions: { enableFindWidget: true, retainContextWhenHidden: true } }));
 }

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -38,8 +38,7 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
             if (e.affectsConfiguration(`java.${JavaConstants.SETTINGS_URL_KEY}`)) {
                 this.settingsUrl = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_URL_KEY);
                 if (this.settingsUrl) {
-                    const res = await getProfilePath(this.settingsUrl);
-                    this.profilePath = res;
+                    this.profilePath = await getProfilePath(this.settingsUrl);
                 }
             }
         });

--- a/src/formatter-settings/types.ts
+++ b/src/formatter-settings/types.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as vscode from "vscode";
 export interface JavaFormatterSetting {
     id: string;
     name: string;
@@ -47,4 +48,13 @@ export enum ExampleKind {
 export interface DOMElement extends Element {
     lineNumber: number;
     columnNumber: number;
+}
+
+export interface ProfileContent {
+    profileElements?: Map<string, DOMElement>,
+    profileSettings?: Map<string, string>,
+    lastElement?: DOMElement,
+    supportedProfileSettings?: Map<string, JavaFormatterSetting>
+    settingsVersion: string,
+    diagnostics: vscode.Diagnostic[],
 }

--- a/src/formatter-settings/types.ts
+++ b/src/formatter-settings/types.ts
@@ -50,11 +50,16 @@ export interface DOMElement extends Element {
     columnNumber: number;
 }
 
+export interface DOMAttr extends Attr {
+    lineNumber: number;
+    columnNumber: number;
+}
+
 export interface ProfileContent {
+    settingsVersion: string,
+    diagnostics: vscode.Diagnostic[],
     profileElements?: Map<string, DOMElement>,
     profileSettings?: Map<string, string>,
     lastElement?: DOMElement,
     supportedProfileSettings?: Map<string, JavaFormatterSetting>
-    settingsVersion: string,
-    diagnostics: vscode.Diagnostic[],
 }

--- a/src/formatter-settings/types.ts
+++ b/src/formatter-settings/types.ts
@@ -42,3 +42,9 @@ export enum ExampleKind {
     WHITESPACE_EXAMPLE,
     WRAPPING_EXAMPLE,
 }
+
+// two extra properties from xmldom package, see https://www.npmjs.com/package/xmldom
+export interface DOMElement extends Element {
+    lineNumber: number;
+    columnNumber: number;
+}

--- a/src/formatter-settings/utils.ts
+++ b/src/formatter-settings/utils.ts
@@ -99,6 +99,7 @@ export function parseProfile(document: vscode.TextDocument): ProfileContent {
                 }
                 const value = settings[j].getAttribute("value");
                 if (!value) {
+                    // value maybe "" or null, "" is an valid value comes from deleting the values in the inpux box of the editor, and we will still push diagnostic here.
                     diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no valid 'value' property.", vscode.DiagnosticSeverity.Error));
                     if (value === null) {
                         continue;
@@ -119,6 +120,7 @@ export function parseProfile(document: vscode.TextDocument): ProfileContent {
     for (const setting of supportedProfileSettings.values()) {
         const element = profileElements.get(setting.id);
         const value = profileSettings.get(setting.id);
+        // "" is a valid value, so we distinguish it and undefined here.
         if (!element || value === undefined)  {
             setting.value = FormatterConverter.profile2WebViewConvert(setting.id, getDefaultValue(setting.id))!;
             continue;

--- a/src/formatter-settings/utils.ts
+++ b/src/formatter-settings/utils.ts
@@ -5,6 +5,10 @@ import * as fse from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
 import { instrumentOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
+import { DOMElement, ProfileContent } from "./types";
+import { DOMParser, XMLSerializer } from "xmldom";
+import { getDefaultValue, getSupportedProfileSettings, JavaConstants } from "./FormatterConstants";
+import { FormatterConverter } from "./FormatterConverter";
 
 export async function getProfilePath(formatterUrl: string): Promise<string> {
     const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -22,10 +26,7 @@ export async function getProfilePath(formatterUrl: string): Promise<string> {
 export async function getVSCodeSetting(setting: string, defaultValue: any): Promise<any> {
     return await instrumentOperation("formatter.getSetting", async (operationId: string) => {
         const config = vscode.workspace.getConfiguration(undefined, { languageId: "java" });
-        let result = config.get<any>(setting);
-        if (result === undefined) {
-            result = vscode.workspace.getConfiguration().get<any>(setting);
-        }
+        let result = config.get<any>(setting) ?? vscode.workspace.getConfiguration().get<any>(setting);
         if (result === undefined) {
             sendInfo(operationId, { notFoundSetting: setting });
             return defaultValue;
@@ -58,4 +59,91 @@ export async function getTargetProfilePath(context: vscode.ExtensionContext, fil
 
 function toPosixPath(inputPath: string): string {
     return inputPath.split(path.win32.sep).join(path.posix.sep);
+}
+
+export function parseProfile(document: vscode.TextDocument): ProfileContent {
+    const profileElements = new Map<string, DOMElement>();
+    const profileSettings = new Map<string, string>();
+    let lastElement = undefined;
+    const diagnostics: vscode.Diagnostic[] = [];
+    const documentDOM = new DOMParser({
+        locator: {}, errorHandler: (_level, msg) => {
+            const bracketExp: RegExp = new RegExp("\\[(.*?)\\]", "g");
+            const result: RegExpMatchArray = msg.match(bracketExp);
+            if (result && result.length) {
+                const lineExp: RegExp = new RegExp("line:(\\d*)");
+                const colExp: RegExp = new RegExp("col:(\\d*)");
+                const line = result[result.length - 1].match(lineExp);
+                const column = result[result.length - 1].match(colExp);
+                if (line && line.length === 2 && column && column.length === 2) {
+                    diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(Number(line[1]) - 1, Number(column[1]) - 1), new vscode.Position(Number(line[1]) - 1, Number(column[1]))), msg));
+                }
+            }
+        }
+    }).parseFromString(document.getText());
+    let settingsVersion = documentDOM.documentElement.getAttribute("version") || JavaConstants.CURRENT_FORMATTER_SETTINGS_VERSION;
+    const profiles = documentDOM.documentElement.getElementsByTagName("profile");
+    if (!profiles || profiles.length === 0) {
+        diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)), "No valid profiles found."));
+        return { settingsVersion: settingsVersion, diagnostics: diagnostics };
+    }
+    const settingsProfileName: string | undefined = vscode.workspace.getConfiguration("java").get<string>(JavaConstants.SETTINGS_PROFILE_KEY);
+    for (let i = 0; i < profiles.length; i++) {
+        if (!settingsProfileName || settingsProfileName === profiles[i].getAttribute("name")) {
+            if (profiles[i].getAttribute("kind") !== "CodeFormatterProfile") {
+                continue;
+            }
+            settingsVersion = profiles[i].getAttribute("version") || settingsVersion;
+            const settings = profiles[i].getElementsByTagName("setting");
+            for (let j = 0; j < settings.length; j++) {
+                const setting: DOMElement = settings[j] as DOMElement;
+                const settingContent: string = new XMLSerializer().serializeToString(setting);
+                const id = setting.getAttribute("id");
+                if (!id) {
+                    diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no 'id' property.", vscode.DiagnosticSeverity.Error));
+                    continue;
+                }
+                const value = settings[j].getAttribute("value");
+                if (!value) {
+                    diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no 'value' property.", vscode.DiagnosticSeverity.Error));
+                    continue;
+                }
+                profileElements.set(id, setting);
+                profileSettings.set(id, value);
+                lastElement = setting;
+            }
+            break;
+        }
+    }
+    if (!profileElements.size) {
+        diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)), "No valid settings found in the profile."));
+        return { settingsVersion: settingsVersion, diagnostics: diagnostics };
+    }
+    const supportedProfileSettings = getSupportedProfileSettings(Number(settingsVersion));
+    for (const setting of supportedProfileSettings.values()) {
+        const element = profileElements.get(setting.id);
+        const value = profileSettings.get(setting.id);
+        if (!element || !value) {
+            setting.value = FormatterConverter.profile2WebViewConvert(setting.id, getDefaultValue(setting.id))!;
+            continue;
+        }
+        const webViewValue: string | undefined = FormatterConverter.profile2WebViewConvert(setting.id, value);
+        if (!webViewValue) {
+            const elementContent = new XMLSerializer().serializeToString(element);
+            const elementRange = new vscode.Range(new vscode.Position(element.lineNumber - 1, element.columnNumber - 1), new vscode.Position(element.lineNumber - 1, element.columnNumber - 1 + elementContent.length));
+            diagnostics.push(new vscode.Diagnostic(elementRange, `Invalid value in id: "${setting.id}", "${value}" is not supported.`, vscode.DiagnosticSeverity.Error));
+            profileSettings.delete(setting.id);
+            setting.value = FormatterConverter.profile2WebViewConvert(setting.id, getDefaultValue(setting.id))!;
+            continue;
+        }
+        setting.value = webViewValue;
+    }
+    return {
+        profileElements: profileElements,
+        profileSettings: profileSettings,
+        lastElement: lastElement,
+        supportedProfileSettings: supportedProfileSettings,
+        settingsVersion: settingsVersion,
+        diagnostics: diagnostics
+    }
 }

--- a/src/formatter-settings/utils.ts
+++ b/src/formatter-settings/utils.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as fse from "fs-extra";
+import * as path from "path";
+import * as vscode from "vscode";
+import { instrumentOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
+
+export async function getProfilePath(formatterUrl: string): Promise<string> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders?.length && !path.isAbsolute(formatterUrl)) {
+        for (const workspaceFolder of workspaceFolders) {
+            const filePath = path.resolve(workspaceFolder.uri.fsPath, formatterUrl);
+            if (await fse.pathExists(filePath)) {
+                return filePath;
+            }
+        }
+    }
+    return path.resolve(formatterUrl);
+}
+
+export async function getVSCodeSetting(setting: string, defaultValue: any): Promise<any> {
+    return await instrumentOperation("formatter.getSetting", async (operationId: string) => {
+        const config = vscode.workspace.getConfiguration(undefined, { languageId: "java" });
+        let result = config.get<any>(setting);
+        if (result === undefined) {
+            result = vscode.workspace.getConfiguration().get<any>(setting);
+        }
+        if (result === undefined) {
+            sendInfo(operationId, { notFoundSetting: setting });
+            return defaultValue;
+        }
+        return result;
+    })();
+}
+
+export function isRemote(path: string): boolean {
+    return path !== null && path.startsWith("http:/") || path.startsWith("https:/");
+}
+
+export async function getTargetProfilePath(context: vscode.ExtensionContext, fileName?: string): Promise<string> {
+    const targetFileName = fileName || "java-formatter.xml";
+    let profilePath: string;
+    const workspaceFolder = vscode.workspace.workspaceFolders;
+    if (workspaceFolder?.length) {
+        profilePath = path.posix.join(workspaceFolder[0].uri.fsPath, ".vscode", targetFileName);
+    } else {
+        const folder: string = context.globalStorageUri.fsPath;
+        await fse.ensureDir(folder);
+        profilePath = path.posix.join(folder, targetFileName);
+    }
+    // bug: https://github.com/redhat-developer/vscode-java/issues/1944, only the profiles in posix path can be monitored when changes, so we use posix path for default profile creation temporarily.
+    const relativePath = toPosixPath(path.join(".vscode", targetFileName));
+    profilePath = toPosixPath(profilePath);
+    await vscode.workspace.getConfiguration("java").update("format.settings.url", (workspaceFolder?.length ? relativePath : profilePath), !(workspaceFolder?.length));
+    return profilePath;
+}
+
+function toPosixPath(inputPath: string): string {
+    return inputPath.split(path.win32.sep).join(path.posix.sep);
+}

--- a/src/formatter-settings/utils.ts
+++ b/src/formatter-settings/utils.ts
@@ -4,9 +4,6 @@
 import * as fse from "fs-extra";
 import * as path from "path";
 import * as vscode from "vscode";
-import * as http from "http";
-import * as https from "https";
-import * as url from "url";
 import axios from 'axios';
 import { instrumentOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { DOMAttr, DOMElement, ProfileContent } from "./types";

--- a/src/formatter-settings/utils.ts
+++ b/src/formatter-settings/utils.ts
@@ -94,13 +94,15 @@ export function parseProfile(document: vscode.TextDocument): ProfileContent {
                 const settingContent: string = new XMLSerializer().serializeToString(setting);
                 const id = setting.getAttribute("id");
                 if (!id) {
-                    diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no 'id' property.", vscode.DiagnosticSeverity.Error));
+                    diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no valid 'id' property.", vscode.DiagnosticSeverity.Error));
                     continue;
                 }
                 const value = settings[j].getAttribute("value");
                 if (!value) {
-                    diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no 'value' property.", vscode.DiagnosticSeverity.Error));
-                    continue;
+                    diagnostics.push(new vscode.Diagnostic(new vscode.Range(new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1), new vscode.Position(setting.lineNumber - 1, setting.columnNumber - 1 + settingContent.length)), "The setting has no valid 'value' property.", vscode.DiagnosticSeverity.Error));
+                    if (value === null) {
+                        continue;
+                    }
                 }
                 profileElements.set(id, setting);
                 profileSettings.set(id, value);
@@ -117,12 +119,12 @@ export function parseProfile(document: vscode.TextDocument): ProfileContent {
     for (const setting of supportedProfileSettings.values()) {
         const element = profileElements.get(setting.id);
         const value = profileSettings.get(setting.id);
-        if (!element || !value) {
+        if (!element || value === undefined)  {
             setting.value = FormatterConverter.profile2WebViewConvert(setting.id, getDefaultValue(setting.id))!;
             continue;
         }
         const webViewValue: string | undefined = FormatterConverter.profile2WebViewConvert(setting.id, value);
-        if (!webViewValue) {
+        if (webViewValue === undefined) {
             const valueNode = element.getAttributeNode("value") as DOMAttr;
             if (!valueNode || !valueNode.nodeValue) {
                 continue;

--- a/src/formatter-settings/utils.ts
+++ b/src/formatter-settings/utils.ts
@@ -37,8 +37,9 @@ export function isRemote(path: string): boolean {
     return path !== null && path.startsWith("http:/") || path.startsWith("https:/");
 }
 
-export async function getTargetProfilePath(context: vscode.ExtensionContext, fileName?: string): Promise<string> {
-    const targetFileName = fileName || "java-formatter.xml";
+export async function addDefaultProfile(context: vscode.ExtensionContext): Promise<void> {
+    const defaultProfile: string = path.join(context.extensionPath, "webview-resources", "java-formatter.xml");
+    const targetFileName = "java-formatter.xml";
     let profilePath: string;
     const workspaceFolder = vscode.workspace.workspaceFolders;
     if (workspaceFolder?.length) {
@@ -51,8 +52,9 @@ export async function getTargetProfilePath(context: vscode.ExtensionContext, fil
     // bug: https://github.com/redhat-developer/vscode-java/issues/1944, only the profiles in posix path can be monitored when changes, so we use posix path for default profile creation temporarily.
     const relativePath = toPosixPath(path.join(".vscode", targetFileName));
     profilePath = toPosixPath(profilePath);
+    await fse.copy(defaultProfile, profilePath);
     await vscode.workspace.getConfiguration("java").update("format.settings.url", (workspaceFolder?.length ? relativePath : profilePath), !(workspaceFolder?.length));
-    return profilePath;
+    vscode.commands.executeCommand("vscode.openWith", vscode.Uri.file(profilePath), "java.formatterSettingsEditor");
 }
 
 function toPosixPath(inputPath: string): string {

--- a/src/formatter-settings/utils.ts
+++ b/src/formatter-settings/utils.ts
@@ -41,9 +41,9 @@ export async function addDefaultProfile(context: vscode.ExtensionContext): Promi
     const defaultProfile: string = path.join(context.extensionPath, "webview-resources", "java-formatter.xml");
     const targetFileName = "java-formatter.xml";
     let profilePath: string;
-    const workspaceFolder = vscode.workspace.workspaceFolders;
-    if (workspaceFolder?.length) {
-        profilePath = path.posix.join(workspaceFolder[0].uri.fsPath, ".vscode", targetFileName);
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders?.length) {
+        profilePath = path.posix.join(workspaceFolders[0].uri.fsPath, ".vscode", targetFileName);
     } else {
         const folder: string = context.globalStorageUri.fsPath;
         await fse.ensureDir(folder);
@@ -53,7 +53,7 @@ export async function addDefaultProfile(context: vscode.ExtensionContext): Promi
     const relativePath = toPosixPath(path.join(".vscode", targetFileName));
     profilePath = toPosixPath(profilePath);
     await fse.copy(defaultProfile, profilePath);
-    await vscode.workspace.getConfiguration("java").update("format.settings.url", (workspaceFolder?.length ? relativePath : profilePath), !(workspaceFolder?.length));
+    await vscode.workspace.getConfiguration("java").update("format.settings.url", (workspaceFolders?.length ? relativePath : profilePath), !(workspaceFolders?.length));
     vscode.commands.executeCommand("vscode.openWith", vscode.Uri.file(profilePath), "java.formatterSettingsEditor");
 }
 


### PR DESCRIPTION
This PR includes the following functionalities:
- Read settings from formatter profile and show them in the editor.
- Changes on the editor will take effect on the active profile.
- Push diagnostics to show the found errors in the current profile.
- Support Read-Only Mode in remote profile