### PR TITLE
Simplify the clean cache notification buttons

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -87,7 +87,7 @@ async function checkIfJavaServerCrashed(wait: number = 0/*ms*/) {
          name: "corrupted-cache",
       });
       const ans = await vscode.window.showErrorMessage("Java extension cannot start due to corrupted workspace cache, please try to clean the workspace.",
-                     "Clean and Restart", "Later");
+                     "Clean and Restart");
       if (ans === "Clean and Restart") {
          sendInfo("", {
             name: "clean-cache-action",


### PR DESCRIPTION
Since the "Later" button doesn't provide much help, remove it.

Before:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/14052197/178725782-07b4c735-19c8-4016-b2ee-a5db9be59da2.png">

After:
<img width="453" alt="image" src="https://user-images.githubusercontent.com/14052197/178725384-3e0a4a66-3c08-42e0-8a0e-85f30829c0db.png">
