### PR TITLE
Remove Release Notes from Overview

### DIFF
--- a/src/overview/index.ts
+++ b/src/overview/index.ts
@@ -240,20 +240,6 @@ function getHtmlForWebview(scriptPath: string) {
           </div>
           <div class="row mb-3">
             <div class="col">
-              <h3 class="font-weight-light">Release Notes</h3>
-              <div>
-                <a href="command:java.showReleaseNotes?%220.7.0%22" title="April 2019 Release Notes">April 2019</a>
-              </div>
-              <div>
-                <a href="command:java.showReleaseNotes?%220.6.0%22" title="February 2019 Release Notes">February 2019</a>
-              </div>
-              <div>
-                <a href="command:java.showReleaseNotes?%220.5.0%22" title="November 2018 Release Notes">November 2018</a>
-              </div>
-            </div>
-          </div>
-          <div class="row mb-3">
-            <div class="col">
               <h3 class="font-weight-light">Help</h3>
               <div>
                 <a href="command:java.helper.openUrl?%22https%3A%2F%2Fgithub.com%2FMicrosoft%2Fvscode-java-pack%2Fissues%22" title="Report issues or request features">Questions & Issues</a>


### PR DESCRIPTION
Hasn't been updated since 2019, so I thought it would simply be best to remove the Release Notes section.