### PR TITLE
stop logging useless info when embedded jre is absent

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -80,6 +80,8 @@ async function checkIfJavaServerCrashed(wait: number = 0/*ms*/) {
       await delay(wait);
    }
 
+   // TODO: not to call start() repeatedly. @testforstephen
+   // daemon.processWatcher.start() can return false when there is no embedded jre, where you cannot judge whether the process is started or not.
    const corruptedCache = !await daemon.processWatcher.start() && await daemon.logWatcher.checkIfWorkspaceCorrupted();
    if (!corruptedCacheDetected && corruptedCache) {
       corruptedCacheDetected = true;

--- a/src/daemon/processWatcher.ts
+++ b/src/daemon/processWatcher.ts
@@ -42,7 +42,7 @@ export class ProcessWatcher {
             jreHome = path.join(jreFolder, jreDistros[0]);
          }
       } catch (error) {
-         console.error(error);
+         // do nothing when jre is not embedded, to avoid spamming logs
       }
       if (!jreHome) {
          return false;


### PR DESCRIPTION
Signed-off-by: Yan Zhang <yanzh@microsoft.com>