### PR TITLE
Normalize extension naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
       {
         "command": "java.extGuide",
         "category": "Java",
-        "title": "Extension Guide"
+        "title": "Extensions Guide"
       },
       {
         "command": "java.formatterSettings",

--- a/src/classpath/assets/features/classpathConfiguration/components/Exception.tsx
+++ b/src/classpath/assets/features/classpathConfiguration/components/Exception.tsx
@@ -26,14 +26,14 @@ const Exception = (): JSX.Element | null => {
     case ClasspathViewException.JavaExtensionNotInstalled:
       content = (
         <div>
-          <span>The required extension <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.openJavaLanguageSupportMarketPlace", "extension.open", ["redhat.java"])}>Language Support for Java(TM) by Red Hat</a> is not installed or it's disabled. Please <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.installJavaLanguageSupport", "workbench.extensions.installExtension", ["redhat.java"])}>install</a> it in Visual Studio Code and <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.reloadWebview", "workbench.action.webview.reloadWebviewAction")}>reload</a> the page after installation.</span>
+          <span>The required extension <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.openJavaLanguageSupportMarketPlace", "extension.open", ["redhat.java"])}>Language Support for Java™ by Red Hat</a> is not installed or it's disabled. Please <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.installJavaLanguageSupport", "workbench.extensions.installExtension", ["redhat.java"])}>install</a> it in Visual Studio Code and <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.reloadWebview", "workbench.action.webview.reloadWebviewAction")}>reload</a> the page after installation.</span>
         </div>
       );
       break;
     case ClasspathViewException.StaleJavaExtension:
       content = (
         <div>
-          <span>The version of required extension <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.openJavaLanguageSupportMarketPlace", "extension.open", ["redhat.java"])}>Language Support for Java(TM) by Red Hat</a> is too stale. Please <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.installJavaLanguageSupport", "workbench.extensions.installExtension", ["redhat.java"])}>update</a> it and <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.reloadWebview", "workbench.action.webview.reloadWebviewAction")}>reload</a> the page.</span>
+          <span>The version of required extension <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.openJavaLanguageSupportMarketPlace", "extension.open", ["redhat.java"])}>Language Support for Java™ by Red Hat</a> is too stale. Please <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.installJavaLanguageSupport", "workbench.extensions.installExtension", ["redhat.java"])}>update</a> it and <a href={encodeCommandUriWithTelemetry(WEBVIEW_ID, "classpath.reloadWebview", "workbench.action.webview.reloadWebviewAction")}>reload</a> the page.</span>
         </div>
       );
       break;

--- a/src/ext-guide/assets/index.html
+++ b/src/ext-guide/assets/index.html
@@ -4,14 +4,14 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'unsafe-inline'">
-  <title>Java Extension Guide</title>
+  <title>Java Extensions Guide</title>
 </head>
 
 <body>
   <div class="container mt-5 mb-5">
     <div class="row mb-3">
       <div class="col">
-        <h1 class="font-weight-light">Java Extension Guide</h1>
+        <h1 class="font-weight-light">Java Extensions Guide</h1>
         <h6 class="font-weight-light">Recommended extensions for Java development.</h5>
       </div>
     </div>

--- a/src/ext-guide/index.ts
+++ b/src/ext-guide/index.ts
@@ -14,7 +14,7 @@ export async function javaExtGuideCmdHandler(context: vscode.ExtensionContext, o
     return;
   }
 
-  javaExtGuideView = vscode.window.createWebviewPanel("java.extGuide", "Java Extension Guide", {
+  javaExtGuideView = vscode.window.createWebviewPanel("java.extGuide", "Java Extensions Guide", {
     viewColumn: vscode.ViewColumn.One,
   }, {
     enableScripts: true,

--- a/src/getting-started/assets/index.html
+++ b/src/getting-started/assets/index.html
@@ -319,11 +319,11 @@
                     </blockquote>
                     <h3 class="font-weight-light">Why do I see the JDK errors?</h3>
                     <p>
-                      <strong><code>JDK 11+</code> is required</strong> to run VS Code Java! You see this error because we failed to find one on your machine. The <a href="command:java.runtime">Configure Java Runtime</a> guide can help you understand how JDK path is searched and provides download links if you need to install one.
+                      <strong><code>JDK 11+</code> is required</strong> to run the Java language support (redhat.java) extension! You see this error because we failed to find one on your machine. The <a href="command:java.runtime">Configure Java Runtime</a> guide can help you understand how JDK path is searched and provides download links if you need to install one.
                     </p>
                     <h3 class="font-weight-light">Can I run my Java 8 project with JDK 1.8?</h3>
                     <p>
-                      Yes. The JDK 11 requirement is just for running the VS Code Java extension itself. You can still configure a different runtime <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-project%23_jdk-for-projects%22">JDK for your project</a> via the user setting <a href="command:workbench.action.openSettings?%22java.configuration.runtimes%22">"java.configuration.runtimes"</a>. The extension will pick a matching JDK to compile/run your project according to the compiler version specified by the project build file.
+                      Yes. The JDK 11 requirement is just for running the Java language support (redhat.java) extension itself. You can still configure a different runtime <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-project%23_jdk-for-projects%22">JDK for your project</a> via the user setting <a href="command:workbench.action.openSettings?%22java.configuration.runtimes%22">"java.configuration.runtimes"</a>. The extension will pick a matching JDK to compile/run your project according to the compiler version specified by the project build file.
                       <pre>
 "java.configuration.runtimes": [
   {

--- a/src/getting-started/assets/index.html
+++ b/src/getting-started/assets/index.html
@@ -323,7 +323,7 @@
                     </p>
                     <h3 class="font-weight-light">Can I run my Java 8 project with JDK 1.8?</h3>
                     <p>
-                      Yes. JDK 11 requirement is just for running VS Code Java extension itself, you can still configure a different runtime <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-project%23_jdk-for-projects%22">JDK for your project</a> via user setting <a href="command:workbench.action.openSettings?%22java.configuration.runtimes%22">"java.configuration.runtimes"</a>. The extension will pick a mapping JDK to compile/run your project according to the compiler version specified by the project build file.
+                      Yes. The JDK 11 requirement is just for running the VS Code Java extension itself. You can still configure a different runtime <a href="command:java.helper.openUrl?%22https%3A%2F%2Fcode.visualstudio.com%2Fdocs%2Fjava%2Fjava-project%23_jdk-for-projects%22">JDK for your project</a> via the user setting <a href="command:workbench.action.openSettings?%22java.configuration.runtimes%22">"java.configuration.runtimes"</a>. The extension will pick a matching JDK to compile/run your project according to the compiler version specified by the project build file.
                       <pre>
 "java.configuration.runtimes": [
   {

--- a/src/java-runtime/index.ts
+++ b/src/java-runtime/index.ts
@@ -206,7 +206,7 @@ export async function findJavaRuntimeEntries(): Promise<{
     javaDotHome = runtime.java_home;
     const javaVersion = runtime.java_version;
     if (!javaVersion || javaVersion < 11) {
-      javaHomeError = `Java 11 or more recent is required to run the Java extension. Preferred JDK "${javaDotHome}" (version ${javaVersion}) doesn't meet the requirement. Please specify or install a recent JDK.`;
+      javaHomeError = `Java 11 or more recent is required by the Java language support (redhat.java) extension. Preferred JDK "${javaDotHome}" (version ${javaVersion}) doesn't meet the requirement. Please specify or install a recent JDK.`;
     }
   } catch (error) {
     javaHomeError = error.message;

--- a/src/java-runtime/utils/upstreamApi.ts
+++ b/src/java-runtime/utils/upstreamApi.ts
@@ -49,7 +49,7 @@ export async function resolveRequirements(): Promise<any> {
         }
 
         if (javaVersion < REQUIRED_JDK_VERSION) {
-            let message = `Java ${REQUIRED_JDK_VERSION} or more recent is required to run the Java extension.`;
+            let message = `Java ${REQUIRED_JDK_VERSION} or more recent is required by the Java language support (redhat.java) extension.`;
             if (javaHome) {
                 message += `(Current JDK: ${javaHome})`;
             }

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -47,8 +47,8 @@
         <div class="row mb-3">
           <div class="col">
             <h3 class="font-weight-light">Extensions</h3>
-            <div ext="redhat.java" displayName="Java Language Support by Red Hat">
-              <a href="#" title="Install the Java Language Support extension...">Install Java Language Support by Red Hat</a>
+            <div ext="redhat.java" displayName="Language Support for Java by Red Hat">
+              <a href="#" title="Install the Java language support extension...">Install Language Support for Java by Red Hat</a>
             </div>
             <div ext="vscjava.vscode-java-debug" displayName="Debugger for Java">
               <a href="#" title="Install the Debugger for Java extension...">Install Debugger for Java</a>

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -48,31 +48,31 @@
           <div class="col">
             <h3 class="font-weight-light">Extensions</h3>
             <div ext="redhat.java" displayName="Java Language Support by Red Hat">
-              <a href="#" title="Install Java Language Support extension...">Install Java Language Support by Red Hat</a>
+              <a href="#" title="Install the Java Language Support extension...">Install Java Language Support by Red Hat</a>
             </div>
             <div ext="vscjava.vscode-java-debug" displayName="Debugger for Java">
-              <a href="#" title="Install Debugger for Java extension...">Install Debugger for Java</a>
+              <a href="#" title="Install the Debugger for Java extension...">Install Debugger for Java</a>
             </div>
             <div ext="vscjava.vscode-java-test" displayName="Java Test Runner">
-              <a href="#" title="Install Java Test Runner extension...">Install Java Test Runner</a>
+              <a href="#" title="Install the Java Test Runner extension...">Install Java Test Runner</a>
             </div>
             <div ext="vscjava.vscode-maven" displayName="Maven for Java">
-              <a href="#" title="Install Maven for Java extension...">Install Maven for Java</a>
+              <a href="#" title="Install the Maven for Java extension...">Install Maven for Java</a>
             </div>
             <div ext="SonarSource.sonarlint-vscode" displayName="SonarLint">
               <a href="#" title="Install SonarLint...">Install SonarLint</a>
             </div>
             <div ext="adashen.vscode-tomcat" displayName="Tomcat for Java">
-              <a href="#" title="Install Tomcat for Java extension...">Install Tomcat for Java</a>
+              <a href="#" title="Install the Tomcat for Java extension...">Install Tomcat for Java</a>
             </div>
             <div ext="shengchen.vscode-checkstyle" displayName="Checkstyle for Java">
-              <a href="#" title="Install Checkstyle for Java extension...">Install Checkstyle for Java</a>
+              <a href="#" title="Install the Checkstyle for Java extension...">Install Checkstyle for Java</a>
             </div>
             <div ext="redhat.vscode-xml" displayName="XML">
               <a href="#" title="Schema validation when editing pom.xml...">Install XML extension</a>
             </div>
             <div ext="vscjava.vscode-java-dependency" displayName="Project Manager for Java">
-              <a href="#" title="Install Project Manager for Java extension...">Install Project Manager for Java</a>
+              <a href="#" title="Install the Project Manager for Java extension...">Install Project Manager for Java</a>
             </div>
           </div>
         </div>

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -171,8 +171,8 @@
                 <p class="mb-1">Configure Java Runtime</p>
                 <small>Setup JDKs for projects and VS Code Java.</small>
               </a>
-              <a href="javascript:void(0)" command="java.extGuide" class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2 p-2" title="Open Extension Guide">
-                <p class="mb-1">Extension Guide</p>
+              <a href="javascript:void(0)" command="java.extGuide" class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2 p-2" title="Open Extensions Guide">
+                <p class="mb-1">Extensions Guide</p>
                 <small>Recommended extensions for Java development.</small>
               </a>
               <a href="javascript:void(0)" command="workbench.action.openSettings" args='"java."' class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2 p-2" title="Open Java Settings">


### PR DESCRIPTION
- Tweak name of the Java Extensions Guide, so it doesn't mix up with either the redhat.java extension or the Java extension pack;  
- Minor phrasing corrections (mostly adding articles where needed);
- Normalize the name of the redhat.java extension

Fixes #729. Replaces #732.
