### PR TITLE
add more categories for better visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   ],
   "categories": [
     "Programming Languages",
+    "Linters",
+    "Debuggers",
+    "Formatters",
     "Extension Packs"
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "Linters",
     "Debuggers",
     "Formatters",
+    "Snippets",
     "Extension Packs"
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "spring"
   ],
   "categories": [
+    "Programming Languages",
     "Extension Packs"
   ],
   "repository": {


### PR DESCRIPTION
Nick found Java Ext Pack is missing with below filtering condition, generated by VS Code's native getting started walkthrough.

![image](https://user-images.githubusercontent.com/2351748/121653336-2c95fc00-cacf-11eb-9235-0192ad19ee9e.png)
