### PR TITLE
Add Azul Zulu into other JDKs

### DIFF
--- a/src/install-jdk/assets/features/components/OtherJDKsPanel.tsx
+++ b/src/install-jdk/assets/features/components/OtherJDKsPanel.tsx
@@ -14,6 +14,7 @@ class OtherJDKsPanel extends React.Component {
   public render() {
     const jdkList = [
       { name: "Amazon Corretto", url: "https://aws.amazon.com/corretto" },
+      { name: "Azul Zulu", url: "https://www.azul.com/downloads/?package=jdk" },
       { name: "Eclipse Adoptium's Temurin", url: "https://adoptium.net/" },
       { name: "Microsoft Build of OpenJDK", url: "https://www.microsoft.com/openjdk" },
       { name: "Oracle Java SE", url: "https://www.oracle.com/java/technologies/javase-downloads.html" },


### PR DESCRIPTION
Zulu was there before, and was used in MSFT's related docker images. After MSFT shipped its own Openjdk distro, Zulu was replaced then.

@nickzhums  Please review. 

