### PR TITLE
should open webview on clicking 'Install A New JDK' button

### DIFF
--- a/src/java-runtime/assets/ToolingJDKPanel.tsx
+++ b/src/java-runtime/assets/ToolingJDKPanel.tsx
@@ -4,9 +4,8 @@
 import { provideReactWrapper } from '@microsoft/fast-react-wrapper';
 import * as webviewUI from "@vscode/webview-ui-toolkit";
 import * as React from "react";
-import { encodeCommandUriWithTelemetry } from '../../utils/webview';
 import { JavaRuntimeEntry } from "../types";
-import { onWillBrowseForJDK } from './vscode.api';
+import { onWillBrowseForJDK, onWillRunCommandFromWebview } from './vscode.api';
 
 const REQUIRED_JDK_VERSION = 17;
 const { wrap } = provideReactWrapper(React);
@@ -25,8 +24,7 @@ interface State {
 export class ToolingJDKPanel extends React.Component<Props, State> {
   render = () => {
     const { javaHomeError } = this.props;
-    const downloadJDKCommand = encodeCommandUriWithTelemetry("java.runtime", "download", "java.installJdk");
-
+    
     return (
       <div className="container">
         <h1>Configure Runtime for Language Server</h1>
@@ -39,7 +37,7 @@ export class ToolingJDKPanel extends React.Component<Props, State> {
           {this?.state?.isDirty && <Button><a href="command:workbench.action.reloadWindow">Reload</a></Button> }
         </div>
         <div className="jdk-action">
-          <Button appearance="secondary"><a href={downloadJDKCommand}>Install a <b>New JDK</b></a></Button>
+          <Button appearance="secondary" onClick={this.onClickInstallButton}><a href="#">Install a <b>New JDK</b></a></Button>
         </div>
       </div>
     );
@@ -48,5 +46,9 @@ export class ToolingJDKPanel extends React.Component<Props, State> {
   onClickBrowseJDKButton = () => {
     onWillBrowseForJDK();
     this.setState({ isDirty: true });
+  }
+
+  onClickInstallButton = () => {
+    onWillRunCommandFromWebview("java.runtime", "download", "java.installJdk");
   }
 }

--- a/src/java-runtime/assets/vscode.api.ts
+++ b/src/java-runtime/assets/vscode.api.ts
@@ -46,3 +46,15 @@ export function onWillBrowseForJDK() {
     command: "onWillBrowseForJDK"
   });
 }
+
+export function onWillRunCommandFromWebview(webview: string, identifier: string, command: string, args?: any[]) {
+  vscode.postMessage({
+    command: "onWillRunCommandFromWebview",
+    wrappedArgs: {
+      webview,
+      identifier,
+      command,
+      args
+    }
+  });
+}

--- a/src/java-runtime/index.ts
+++ b/src/java-runtime/index.ts
@@ -129,6 +129,11 @@ async function initializeJavaRuntimeView(context: vscode.ExtensionContext, webvi
         }
         break;
       }
+      case "onWillRunCommandFromWebview": {
+        const { wrappedArgs } = e;
+        vscode.commands.executeCommand("java.webview.runCommand", wrappedArgs);
+        break;
+      }
       default:
         break;
     }


### PR DESCRIPTION
Reported by @nickzhums

Previously only when you click on the text, it opens corresponding webview. 

Now the event is bound to the button. 