### PR TITLE
continue #700: support local overridden by settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { initRemoteProfileProvider } from "./formatter-settings/RemoteProfilePro
 import { CodeActionProvider } from "./providers/CodeActionProvider";
 import { KEY_IS_WELCOME_PAGE_VIEWED, KEY_SHOW_WHEN_USING_JAVA } from "./utils/globalState";
 import { TreatmentVariables } from "./exp/TreatmentVariables";
+import { isWalkthroughEnabled } from "./utils/walkthrough";
 
 export async function activate(context: vscode.ExtensionContext) {
   syncState(context);
@@ -36,7 +37,7 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
   initCommands(context);
   initRecommendations(context);
 
-  context.subscriptions.push(vscode.languages.registerCodeActionsProvider({scheme: "file", language: "java", pattern: "**/*.java"}, new CodeActionProvider()));
+  context.subscriptions.push(vscode.languages.registerCodeActionsProvider({ scheme: "file", language: "java", pattern: "**/*.java" }, new CodeActionProvider()));
 
   // webview serializers to restore pages
   context.subscriptions.push(vscode.window.registerWebviewPanelSerializer("java.extGuide", new JavaExtGuideViewSerializer()));
@@ -49,7 +50,7 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
   const config = vscode.workspace.getConfiguration("java.help");
 
   // for control group where walkthrough is not enabled, present first view for once.
-  const walkthroughEnabled = getExpService().getTreatmentVariable<boolean>(TreatmentVariables.VSCodeConfig, TreatmentVariables.JavaWalkthroughEnabled);
+  const walkthroughEnabled = isWalkthroughEnabled();
   if (walkthroughEnabled === false && !context.globalState.get(KEY_IS_WELCOME_PAGE_VIEWED)) {
     presentFirstView(context);
     context.globalState.update(KEY_IS_WELCOME_PAGE_VIEWED, true)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { initialize as initUtils } from "./utils";
 import { initialize as initCommands } from "./commands";
 import { initialize as initRecommendations } from "./recommendation";
 import { showReleaseNotesOnStart, HelpViewType } from "./misc";
-import { getExpService, initialize as initExp } from "./exp";
+import { initialize as initExp } from "./exp";
 import { OverviewViewSerializer } from "./overview";
 import { JavaRuntimeViewSerializer, validateJavaRuntime } from "./java-runtime";
 import { scheduleAction } from "./utils/scheduler";
@@ -19,7 +19,6 @@ import { initFormatterSettingsEditorProvider } from "./formatter-settings";
 import { initRemoteProfileProvider } from "./formatter-settings/RemoteProfileProvider";
 import { CodeActionProvider } from "./providers/CodeActionProvider";
 import { KEY_IS_WELCOME_PAGE_VIEWED, KEY_SHOW_WHEN_USING_JAVA } from "./utils/globalState";
-import { TreatmentVariables } from "./exp/TreatmentVariables";
 import { isWalkthroughEnabled } from "./utils/walkthrough";
 
 export async function activate(context: vscode.ExtensionContext) {

--- a/src/utils/walkthrough.ts
+++ b/src/utils/walkthrough.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { workspace } from "vscode"; 
+import { getExpService } from "../exp";
+import { TreatmentVariables } from "../exp/TreatmentVariables";
+
+export function isWalkthroughEnabled() {
+
+    const fromExp = getExpService().getTreatmentVariable<boolean>(TreatmentVariables.VSCodeConfig, TreatmentVariables.JavaWalkthroughEnabled);
+    // 	can be overridden by local settings "experiments.override.gettingStarted.overrideCategory.vscjava.vscode-java-pack#javaWelcome.when": "true"
+    const fromSettings = workspace.getConfiguration("experiments.override.gettingStarted.overrideCategory").get<string>("vscjava.vscode-java-pack#javaWelcome.when") === "true";
+
+    return fromExp || fromSettings;
+}

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -6,8 +6,7 @@ import * as path from "path";
 import { getExtensionContext, loadTextFromFile } from "../utils";
 import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import { KEY_SHOW_WHEN_USING_JAVA, KEY_IS_WELCOME_PAGE_VIEWED } from "../utils/globalState";
-import { getExpService } from "../exp";
-import { TreatmentVariables } from "../exp/TreatmentVariables";
+import { isWalkthroughEnabled } from "../utils/walkthrough";
 
 let welcomeView: vscode.WebviewPanel | undefined;
 
@@ -88,7 +87,7 @@ const setFirstTimeRun = (context: vscode.ExtensionContext, firstTimeRun: boolean
 };
 
 const fetchInitProps = (context: vscode.ExtensionContext) => {
-    const walkthrough = getExpService().getTreatmentVariable<boolean>(TreatmentVariables.VSCodeConfig, TreatmentVariables.JavaWalkthroughEnabled);
+    const walkthrough = isWalkthroughEnabled();
     welcomeView?.webview.postMessage({
         command: "onDidFetchInitProps",
         props: {
@@ -101,7 +100,7 @@ const fetchInitProps = (context: vscode.ExtensionContext) => {
 };
 
 const showTourPage = (context: vscode.ExtensionContext) => {
-    const walkthrough = getExpService().getTreatmentVariable<boolean>(TreatmentVariables.VSCodeConfig, TreatmentVariables.JavaWalkthroughEnabled);
+    const walkthrough = isWalkthroughEnabled();
     welcomeView?.webview.postMessage({
         command: "onDidFetchInitProps",
         props: {


### PR DESCRIPTION
Before EXP is created, we use local settings to override it. 

> "experiments.override.gettingStarted.overrideCategory.vscjava.vscode-java-pack#javaWelcome.when": "true",
