### PR TITLE
update to adopt @vscode/extension-telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -324,6 +324,11 @@
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.25.tgz",
       "integrity": "sha512-uqPhTdADjwoCh5Ufbv0M6TZiiP2mqbfJVB4grhVx1k+YeP03LDMOHBWPsNwGKn4/0S5Mq9o1w1GeftvR031Gzg=="
     },
+    "@vscode/extension-telemetry": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.4.6.tgz",
+      "integrity": "sha512-bDXwHoNXIR1Rc8xdphJ4B3rWdzAGm+FUPk4mJl6/oyZmfEX+QdlDLxnCwlv/vxHU1p11ThHSB8kRhsWZ1CzOqw=="
+    },
     "@vscode/webview-ui-toolkit": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-0.8.2.tgz",
@@ -2505,25 +2510,18 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "vscode-extension-telemetry": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.4.tgz",
-      "integrity": "sha512-LzirNf2GnykXCAqqWrvj+snYqgkPVyjwM72tYOHgcZiG/ZRuNjmqlgvs+SomEJdmD8cutduitPmhoyIuzOrVfA=="
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "vscode-extension-telemetry-wrapper": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.11.0.tgz",
-      "integrity": "sha512-+Ep9D0rYzSwSr/KJTeUmbIa67ssQqhtN1ikypYgS9VfP8jFxNyASIabkXg0PXJfCzJovQCpBBtO05UUV6gP+6g==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.11.1.tgz",
+      "integrity": "sha512-O8yrlxQNJCfuNylJ1tGTICEGszoNyexw9ZAaZ5EskOPcCEua96/9q/Fn6Xif1suLwReMcVplGR043fnF0ZAoFA==",
       "requires": {
-        "uuid": "^3.4.0",
-        "vscode-extension-telemetry": "^0.4.4"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
+        "@vscode/extension-telemetry": "^0.4.6",
+        "uuid": "^3.4.0"
       }
     },
     "vscode-tas-client": {

--- a/package.json
+++ b/package.json
@@ -346,7 +346,7 @@
     "react-dom": "^16.14.0",
     "react-redux": "^7.2.6",
     "semver": "^5.7.1",
-    "vscode-extension-telemetry-wrapper": "^0.11.0",
+    "vscode-extension-telemetry-wrapper": "^0.11.1",
     "vscode-tas-client": "^0.1.27",
     "winreg-utf8": "^0.1.1"
   }


### PR DESCRIPTION
> This package has been moved from vscode-extension-telemetry to @vscode/extension-telemetry to better unify the packages vscode publishes.
> 
> Some bug fixes:
> 
> Remote name being wrongly reported
> Better cleaning of passwords and other possible credentials from telemetry.