### PR TITLE
update tooling jdk validation mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,9 @@
       "dev": true
     },
     "jdk-utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.2.1.tgz",
-      "integrity": "sha512-5WH2CdGx4yZ0P7scm9UE04tq1n/LPI77aa/IJOTqoYfpUqlN+YlAAH/U1VdATgJQufN3xuZ3I798KUYjFmETCw=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.3.1.tgz",
+      "integrity": "sha512-0a7qkPdlXqltqgJOiXBjawFYfL1w0eRQ4vrjKVRkNgB0U8+P/J5ZMZS5LW/BtQwdM3mBUpodtI0nWklm4pmOSg=="
     },
     "jest-worker": {
       "version": "27.3.1",

--- a/package.json
+++ b/package.json
@@ -378,7 +378,7 @@
     "expand-tilde": "^2.0.2",
     "fs-extra": "^9.0.1",
     "highlight.js": "10.5.0",
-    "jdk-utils": "^0.2.1",
+    "jdk-utils": "^0.3.1",
     "jquery": "^3.5.1",
     "lodash": "^4.17.21",
     "minimatch": "^3.0.4",

--- a/src/java-runtime/index.ts
+++ b/src/java-runtime/index.ts
@@ -196,7 +196,7 @@ export async function validateJavaRuntime() {
   // * option b) use the same way to check java_home as vscode-java
   try {
     const runtime = await resolveRequirements();
-    if (runtime.java_version >=11 && runtime.java_home) {
+    if (runtime.tooling_jre_version >=11 && runtime.tooling_jre) {
       return true;
     }
   } catch (error) {
@@ -226,8 +226,8 @@ export async function findJavaRuntimeEntries(): Promise<{
   let javaHomeError;
   try {
     const runtime = await resolveRequirements();
-    javaDotHome = runtime.java_home;
-    const javaVersion = runtime.java_version;
+    javaDotHome = runtime.tooling_jre;
+    const javaVersion = runtime.tooling_jre_version;
     if (!javaVersion || javaVersion < 11) {
       javaHomeError = `Java 11 or more recent is required by the Java language support (redhat.java) extension. Preferred JDK "${javaDotHome}" (version ${javaVersion}) doesn't meet the requirement. Please specify or install a recent JDK.`;
     }

--- a/src/java-runtime/utils/upstreamApi.ts
+++ b/src/java-runtime/utils/upstreamApi.ts
@@ -1,33 +1,36 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-// based on https://github.com/redhat-developer/vscode-java/blob/fcbe9204638610ce773cedaef445f19032a785cb/src/requirements.ts
+// based on https://github.com/redhat-developer/vscode-java/blob/c4cdbed1190fc705c364179dab525645acf03898/src/requirements.ts
 
 import * as fse from "fs-extra";
+import { findRuntimes, getRuntime, getSources, IJavaRuntime, JAVAC_FILENAME, JAVA_FILENAME } from 'jdk-utils';
 import * as path from "path";
 import * as vscode from "vscode";
-import { env } from "vscode";
+import { env, workspace } from 'vscode';
 
 const expandHomeDir = require("expand-home-dir");
 const REQUIRED_JDK_VERSION = 11;
-import { findJavaHomes, getJavaVersion, JavaRuntime } from "./findJavaRuntime";
 
-
-const isWindows = process.platform.indexOf("win") === 0;
-const JAVAC_FILENAME = "javac" + (isWindows ? ".exe" : "");
-
-export async function resolveRequirements(): Promise<any> {
+export async function resolveRequirements(): Promise<{
+    tooling_jre: string | undefined;  // Used to launch Java extension.
+    tooling_jre_version: number;
+    java_home: string | undefined; // Used as default project JDK.
+    java_version: number;
+}> {
+    const javaExtPath: string | undefined = vscode.extensions.getExtension("redhat.java")?.extensionPath
+    let toolingJre: string | undefined = await findEmbeddedJRE(javaExtPath);
+    let toolingJreVersion: number = await getMajorVersion(toolingJre);
     return new Promise(async (resolve, reject) => {
         let source: string;
         let javaVersion: number = 0;
-        let javaHome = await checkJavaPreferences();
-        if (javaHome) {
-            // java.home explictly specified
+        let javaHome = checkJavaPreferences();
+        if (!toolingJre && javaHome) { // "java.home" setting is only used for the universal version.
             source = `java.home variable defined in ${env.appName} settings`;
-            javaHome = expandHomeDir(javaHome) as string;
+            javaHome = expandHomeDir(javaHome);
             if (!await fse.pathExists(javaHome)) {
                 invalidJavaHome(reject, `The ${source} points to a missing or inaccessible folder (${javaHome})`);
-            } else if (!await fse.pathExists(path.resolve(javaHome, "bin", JAVAC_FILENAME))) {
+            } else if (!await fse.pathExists(path.resolve(javaHome, 'bin', JAVAC_FILENAME))) {
                 let msg: string;
                 if (await fse.pathExists(path.resolve(javaHome, JAVAC_FILENAME))) {
                     msg = `'bin' should be removed from the ${source} (${javaHome})`;
@@ -36,36 +39,111 @@ export async function resolveRequirements(): Promise<any> {
                 }
                 invalidJavaHome(reject, msg);
             }
-            javaVersion = await getJavaVersion(javaHome);
+            javaVersion = await getMajorVersion(javaHome);
+            toolingJre = javaHome;
+            toolingJreVersion = javaVersion;
         } else {
-            // java.home not specified, search valid JDKs from env.JAVA_HOME, env.PATH, Registry(Window), Common directories
-            const javaRuntimes = await findJavaHomes();
-            const validJdks = javaRuntimes.filter(r => r.version >= REQUIRED_JDK_VERSION);
-            if (validJdks.length > 0) {
-                sortJdksBySource(validJdks);
-                javaHome = validJdks[0].home;
-                javaVersion = validJdks[0].version;
+            // java.home not specified, search valid JDKs from env.JAVA_HOME, env.PATH, SDKMAN, jEnv, jabba, Common directories
+            const javaRuntimes = await findRuntimes({checkJavac: true, withVersion: true, withTags: true});
+            if (!toolingJre) { // universal version
+                // as latest version as possible.
+                sortJdksByVersion(javaRuntimes);
+                const validJdks = javaRuntimes.filter(r => r.version && r.version.major >= REQUIRED_JDK_VERSION);
+                if (validJdks.length > 0) {
+                    sortJdksBySource(validJdks);
+                    javaHome = validJdks[0].homedir;
+                    javaVersion = validJdks[0].version?.major ?? 0;
+                    toolingJre = javaHome;
+                    toolingJreVersion = javaVersion;
+                }
+            } else { // pick a default project JDK/JRE
+                /**
+                 * For legacy users, we implicitly following the order below to
+                 * set a default project JDK during initialization:
+                 * java.home > env.JDK_HOME > env.JAVA_HOME > env.PATH
+                 *
+                 * We'll keep it for compatibility.
+                 */
+                if (javaHome && (await getRuntime(javaHome) !== undefined)) {
+                    const runtime = await getRuntime(javaHome, {withVersion: true});
+                    if (runtime) {
+                        javaHome = runtime.homedir;
+                        javaVersion = runtime.version?.major ?? 0;
+                    }
+                } else if (javaRuntimes.length) {
+                    sortJdksBySource(javaRuntimes);
+                    javaHome = javaRuntimes[0].homedir;
+                    javaVersion = javaRuntimes[0].version?.major ?? 0;
+                } else if (javaHome = (await findDefaultRuntimeFromSettings() ?? "")) {
+                    javaVersion = await getMajorVersion(javaHome);
+                } else {
+                    invalidJavaHome(reject, "Please download and install a JDK to compile your project. You can configure your projects with different JDKs by the setting ['java.configuration.runtimes'](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)");
+                }
             }
         }
 
-        if (javaVersion < REQUIRED_JDK_VERSION) {
-            let message = `Java ${REQUIRED_JDK_VERSION} or more recent is required by the Java language support (redhat.java) extension.`;
-            if (javaHome) {
-                message += `(Current JDK: ${javaHome})`;
-            }
-            invalidJavaHome(reject, message);
+        if (!toolingJre || toolingJreVersion < REQUIRED_JDK_VERSION) {
+            // For universal version, we still require users to install a qualified JDK to run Java extension.
+            invalidJavaHome(reject, `Java ${REQUIRED_JDK_VERSION} or more recent is required to run the Java extension. Please download and install a recent JDK. You can still compile your projects with older JDKs by configuring ['java.configuration.runtimes'](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)`);
         }
 
-        resolve({ java_home: javaHome, java_version: javaVersion });
+        resolve({
+            tooling_jre: toolingJre,  // Used to launch Java extension.
+            tooling_jre_version: toolingJreVersion,
+            java_home: javaHome, // Used as default project JDK.
+            java_version: javaVersion,
+        });
     });
 }
 
-function sortJdksBySource(jdks: JavaRuntime[]) {
-    const rankedJdks = jdks as Array<JavaRuntime & { rank: number }>;
-    const sources = ["env.JDK_HOME", "env.JAVA_HOME", "env.PATH"];
+async function findEmbeddedJRE(javaExtPath?: string): Promise<string | undefined> {
+    if (!javaExtPath) {
+        return undefined;
+    }
+    const jreHome = path.join(javaExtPath, "jre");
+    if (fse.existsSync(jreHome) && fse.statSync(jreHome).isDirectory()) {
+        const candidates = fse.readdirSync(jreHome);
+        for (const candidate of candidates) {
+            if (fse.existsSync(path.join(jreHome, candidate, "bin", JAVA_FILENAME))) {
+                return path.join(jreHome, candidate);
+            }
+        }
+    }
+
+    return;
+}
+
+async function findDefaultRuntimeFromSettings(): Promise<string | undefined> {
+    const runtimes = workspace.getConfiguration().get("java.configuration.runtimes");
+    if (Array.isArray(runtimes) && runtimes.length) {
+        let candidate: string | undefined;
+        for (const runtime of runtimes) {
+            if (!runtime || typeof runtime !== 'object' || !runtime.path) {
+                continue;
+            }
+
+            const jr = await getRuntime(runtime.path);
+            if (jr) {
+                candidate = jr.homedir;
+            }
+
+            if (runtime.default) {
+                break;
+            }
+        }
+
+        return candidate;
+    }
+
+    return undefined;
+}
+
+function sortJdksBySource(jdks: IJavaRuntime[]) {
+    const rankedJdks = jdks as Array<IJavaRuntime & { rank: number }>;
+    const sources = ["JDK_HOME", "JAVA_HOME", "PATH"];
     for (const [index, source] of sources.entries()) {
         for (const jdk of rankedJdks) {
-            if (jdk.rank === undefined && jdk.sources.includes(source)) {
+            if (jdk.rank === undefined && getSources(jdk).includes(source)) {
                 jdk.rank = index;
             }
         }
@@ -74,10 +152,26 @@ function sortJdksBySource(jdks: JavaRuntime[]) {
     rankedJdks.sort((a, b) => a.rank - b.rank);
 }
 
+/**
+ * Sort by major version in descend order.
+ */
+function sortJdksByVersion(jdks: IJavaRuntime[]) {
+    jdks.sort((a, b) => (b.version?.major ?? 0) - (a.version?.major ?? 0));
+}
+
+
 function checkJavaPreferences(){
-    return vscode.workspace.getConfiguration("java").get<string>("home");
+    return vscode.workspace.getConfiguration("java").get<string>("home") ?? "";
 }
 
 function invalidJavaHome(reject: any, reason: string) {
     reject(new Error(reason));
+}
+
+async function getMajorVersion(javaHome?: string): Promise<number> {
+    if (!javaHome) {
+        return 0;
+    }
+    const runtime = await getRuntime(javaHome, { withVersion: true });
+    return runtime?.version?.major || 0;
 }

--- a/src/java-runtime/utils/upstreamApi.ts
+++ b/src/java-runtime/utils/upstreamApi.ts
@@ -77,7 +77,13 @@ export async function resolveRequirements(): Promise<{
                 } else if (javaHome = (await findDefaultRuntimeFromSettings() ?? "")) {
                     javaVersion = await getMajorVersion(javaHome);
                 } else {
-                    invalidJavaHome(reject, "Please download and install a JDK to compile your project. You can configure your projects with different JDKs by the setting ['java.configuration.runtimes'](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)");
+                    /**
+                     * Originally it was:
+                     * invalidJavaHome(reject, "Please download and install a JDK to compile your project. You can configure your projects with different JDKs by the setting ['java.configuration.runtimes'](https://github.com/redhat-developer/vscode-java/wiki/JDK-Requirements#java.configuration.runtimes)");
+                     * 
+                     * here we focus on tooling jre, so we swallow the error.
+                     * 
+                     */
                 }
             }
         }


### PR DESCRIPTION
udpate `upstreamApi.ts` to align with changes in redhat.java extension.

The "configure java runtime" page pops up only when an invalid `java.home` is set for **generic** redhat.java extension. For platform-specific extension, tooling JDK is embedded, so we don't pop up any page.