### PR TITLE
rename 'Getting Started' page to 'Beginner Tips'

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
       {
         "command": "java.gettingStarted",
         "category": "Java",
-        "title": "Getting Started"
+        "title": "Beginner Tips"
       },
       {
         "command": "java.extGuide",
@@ -248,7 +248,7 @@
           "enumDescriptions": [
             "Automatically pick the first experience view",
             "Present the Java Overview page",
-            "Present the Java Getting Started page",
+            "Present the Java Beginner Tips page",
             "Present the Java Help Center page",
             "Do not show any view"
           ],

--- a/src/getting-started/index.ts
+++ b/src/getting-started/index.ts
@@ -15,7 +15,7 @@ export async function javaGettingStartedCmdHandler(context: vscode.ExtensionCont
     return;
   }
 
-  javaGettingStartedView = vscode.window.createWebviewPanel("java.gettingStarted", "Java Getting Started", {
+  javaGettingStartedView = vscode.window.createWebviewPanel("java.gettingStarted", "Java Beginner Tips", {
     viewColumn: vscode.ViewColumn.One,
   }, {
     enableScripts: true,

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -152,8 +152,8 @@
           <div class="col">
             <h3 class="font-weight-light">Learn</h3>
             <div class="list-group">
-              <button command="java.gettingStarted" class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2 p-2" title="Open Java Getting Started View">
-                  <p class="mb-1">Java Getting Started</p>
+              <button command="java.gettingStarted" class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2 p-2" title="Open Java Beginner Tips View">
+                  <p class="mb-1">Java Beginner Tips</p>
                   <small>Learn 1 min <a href="javascript:void(0)" title="Quick Start" command="java.gettingStarted" args='"#quick-start-tab"'>Quick Start</a> tutorial, common shortcuts for <a href="javascript:void(0)" title="Code Editing" command="java.gettingStarted" args='"#code-editing-tab"'>Code Editing</a> and <a href="javascript:void(0)" title="Debugging" command="java.gettingStarted" args='"#debugging-tab"'>Debugging</a>, and <a href="javascript:void(0)" title="FAQ" command="java.gettingStarted" args='"#faq-tab"'>FAQ</a>.</small>
               </button>
               <button command="java.helper.openUrl" args='"https://code.visualstudio.com/docs/java/java-tutorial"' class="list-group-item list-group-item-action flex-column align-items-start btn btn-link mb-2 p-2" title="Open Java Tutorials">


### PR DESCRIPTION
See #809 
