### PR TITLE
Fix compile warning about `debug` in `follow-redirects`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,8 @@ module.exports = function (env, argv) {
     resolve: {
       modules: ['node_modules', path.resolve(__dirname, 'src')],
       mainFiles: ['index'],
-      extensions: ['.js', '.ts', '.json']
+      extensions: ['.js', '.ts', '.json'],
+      preferRelative: true
     },
     output: {
       filename: '[name].js',


### PR DESCRIPTION
fix 
```
WARNING in ./node_modules/follow-redirects/debug.js 7:14-30
Module not found: Error: Can't resolve 'debug' in 'C:\Users\yanzh\Work\vscode-java-pack\node_modules\follow-redirects'
Did you mean './debug'?
Requests that should resolve in the current directory need to start with './'.
```

It's a change in the webpack configuration, so I suggest a check from the page owners. @Eskibear @jdneo 