### PR TITLE
refine welcome view for getting started experiment

### DIFF
--- a/src/exp/TreatmentVariables.ts
+++ b/src/exp/TreatmentVariables.ts
@@ -4,4 +4,5 @@
 export class TreatmentVariables {
     public static readonly VSCodeConfig = 'vscode';
     public static readonly PresentWelcomePageByDefault = 'presentWelcomePageByDefault';
+    public static readonly JavaWalkthroughEnabled = "vscode.gettingStarted.overrideCategory.vscjava.vscode-java-pack.javaWelcome.when"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,17 +47,10 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
 
   const config = vscode.workspace.getConfiguration("java.help");
 
-  if (config.get("firstView") !== HelpViewType.None) {
-    let showWhenUsingJava = context.globalState.get(KEY_SHOW_WHEN_USING_JAVA);
-    if (showWhenUsingJava === undefined) {
-      showWhenUsingJava = vscode.env.uiKind === vscode.UIKind.Desktop;
-    }
-
-    if (showWhenUsingJava) {
-      scheduleAction("showFirstView", true).then(() => {
-        presentFirstView(context);
-      });
-    }
+  if (config.get("firstView") !== HelpViewType.None && context.globalState.get(KEY_SHOW_WHEN_USING_JAVA)) {
+    scheduleAction("showFirstView", true).then(() => {
+      presentFirstView(context);
+    });
   }
 
   if (config.get("showReleaseNotes")) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { initialize as initUtils } from "./utils";
 import { initialize as initCommands } from "./commands";
 import { initialize as initRecommendations } from "./recommendation";
 import { showReleaseNotesOnStart, HelpViewType } from "./misc";
-import { initialize as initExp } from "./exp";
+import { getExpService, initialize as initExp } from "./exp";
 import { OverviewViewSerializer } from "./overview";
 import { JavaRuntimeViewSerializer, validateJavaRuntime } from "./java-runtime";
 import { scheduleAction } from "./utils/scheduler";
@@ -18,7 +18,8 @@ import { ClassPathConfigurationViewSerializer } from "./classpath/classpathConfi
 import { initFormatterSettingsEditorProvider } from "./formatter-settings";
 import { initRemoteProfileProvider } from "./formatter-settings/RemoteProfileProvider";
 import { CodeActionProvider } from "./providers/CodeActionProvider";
-import { KEY_SHOW_WHEN_USING_JAVA } from "./utils/globalState";
+import { KEY_IS_WELCOME_PAGE_VIEWED, KEY_SHOW_WHEN_USING_JAVA } from "./utils/globalState";
+import { TreatmentVariables } from "./exp/TreatmentVariables";
 
 export async function activate(context: vscode.ExtensionContext) {
   syncState(context);
@@ -46,6 +47,13 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
   context.subscriptions.push(vscode.window.registerWebviewPanelSerializer("java.classpathConfiguration", new ClassPathConfigurationViewSerializer()));
 
   const config = vscode.workspace.getConfiguration("java.help");
+
+  // for control group where walkthrough is not enabled, present first view for once.
+  const walkthroughEnabled = getExpService().getTreatmentVariable<boolean>(TreatmentVariables.VSCodeConfig, TreatmentVariables.JavaWalkthroughEnabled);
+  if (walkthroughEnabled === false && !context.globalState.get(KEY_IS_WELCOME_PAGE_VIEWED)) {
+    presentFirstView(context);
+    context.globalState.update(KEY_IS_WELCOME_PAGE_VIEWED, true)
+  }
 
   if (config.get("firstView") !== HelpViewType.None && context.globalState.get(KEY_SHOW_WHEN_USING_JAVA)) {
     scheduleAction("showFirstView", true).then(() => {

--- a/src/welcome/assets/components/GetStartedPage.tsx
+++ b/src/welcome/assets/components/GetStartedPage.tsx
@@ -12,7 +12,8 @@ import TourPage from "./TourPage";
 
 export class GetStartedPage extends React.Component<{
     showWhenUsingJava: boolean,
-    firstTimeRun: boolean
+    firstTimeRun: boolean,
+    walkthrough?: boolean
 }> {
 
     render() {
@@ -25,7 +26,7 @@ export class GetStartedPage extends React.Component<{
     }
 
     renderWelcomePage() {
-        const {showWhenUsingJava} = this.props;
+        const {showWhenUsingJava, walkthrough} = this.props;
         return (
             <Container fluid className="root">
                 <Row className="mb-4">
@@ -35,7 +36,7 @@ export class GetStartedPage extends React.Component<{
                 </Row>
                 <Row className="mb-4">
                     <Col>
-                        <QuickActionPanel />
+                        <QuickActionPanel walkthrough={walkthrough}/>
                     </Col>
                 </Row>
                 <Row className="mb-4">

--- a/src/welcome/assets/components/QuickActionPanel.tsx
+++ b/src/welcome/assets/components/QuickActionPanel.tsx
@@ -6,7 +6,9 @@ import { ListGroup } from "react-bootstrap";
 import { encodeCommandUriWithTelemetry, supportedByNavigator } from "../../../utils/webview";
 import { WEBVIEW_ID } from "../utils";
 
-export default class QuickActionPanel extends React.Component {
+export default class QuickActionPanel extends React.Component<{
+    walkthrough?: boolean
+}, {}> {
     render() {
         const newProjectElement = <span>
             {"Create a "}
@@ -20,13 +22,17 @@ export default class QuickActionPanel extends React.Component {
             {"Take a "}
             <span className="highlight">{"Tour"}</span>
         </span>;
-        const actions = [
+        const actions: any[] = [
             { name: "Create a New Project", command: "java.project.create", element: newProjectElement },
             { name: "Open an Existing Project", command: "workbench.action.files.openFolder", os: "win", element: existingProjectElement },
             { name: "Open an Existing Project", command: "workbench.action.files.openFolder", os: "linux", element: existingProjectElement },
             { name: "Open an Existing Project", command: "workbench.action.files.openFileFolder", os: "mac", element: existingProjectElement },
-            { name: "Take a Tour", command: "java.welcome", args: [{ firstTimeRun: true }], element: tourElement }
         ];
+        // EXP: walkthrough v.s. previous feature tour
+        actions.push(this.props.walkthrough ?
+            { name: "Take a Tour", command: "workbench.action.openWalkthrough", args: ["vscjava.vscode-java-pack#javaWelcome"], element: tourElement } :
+            { name: "Take a Tour", command: "java.welcome", args: [{ firstTimeRun: true }], element: tourElement }
+        );
         const actionItems = actions.filter(action => !action.os || supportedByNavigator(action.os)).map(action => (
             <ListGroup.Item
                 action

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -6,6 +6,8 @@ import * as path from "path";
 import { getExtensionContext, loadTextFromFile } from "../utils";
 import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { KEY_SHOW_WHEN_USING_JAVA, KEY_IS_WELCOME_PAGE_VIEWED } from "../utils/globalState";
+import { getExpService } from "../exp";
+import { TreatmentVariables } from "../exp/TreatmentVariables";
 
 let welcomeView: vscode.WebviewPanel | undefined;
 
@@ -86,22 +88,26 @@ const setFirstTimeRun = (context: vscode.ExtensionContext, firstTimeRun: boolean
 };
 
 const fetchInitProps = (context: vscode.ExtensionContext) => {
+    const walkthrough = getExpService().getTreatmentVariable<boolean>(TreatmentVariables.VSCodeConfig, TreatmentVariables.JavaWalkthroughEnabled);
     welcomeView?.webview.postMessage({
         command: "onDidFetchInitProps",
         props: {
             showWhenUsingJava: context.globalState.get(KEY_SHOW_WHEN_USING_JAVA),
-            firstTimeRun: context.globalState.get(KEY_IS_WELCOME_PAGE_VIEWED) !== true
+            firstTimeRun: context.globalState.get(KEY_IS_WELCOME_PAGE_VIEWED) !== true,
+            walkthrough
         }
     });
     setFirstTimeRun(context, false);
 };
 
 const showTourPage = (context: vscode.ExtensionContext) => {
+    const walkthrough = getExpService().getTreatmentVariable<boolean>(TreatmentVariables.VSCodeConfig, TreatmentVariables.JavaWalkthroughEnabled);
     welcomeView?.webview.postMessage({
         command: "onDidFetchInitProps",
         props: {
             showWhenUsingJava: context.globalState.get(KEY_SHOW_WHEN_USING_JAVA),
-            firstTimeRun: true
+            firstTimeRun: true,
+            walkthrough
         }
     });
     setFirstTimeRun(context, false);


### PR DESCRIPTION
Change:
- For all users, first view will not show by default.

About EXP:
use `vscode.gettingStarted.overrideCategory.vscjava.vscode-java-pack.javaWelcome.when` as feature gate. @digitarald please use the same name when you set up experiment later.

- Treatment group
  - no page will be open by vscode-java-pack extension.
  - walkthrough is expected to show after installation 
- Control group
  - we will show the "welcome webbiew" only **once** when extension is activated.
  - walkthough not visible, because by default it's disabled by `when: false`.



 