### PR TITLE
update jdk-utils to cover asdf-vm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1393,9 +1393,9 @@
       "dev": true
     },
     "jdk-utils": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.4.2.tgz",
-      "integrity": "sha512-Xc9KTVXJ048A3EaCyBRAzLRNhDEZQq/awcZHCQCvV9lnYEFMrnLZh7ZzCnFiXLCXWN9JDm9A0BW8MfTbLthA3g=="
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.4.3.tgz",
+      "integrity": "sha512-6d4tEkaBfpbQy32TF8lt+CFYaaWicBQEekWO5HozSzSMY4Y2ufsdNhpUbza0r2cuGEzoScE1r8vd9wkuUgypAA=="
     },
     "jest-worker": {
       "version": "27.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2554,11 +2554,6 @@
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
     },
-    "winreg-utf8": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/winreg-utf8/-/winreg-utf8-0.1.1.tgz",
-      "integrity": "sha512-A4tBCO0bx3FCA/s8RowK40h3BQhKOWRFmsn6gYrXj6WjRAbOGnNJkTOpVmtA82UeGNMtpn3Wr0TWb742C1AS+g=="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
     "expand-tilde": "^2.0.2",
     "fs-extra": "^9.1.0",
     "highlight.js": "10.5.0",
-    "jdk-utils": "^0.4.2",
+    "jdk-utils": "^0.4.3",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",
     "minimatch": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -353,7 +353,6 @@
     "react-redux": "^7.2.6",
     "semver": "^5.7.1",
     "vscode-extension-telemetry-wrapper": "^0.12.0",
-    "vscode-tas-client": "^0.1.31",
-    "winreg-utf8": "^0.1.1"
+    "vscode-tas-client": "^0.1.31"
   }
 }


### PR DESCRIPTION


Install a JDK via asdf-vm, and run `npx jdk-utils@0.4.3`. It can be successfully detected.
```
  {
    homedir: '/home/yanzh/.asdf/installs/java/microsoft-17.35.1',
    isFromASDF: true,
    hasJavac: true,
    version: { java_version: '17', major: 17 }
  }
```