### PR TITLE
focusing on specific error in server logs

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -44,6 +44,8 @@ async function checkJavaExtActivated(_context: vscode.ExtensionContext): Promise
       if (mode === "Standard") {
          daemon.logWatcher.sendStartupMetadata("jdtls standard server ready");
 
+         daemon.logWatcher.stop(); // Only focus on errors occurred during startup.
+
          // watchdog
          if (await daemon.processWatcher.start()) {
             daemon.processWatcher.monitor();

--- a/src/daemon/serverLog/whitelist.ts
+++ b/src/daemon/serverLog/whitelist.ts
@@ -22,6 +22,7 @@ const MESSAGE_WHITELIST: string[] = [
     "Failed to detect project changes",
     "Failed to update qualified index.",
     "Failed to launch debuggee in terminal. Reason: java.util.concurrent.TimeoutException: timeout",
+    "Failed to save JDT index",
     "failed to send diagnostics",
     "FrameworkEvent ERROR",
     "Initialization failed",

--- a/src/daemon/serverLog/whitelist.ts
+++ b/src/daemon/serverLog/whitelist.ts
@@ -3,6 +3,7 @@
 
 const TAGS: string[] = [
     "buildship",
+    "m2e",
     "gradle",
     "maven",
     "bundle"

--- a/src/daemon/serverLog/whitelist.ts
+++ b/src/daemon/serverLog/whitelist.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+const TAGS: string[] = [
+    "buildship",
+    "gradle",
+    "maven",
+    "bundle"
+];
+
+const MESSAGE_WHITELIST: string[] = [
+    "Application error",
+    "BadLocationException",
+    "Could not load Gradle version information",
+    "Error computing hover",
+    "Error in calling delegate command handler",
+    "Error in JDT Core during AST creation",
+    "Error occurred while deleting",
+    "Error filtering index locations based on qualifier.",
+    "Failed to publish diagnostics for",
+    "Failed to detect project changes",
+    "Failed to update qualified index.",
+    "Failed to launch debuggee in terminal. Reason: java.util.concurrent.TimeoutException: timeout",
+    "failed to send diagnostics",
+    "FrameworkEvent ERROR",
+    "Initialization failed",
+    "Index out of bounds",
+    "JavaBuilder handling CoreException",
+    "Offset > length",
+    "Problems occurred when invoking code from plug-in: \"org.eclipse.jdt.ls.core\".",
+    "Problems occurred when invoking code from plug-in: \"org.eclipse.core.resources\".",
+    "Problems occurred when invoking code from plug-in: \"org.eclipse.jdt.core.manipulation\".",
+    "Problem resolving refactor code actions",
+    "Problem with folding range",
+    "Problem with codeComplete for",
+    "Synchronize Gradle projects with workspace failed due to an error connecting to the Gradle build.",
+    "Synchronize Gradle projects with workspace failed due to an error in the referenced Gradle build.",
+    "Unable to read JavaModelManager nonChainingJarsCache file",
+    "Workspace restored, but some problems occurred.",
+];
+
+export function redact(rawMessage: string): string {
+    const matchedMessage = MESSAGE_WHITELIST.find(msg => rawMessage.includes(msg));
+    if (matchedMessage) {
+        return matchedMessage;
+    } else {
+        const lower = rawMessage.toLocaleLowerCase();
+        const tags = TAGS.filter(tag => lower.includes(tag));
+        return tags.length > 0 ? `Tags:${tags.join(",")}` : "";
+    }
+}


### PR DESCRIPTION
1. add whitelist of error mssages. Only those on the list will be sent back. Otherwise only tags found in the message will be sent back.
2. After LS service is ready, stop listen to server log changes. So we focus only on startup stage.


Sample Error messages:
- "Error in calling delegate command handler"
- "tags:maven,bundle"
- ""