### PR TITLE
fix: Cannot read properties of undefined (reading 'startsWith')

### DIFF
--- a/src/daemon/clientLog/logWatcher.ts
+++ b/src/daemon/clientLog/logWatcher.ts
@@ -21,10 +21,10 @@ export class ClientLogWatcher {
         if (logs) {
             const info: any = {};
 
-            const jdkLog = logs.find(log => log.message.startsWith("Use the JDK from"));
+            const jdkLog = logs.find(log => log.message?.startsWith("Use the JDK from"));
             info.defaultProjectJdk = jdkLog?.message.replace("Use the JDK from '", "").replace("' as the initial default project JDK.", "");
 
-            const startupLog = logs.find(log => log.message.startsWith("Starting Java server with:") && log.message.endsWith("jdt_ws") /* limit to standard server */);
+            const startupLog = logs.find(log => log.message?.startsWith("Starting Java server with:") && log.message.endsWith("jdt_ws") /* limit to standard server */);
             if (startupLog) {
                 info.xmx = startupLog.message.match(/-Xmx[0-9kmgKMG]+/g)?.[0];
                 info.xms = startupLog.message.match(/-Xms[0-9kmgKMG]+/g)?.[0];
@@ -36,11 +36,11 @@ export class ClientLogWatcher {
             info.error = errorLog ? "true" : undefined;
 
             const missingJar = "Error opening zip file or JAR manifest missing"; // lombok especially
-            if (logs.find(log => log.message.startsWith(missingJar))) {
+            if (logs.find(log => log.message?.startsWith(missingJar))) {
                 info.error = missingJar;
             }
 
-            const crashLog = logs.find(log => log.message.startsWith("The Language Support for Java server crashed and will restart."));
+            const crashLog = logs.find(log => log.message?.startsWith("The Language Support for Java server crashed and will restart."));
             info.crash = crashLog ? "true" : undefined;
 
             sendInfo("", {


### PR DESCRIPTION
Fix issue found by @jdneo

```
stack trace: TypeError: Cannot read properties of undefined (reading 'startsWith')
at /home/codespace/.vscode-remote/extensions/vscjava.vscode-java-pack-0.22.3/out/extension.js:2:581113
at Array.find (<anonymous>)
at t.ClientLogWatcher.<anonymous> (/home/codespace/.vscode-remote/extensions/vscjava.vscode-java-pack-0.22.3/out/extension.js:2:581094)
at Generator.next (<anonymous>)
at a (/home/codespace/.vscode-remote/extensions/vscjava.vscode-java-pack-0.22.3/out/extension.js:2:580450)
```