### PR TITLE
can read client.log for empty workspace

### DIFF
--- a/src/daemon/clientLog/logWatcher.ts
+++ b/src/daemon/clientLog/logWatcher.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 import * as vscode from "vscode";
+import * as path from "path";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { LSDaemon } from "../daemon";
 
@@ -62,6 +63,13 @@ export class ClientLogWatcher {
     }
 
     private async readLatestLogFile() {
+        if (!this.javaExtensionRoot) {
+            try {
+                this.javaExtensionRoot = vscode.Uri.file(path.dirname(await vscode.commands.executeCommand("_java.workspace.path")));
+            } catch (error) {
+            }
+        }
+
         if (this.javaExtensionRoot) {
             const files = await vscode.workspace.fs.readDirectory(this.javaExtensionRoot);
             const logFiles = files.filter(elem => elem[0].startsWith("client.log")).sort((a, b) => compare_file(a[0], b[0]));

--- a/src/daemon/serverLog/logWatcher.ts
+++ b/src/daemon/serverLog/logWatcher.ts
@@ -29,6 +29,14 @@ export class LogWatcher {
      */
     public async start() {
         if (!this.serverLogUri) {
+            try {
+                const jdtWsPath: string = await vscode.commands.executeCommand("_java.workspace.path");
+                this.serverLogUri= vscode.Uri.file(path.join(jdtWsPath, ".metadata"));
+            } catch (error) {
+            }
+        }
+
+        if (!this.serverLogUri) {
             sendInfo("", { name: "no-server-log" });
             return;
         }


### PR DESCRIPTION
Now empty workspace can be identified, and metadata can be parsed from its client.log

Corresponding event field:
```
workspaceType:'vscodesws'
```