### PR TITLE
extract global state keys

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { initialize as initCommands } from "./commands";
 import { initialize as initRecommendations } from "./recommendation";
 import { showReleaseNotesOnStart, HelpViewType } from "./misc";
 import { initialize as initExp } from "./exp";
-import { KEY_SHOW_WHEN_USING_JAVA, OverviewViewSerializer } from "./overview";
+import { OverviewViewSerializer } from "./overview";
 import { JavaRuntimeViewSerializer, validateJavaRuntime } from "./java-runtime";
 import { scheduleAction } from "./utils/scheduler";
 import { showWelcomeWebview, WelcomeViewSerializer } from "./welcome";
@@ -18,6 +18,7 @@ import { ClassPathConfigurationViewSerializer } from "./classpath/classpathConfi
 import { initFormatterSettingsEditorProvider } from "./formatter-settings";
 import { initRemoteProfileProvider } from "./formatter-settings/RemoteProfileProvider";
 import { CodeActionProvider } from "./providers/CodeActionProvider";
+import { KEY_SHOW_WHEN_USING_JAVA } from "./utils/globalState";
 
 export async function activate(context: vscode.ExtensionContext) {
   syncState(context);

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { RELEASE_NOTE_PRESENTATION_HISTORY } from "../utils/globalState";
 import * as vscode from "vscode";
 import { getReleaseNotesEntries, findLatestReleaseNotes, timeToString, getExtensionVersion } from "../utils";
 
@@ -12,7 +13,6 @@ export enum HelpViewType {
 }
 
 type ReleaseNotesPresentationHistoryEntry = { version: string, timeStamp: string };
-const RELEASE_NOTE_PRESENTATION_HISTORY = "releaseNotesPresentationHistory";
 
 export async function showReleaseNotesOnStart(context: vscode.ExtensionContext) {
   const entries = await getReleaseNotesEntries(context);

--- a/src/overview/index.ts
+++ b/src/overview/index.ts
@@ -2,16 +2,12 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-
 import * as path from "path";
-
 import { instrumentOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
-import { getExtensionContext } from "../utils";
-import { loadTextFromFile } from "../utils";
+import { getExtensionContext, loadTextFromFile } from "../utils";
+import { KEY_OVERVIEW_LAST_SHOW_TIME, KEY_SHOW_WHEN_USING_JAVA } from "../utils/globalState";
 
 let overviewView: vscode.WebviewPanel | undefined;
-export const KEY_SHOW_WHEN_USING_JAVA = "showWhenUsingJava";
-const KEY_OVERVIEW_LAST_SHOW_TIME = "overviewLastShowTime";
 
 const toggleOverviewVisibilityOperation = instrumentOperation("toggleOverviewVisibility", (operationId: string, context: vscode.ExtensionContext, visibility: boolean) => {
   sendInfo(operationId, {

--- a/src/recommendation/handler.ts
+++ b/src/recommendation/handler.ts
@@ -2,12 +2,11 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { instrumentCommand } from "../utils";
 import { isExtensionInstalled, recommendExtension } from "../utils";
+import { KEY_RECOMMENDATION_TIMESTAMP_MAP } from "../utils/globalState";
 
-const KEY_RECOMMENDATION_TIMESTAMP_MAP = "recommendationTimeStampMap";
 
 let handler: (...args: any[]) => any;
 

--- a/src/utils/globalState.ts
+++ b/src/utils/globalState.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+export const KEY_RECOMMENDATION_TIMESTAMP_MAP = "recommendationTimeStampMap";
+
+// first view (shared)
+export const KEY_SHOW_WHEN_USING_JAVA = "showWhenUsingJava";
+// overview
+export const KEY_OVERVIEW_LAST_SHOW_TIME = "overviewLastShowTime";
+// welcome
+export const KEY_IS_WELCOME_PAGE_VIEWED = "isWelcomePageViewed";
+
+// release note (inactive)
+export const RELEASE_NOTE_PRESENTATION_HISTORY = "releaseNotesPresentationHistory";

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -5,9 +5,8 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { getExtensionContext, loadTextFromFile } from "../utils";
 import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
+import { KEY_SHOW_WHEN_USING_JAVA, KEY_IS_WELCOME_PAGE_VIEWED } from "../utils/globalState";
 
-const KEY_SHOW_WHEN_USING_JAVA = "showWhenUsingJava";
-const KEY_IS_WELCOME_PAGE_VIEWED = "isWelcomePageViewed";
 let welcomeView: vscode.WebviewPanel | undefined;
 
 export async function showWelcomeWebview(context: vscode.ExtensionContext, _operationId?: string, options?: any) {


### PR DESCRIPTION
Pre-requisite for walkthrough experiment. 

Java Help Center (welcome) will by default not be opened unless user check the checkbox. (SHOW_WHEN_USING_JAVA = false by default).

Meanwhile, for feature exposure, for those in control group (walkthrough not enabled), I'll pop up Java Help Center only once.