### PR TITLE
detach tags from error messages

### DIFF
--- a/src/daemon/serverLog/logWatcher.ts
+++ b/src/daemon/serverLog/logWatcher.ts
@@ -56,16 +56,22 @@ export class LogWatcher {
             const consentToCollectLogs = vscode.workspace.getConfiguration("java").get<boolean>("help.collectErrorLog");
             if (errors) {
                 errors.forEach(e => {
-                    consentToCollectLogs ? sendInfo("", {
-                        name: "jdtls-error",
-                        error: e.message,
-                        stack: e.stack!,
-                        timestamp: e.timestamp!.toString()
-                    }) : sendInfo("", {
-                        name: "jdtls-error",
-                        error: redact(e.message),
-                        timestamp: e.timestamp!.toString()
-                    });
+                    if (consentToCollectLogs) {
+                        sendInfo("", {
+                            name: "jdtls-error",
+                            error: e.message,
+                            stack: e.stack!,
+                            timestamp: e.timestamp!.toString()
+                        });
+                    } else {
+                        const {message, tags} = redact(e.message);
+                        sendInfo("", {
+                            name: "jdtls-error",
+                            error: message,
+                            tags: tags.join(","),
+                            timestamp: e.timestamp!.toString()
+                        })
+                    }
                 })
             }
             this.logProcessedTimestamp = Date.now();
@@ -108,16 +114,23 @@ export class LogWatcher {
             const consentToCollectLogs = vscode.workspace.getConfiguration("java").get<boolean>("help.collectErrorLog");
             if (errors) {
                 errors.forEach(e => {
-                    consentToCollectLogs ? sendInfo("", {
-                        name: "jdtls-error-in-crashed-session",
-                        error: e.message,
-                        stack: e.stack!,
-                        timestamp: e.timestamp!.toString()
-                    }) : sendInfo("", {
-                        name: "jdtls-error-in-crashed-session",
-                        error: redact(e.message),
-                        timestamp: e.timestamp!.toString()
-                    });
+                    if (consentToCollectLogs) {
+                        sendInfo("", {
+                            name: "jdtls-error-in-crashed-session",
+                            error: e.message,
+                            stack: e.stack!,
+                            timestamp: e.timestamp!.toString()
+                        })
+                    } else {
+                        const { message, tags } = redact(e.message);
+                        sendInfo("", {
+                            name: "jdtls-error-in-crashed-session",
+                            error: message,
+                            tags: tags.join(","),
+                            timestamp: e.timestamp!.toString()
+                        })
+                    }
+
                 })
             }
         }

--- a/src/daemon/serverLog/whitelist.ts
+++ b/src/daemon/serverLog/whitelist.ts
@@ -42,13 +42,15 @@ const MESSAGE_WHITELIST: string[] = [
     "Workspace restored, but some problems occurred.",
 ];
 
-export function redact(rawMessage: string): string {
-    const matchedMessage = MESSAGE_WHITELIST.find(msg => rawMessage.includes(msg));
-    if (matchedMessage) {
-        return matchedMessage;
-    } else {
-        const lower = rawMessage.toLocaleLowerCase();
-        const tags = TAGS.filter(tag => lower.includes(tag));
-        return tags.length > 0 ? `Tags:${tags.join(",")}` : "";
+export function redact(rawMessage: string): {
+    message: string;
+    tags: string[];
+} {
+    const message = MESSAGE_WHITELIST.find(msg => rawMessage.includes(msg)) ?? "";
+    const tags = TAGS.filter(tag => rawMessage.toLocaleLowerCase().includes(tag));
+
+    return {
+        message,
+        tags
     }
 }


### PR DESCRIPTION
Previously if error messages are not in the whitelist, we put tags information directly in the same field. Now add a new field `tags` for better clarity.

### Previous
```
message: "Tags: tagA,tagB"
```

### Now
```
message: ""
tags: "tagA,tagB"
```
