### PR TITLE
retire outdated tour page

### DIFF
--- a/src/welcome/assets/components/GetStartedPage.tsx
+++ b/src/welcome/assets/components/GetStartedPage.tsx
@@ -17,12 +17,7 @@ export class GetStartedPage extends React.Component<{
 }> {
 
     render() {
-        const {firstTimeRun} = this.props;
-        if (firstTimeRun) {
-            return this.renderTourPage();
-        } else {
-            return this.renderWelcomePage();
-        }
+        return this.renderWelcomePage();
     }
 
     renderWelcomePage() {
@@ -62,6 +57,9 @@ export class GetStartedPage extends React.Component<{
         );
     }
 
+    /**
+     * @deprecated 
+     */
     renderTourPage() {
         return <TourPage></TourPage>;
     }

--- a/src/welcome/assets/utils.ts
+++ b/src/welcome/assets/utils.ts
@@ -44,12 +44,3 @@ export function onWillFetchInitProps() {
     command: "onWillFetchInitProps"
   });
 }
-
-/**
- * Request main process to initialize a tour page.
- */
-export function onWillShowTourPage() {
-  vscode.postMessage({
-    command: "onWillShowTourPage"
-  });
-}

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -81,9 +81,6 @@ async function initializeWelcomeView(context: vscode.ExtensionContext, webviewPa
             case "onWillFetchInitProps":
                 fetchInitProps(context);
                 break;
-            case "onWillShowTourPage":
-                showTourPage(context);
-                break;
             case "setWelcomeVisibility":
                 setWelcomeVisibility(context, message.visibility);
                 break;
@@ -135,18 +132,6 @@ export const fetchInitProps = async (context: vscode.ExtensionContext) => {
         props: {
             showWhenUsingJava: context.globalState.get(KEY_SHOW_WHEN_USING_JAVA),
             firstTimeRun: context.globalState.get(KEY_IS_WELCOME_PAGE_VIEWED) !== true,
-            isAwtDisabled: isAwtDisabled(),
-        }
-    });
-    setFirstTimeRun(context, false);
-};
-
-const showTourPage = async (context: vscode.ExtensionContext) => {
-    welcomeView?.webview.postMessage({
-        command: "onDidFetchInitProps",
-        props: {
-            showWhenUsingJava: context.globalState.get(KEY_SHOW_WHEN_USING_JAVA),
-            firstTimeRun: true,
             isAwtDisabled: isAwtDisabled(),
         }
     });


### PR DESCRIPTION
When 'java: help center' is opened for the first time, the old "tour page" is still shown, which is unexpected. 

Now always render welcome page instead of tour page. 