### PR TITLE
fix: "formatterExample" in telemetry is regarded as measure

### DIFF
--- a/src/formatter-settings/FormatterConstants.ts
+++ b/src/formatter-settings/FormatterConstants.ts
@@ -279,6 +279,33 @@ export namespace Example {
                 return "";
         }
     }
+
+    export function getExampleTitle(example: ExampleKind): string {
+        switch (example) {
+            case ExampleKind.INDENTATION_EXAMPLE:
+                return "Indentation";
+            case ExampleKind.BLANKLINE_EXAMPLE:
+                return "Blank line";
+            case ExampleKind.COMMENT_EXAMPLE:
+                return "Comment";
+            case ExampleKind.INSERTLINE_EXAMPLE:
+                return "Insert line";
+            case ExampleKind.BRACED_CODE_TYPE_EXAMPLE:
+                return "Braced type";
+            case ExampleKind.BRACED_CODE_RECORD_EXAMPLE:
+                return "Braced record";
+            case ExampleKind.BRACED_CODE_ENUM_EXAMPLE:
+                return "Braced enum";
+            case ExampleKind.ANNOTATION_AND_ANONYMOUS_EXAMPLE:
+                return "Annotation and anonymous";
+            case ExampleKind.WHITESPACE_EXAMPLE:
+                return "whitespace";
+            case ExampleKind.WRAPPING_EXAMPLE:
+                return "wrapping";
+            default:
+                return "";
+        }
+    }
 }
 
 const supportedVSCodeSettings: Map<string, JavaFormatterSetting> = new Map<string, JavaFormatterSetting>([

--- a/src/formatter-settings/FormatterConstants.ts
+++ b/src/formatter-settings/FormatterConstants.ts
@@ -279,33 +279,6 @@ export namespace Example {
                 return "";
         }
     }
-
-    export function getExampleTitle(example: ExampleKind): string {
-        switch (example) {
-            case ExampleKind.INDENTATION_EXAMPLE:
-                return "Indentation";
-            case ExampleKind.BLANKLINE_EXAMPLE:
-                return "Blank line";
-            case ExampleKind.COMMENT_EXAMPLE:
-                return "Comment";
-            case ExampleKind.INSERTLINE_EXAMPLE:
-                return "Insert line";
-            case ExampleKind.BRACED_CODE_TYPE_EXAMPLE:
-                return "Braced type";
-            case ExampleKind.BRACED_CODE_RECORD_EXAMPLE:
-                return "Braced record";
-            case ExampleKind.BRACED_CODE_ENUM_EXAMPLE:
-                return "Braced enum";
-            case ExampleKind.ANNOTATION_AND_ANONYMOUS_EXAMPLE:
-                return "Annotation and anonymous";
-            case ExampleKind.WHITESPACE_EXAMPLE:
-                return "whitespace";
-            case ExampleKind.WRAPPING_EXAMPLE:
-                return "wrapping";
-            default:
-                return "";
-        }
-    }
 }
 
 const supportedVSCodeSettings: Map<string, JavaFormatterSetting> = new Map<string, JavaFormatterSetting>([

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -98,7 +98,7 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
                     break;
                 case "onWillChangeExampleKind":
                     if (this.exampleKind !== e.exampleKind) {
-                        sendInfo("", { formatterExample: Example.getExampleTitle(e.exampleKind) });
+                        sendInfo("", { formatterExample: e.exampleKind });
                         this.exampleKind = e.exampleKind;
                         this.format();
                     }

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -97,9 +97,11 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
                     }
                     break;
                 case "onWillChangeExampleKind":
-                    sendInfo("", { formatterExample: e.exampleKind });
-                    this.exampleKind = e.exampleKind;
-                    this.format();
+                    if (this.exampleKind !== e.exampleKind) {
+                        sendInfo("", { formatterExample: Example.getExampleTitle(e.exampleKind) });
+                        this.exampleKind = e.exampleKind;
+                        this.format();
+                    }
                     break;
                 case "onWillChangeSetting":
                     const settingValue: string | undefined = FormatterConverter.webView2ProfileConvert(e.id, e.value.toString());

--- a/src/formatter-settings/types.ts
+++ b/src/formatter-settings/types.ts
@@ -32,16 +32,16 @@ export enum Category {
 }
 
 export enum ExampleKind {
-    INDENTATION_EXAMPLE,
-    BLANKLINE_EXAMPLE,
-    COMMENT_EXAMPLE,
-    INSERTLINE_EXAMPLE,
-    BRACED_CODE_TYPE_EXAMPLE,
-    BRACED_CODE_RECORD_EXAMPLE,
-    BRACED_CODE_ENUM_EXAMPLE,
-    ANNOTATION_AND_ANONYMOUS_EXAMPLE,
-    WHITESPACE_EXAMPLE,
-    WRAPPING_EXAMPLE,
+    INDENTATION_EXAMPLE = "Indentation",
+    BLANKLINE_EXAMPLE = "Blank line",
+    COMMENT_EXAMPLE = "Comment",
+    INSERTLINE_EXAMPLE = "Insert Line",
+    BRACED_CODE_TYPE_EXAMPLE = "Braced type",
+    BRACED_CODE_RECORD_EXAMPLE = "Braced record",
+    BRACED_CODE_ENUM_EXAMPLE = "Braced enum",
+    ANNOTATION_AND_ANONYMOUS_EXAMPLE = "Annotation and anonymous",
+    WHITESPACE_EXAMPLE = "Whitespace",
+    WRAPPING_EXAMPLE = "Wrapping",
 }
 
 // two extra properties from xmldom package, see https://www.npmjs.com/package/xmldom


### PR DESCRIPTION
Currently the value of `formatterExample` is number, so it was regarded as measure. Here to fix it, and send info only when example changes.