### PR TITLE
fix uri of scripts to pass CORS policy

### DIFF
--- a/src/beginner-tips/index.ts
+++ b/src/beginner-tips/index.ts
@@ -105,9 +105,7 @@ class BeginnerTipsPage {
 
 	private _getHtmlForWebview() {
 		const scriptPathOnDisk = vscode.Uri.file(path.join(this._extensionPath, 'out', "assets", "beginner-tips", "index.js"));
-
-		// const scriptUri = this._panel.webview.asWebviewUri(scriptPathOnDisk);
-		const scriptUri = (scriptPathOnDisk).with({ scheme: "vscode-resource" });
+		const scriptUri = this._panel?.webview.asWebviewUri(scriptPathOnDisk);
 
 		// Use a nonce to whitelist which scripts can be run
 		const nonce = getNonce();
@@ -123,7 +121,7 @@ class BeginnerTipsPage {
 			<body>
 				<noscript>You need to enable JavaScript to run this app.</noscript>
 				<div id="root"></div>
-				
+
 				<script nonce="${nonce}" src="${scriptUri}" type="module"></script>
 			</body>
 			</html>`;

--- a/src/classpath/classpathConfigurationView.ts
+++ b/src/classpath/classpathConfigurationView.ts
@@ -93,14 +93,15 @@ async function initializeWebview(context: vscode.ExtensionContext): Promise<void
         }
     })));
 
-    classpathConfigurationPanel.webview.html = getHtmlForWebview(context.asAbsolutePath("./out/assets/classpath/index.js"));
+    classpathConfigurationPanel.webview.html = getHtmlForWebview(classpathConfigurationPanel.webview, context.asAbsolutePath("./out/assets/classpath/index.js"));
 
     await checkRequirement();
 }
 
-function getHtmlForWebview(scriptPath: string) {
+function getHtmlForWebview(webview: vscode.Webview, scriptPath: string) {
     const scriptPathOnDisk = vscode.Uri.file(scriptPath);
-    const scriptUri = (scriptPathOnDisk).with({ scheme: "vscode-resource" });
+    const scriptUri = webview.asWebviewUri(scriptPathOnDisk);
+
     // Use a nonce to whitelist which scripts can be run
     const nonce = getNonce();
     return `<!DOCTYPE html>
@@ -115,7 +116,7 @@ function getHtmlForWebview(scriptPath: string) {
         <script nonce="${nonce}" src="${scriptUri}" type="module"></script>
         <div id="content"></div>
     </body>
-    
+
     </html>
     `;
 }
@@ -148,7 +149,7 @@ async function checkRequirement(): Promise<boolean> {
         return false;
     }
 
-    await javaExt.activate(); 
+    await javaExt.activate();
     lsApi = javaExt.exports;
 
     if (lsApi) {

--- a/src/ext-guide/index.ts
+++ b/src/ext-guide/index.ts
@@ -35,7 +35,7 @@ async function initializeJavaExtGuideView(context: vscode.ExtensionContext, webv
     dark: vscode.Uri.file(path.join(context.extensionPath, "caption.dark.svg"))
   };
 
-  webviewPanel.webview.html = getHtmlForWebview(context.asAbsolutePath("./out/assets/ext-guide/index.js"));
+  webviewPanel.webview.html = getHtmlForWebview(webviewPanel, context.asAbsolutePath("./out/assets/ext-guide/index.js"));
 
   context.subscriptions.push(webviewPanel.onDidDispose(onDisposeCallback));
   context.subscriptions.push(webviewPanel.webview.onDidReceiveMessage(async (e) => {
@@ -68,9 +68,10 @@ async function initializeJavaExtGuideView(context: vscode.ExtensionContext, webv
   syncExtensionStatus();
 }
 
-function getHtmlForWebview(scriptPath: string) {
+function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string) {
   const scriptPathOnDisk = vscode.Uri.file(scriptPath);
-  const scriptUri = (scriptPathOnDisk).with({ scheme: "vscode-resource" });
+  const scriptUri = webviewPanel.webview.asWebviewUri(scriptPathOnDisk);
+
   // Use a nonce to whitelist which scripts can be run
   const nonce = getNonce();
   return `<!DOCTYPE html>
@@ -113,7 +114,7 @@ function getHtmlForWebview(scriptPath: string) {
                 </div>
                 <div class="col-5">
                   <div class="tab-content">
-  
+
                     <!-- Basics -->
                     <div class="tab-pane fade show active" id="panel-basics" role="tabpanel" aria-labelledby="tab-basics">
                       <table class="table table-borderless table-hover table-sm">
@@ -125,7 +126,7 @@ function getHtmlForWebview(scriptPath: string) {
                                 <label class="form-check-label" for="chk.redhat.java">
                                   Language Support for Java by Red Hat
                                 </label>
-  
+
                               </div>
                             </td>
                           </tr>
@@ -182,7 +183,7 @@ function getHtmlForWebview(scriptPath: string) {
                         </tbody>
                       </table>
                     </div>
-  
+
                     <!-- Frameworks -->
                     <div class="tab-pane fade" id="panel-frameworks" role="tabpanel" aria-labelledby="tab-frameworks">
                       <table class="table table-borderless table-hover table-sm">
@@ -220,7 +221,7 @@ function getHtmlForWebview(scriptPath: string) {
                         </tbody>
                       </table>
                     </div>
-  
+
                     <!-- Application Servers -->
                     <div class="tab-pane fade" id="panel-app-servers" role="tabpanel" aria-labelledby="tab-app-servers">
                       <table class="table table-borderless table-hover table-sm">
@@ -238,7 +239,7 @@ function getHtmlForWebview(scriptPath: string) {
                         </tbody>
                       </table>
                     </div>
-  
+
                     <!-- Keymaps -->
                     <div class="tab-pane fade" id="panel-keymaps" role="tabpanel" aria-labelledby="tab-keymaps">
                       <table class="table table-borderless table-hover table-sm">
@@ -266,7 +267,7 @@ function getHtmlForWebview(scriptPath: string) {
                         </tbody>
                       </table>
                     </div>
-  
+
                   </div>
                 </div>
                 <div class="col-4">
@@ -324,7 +325,7 @@ function getHtmlForWebview(scriptPath: string) {
       </div>
     </div>
   </body>
-  
+
   </html>
   `;
 }

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -149,7 +149,8 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
 
     private getHtmlForWebview(scriptPath: string) {
         const scriptPathOnDisk = vscode.Uri.file(scriptPath);
-        const scriptUri = (scriptPathOnDisk).with({ scheme: "vscode-resource" });
+        const scriptUri = this.webviewPanel?.webview.asWebviewUri(scriptPathOnDisk);
+
         // Use a nonce to whitelist which scripts can be run
         const nonce = getNonce();
         return `<!DOCTYPE html>

--- a/src/install-jdk/index.ts
+++ b/src/install-jdk/index.ts
@@ -37,7 +37,7 @@ class InstallJdkPage {
 		webviewPanel?: vscode.WebviewPanel;
 		beside?: boolean;
 	}) {
-		
+
 		let column = vscode.ViewColumn.Active;
 		if (options?.beside) {
 			// "smart" Beside
@@ -139,9 +139,7 @@ class InstallJdkPage {
 
 	private _getHtmlForWebview() {
 		const scriptPathOnDisk = vscode.Uri.file(path.join(this._extensionPath, 'out', "assets", "install-jdk", "index.js"));
-
-		// const scriptUri = this._panel.webview.asWebviewUri(scriptPathOnDisk);
-		const scriptUri = (scriptPathOnDisk).with({ scheme: "vscode-resource" });
+		const scriptUri = this._panel?.webview.asWebviewUri(scriptPathOnDisk);
 
 		// Use a nonce to whitelist which scripts can be run
 		const nonce = getNonce();
@@ -157,7 +155,7 @@ class InstallJdkPage {
 			<body>
 				<noscript>You need to enable JavaScript to run this app.</noscript>
 				<div id="root"></div>
-				
+
 				<script nonce="${nonce}" src="${scriptUri}" type="module"></script>
 			</body>
 			</html>`;

--- a/src/java-runtime/index.ts
+++ b/src/java-runtime/index.ts
@@ -41,7 +41,7 @@ async function initializeJavaRuntimeView(context: vscode.ExtensionContext, webvi
     light: vscode.Uri.file(path.join(context.extensionPath, "caption.light.svg")),
     dark: vscode.Uri.file(path.join(context.extensionPath, "caption.dark.svg"))
   };
-  webviewPanel.webview.html = getHtmlForWebview(context.asAbsolutePath("./out/assets/java-runtime/index.js"));
+  webviewPanel.webview.html = getHtmlForWebview(webviewPanel, context.asAbsolutePath("./out/assets/java-runtime/index.js"));
 
   context.subscriptions.push(webviewPanel.onDidDispose(onDisposeCallback));
   context.subscriptions.push(webviewPanel.webview.onDidReceiveMessage(async (e) => {
@@ -159,9 +159,10 @@ async function initializeJavaRuntimeView(context: vscode.ExtensionContext, webvi
   }
 }
 
-function getHtmlForWebview(scriptPath: string) {
+function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string) {
   const scriptPathOnDisk = vscode.Uri.file(scriptPath);
-  const scriptUri = (scriptPathOnDisk).with({ scheme: "vscode-resource" });
+  const scriptUri = webviewPanel.webview.asWebviewUri(scriptPathOnDisk);
+
   // Use a nonce to whitelist which scripts can be run
   const nonce = getNonce();
 
@@ -177,7 +178,7 @@ function getHtmlForWebview(scriptPath: string) {
     <script nonce="${nonce}" src="${scriptUri}" type="module"></script>
     <div id="content"></div>
   </body>
-  
+
   </html>`;
 }
 

--- a/src/overview/index.ts
+++ b/src/overview/index.ts
@@ -51,7 +51,7 @@ async function initializeOverviewView(context: vscode.ExtensionContext, webviewP
     light: vscode.Uri.file(path.join(context.extensionPath, "caption.light.svg")),
     dark: vscode.Uri.file(path.join(context.extensionPath, "caption.dark.svg"))
   };
-  webviewPanel.webview.html = getHtmlForWebview(context.asAbsolutePath("./out/assets/overview/index.js"));
+  webviewPanel.webview.html = getHtmlForWebview(webviewPanel, context.asAbsolutePath("./out/assets/overview/index.js"));
 
   context.subscriptions.push(webviewPanel.onDidDispose(onDisposeCallback));
 
@@ -108,12 +108,13 @@ export class OverviewViewSerializer implements vscode.WebviewPanelSerializer {
   }
 }
 
-function getHtmlForWebview(scriptPath: string) {
+function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string) {
   const scriptPathOnDisk = vscode.Uri.file(scriptPath);
-  const scriptUri = (scriptPathOnDisk).with({ scheme: "vscode-resource" });
+  const scriptUri = webviewPanel.webview.asWebviewUri(scriptPathOnDisk);
+
   // Use a nonce to whitelist which scripts can be run
   const nonce = getNonce();
-  
+
   return `<!DOCTYPE html>
   <html lang="en">
   <head>
@@ -311,6 +312,6 @@ function getHtmlForWebview(scriptPath: string) {
       </div>
     </div>
   </body>
-  
+
   </html>`;
 }

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -74,7 +74,7 @@ async function initializeWelcomeView(context: vscode.ExtensionContext, webviewPa
         light: vscode.Uri.file(path.join(context.extensionPath, "caption.light.svg")),
         dark: vscode.Uri.file(path.join(context.extensionPath, "caption.dark.svg"))
     };
-    webviewPanel.webview.html = getHtmlForWebview(context.asAbsolutePath("./out/assets/welcome/index.js"));
+    webviewPanel.webview.html = getHtmlForWebview(webviewPanel, context.asAbsolutePath("./out/assets/welcome/index.js"));
     context.subscriptions.push(webviewPanel.onDidDispose(onDisposeCallback));
     context.subscriptions.push(webviewPanel.webview.onDidReceiveMessage((message => {
         switch (message.command) {
@@ -98,9 +98,10 @@ async function initializeWelcomeView(context: vscode.ExtensionContext, webviewPa
     }));
 }
 
-function getHtmlForWebview(scriptPath: string) {
+function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string) {
     const scriptPathOnDisk = vscode.Uri.file(scriptPath);
-    const scriptUri = (scriptPathOnDisk).with({ scheme: "vscode-resource" });
+    const scriptUri = webviewPanel.webview.asWebviewUri(scriptPathOnDisk);
+
     // Use a nonce to whitelist which scripts can be run
     const nonce = getNonce();
     return `<!DOCTYPE html>


### PR DESCRIPTION
fix #1102 
- Now use `webview.asWebviewUri` to generate correct Uri for scripts, instead of constructing Uri on our own... Root cause is, in vscode1.73, corresponding URI changes from `vscode-resource:/path-to-script` to something like `https://file+.vscode-resource.vscode-cdn.net/path-to-script`