### PR TITLE
pivotal.vscode-boot-dev-pack -> vmware.vscode-boot-dev-pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can do more with VS Code. Here are some more recommendations that could help
 
 Spring Tools 4 (ST4) is also available in Visual Studio Code. It understands Spring so you can navigate Spring code at the level of beans, routes, etc. It can also show live information of the running Spring Boot applications. Check out [the ST4 website](https://spring.io/tools) to see a complete list of its features.
 
-To use ST4, install [📦 Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack). Please also check out the [User Guide](https://github.com/spring-projects/sts4/wiki) to make the most of it.
+To use ST4, install [📦 Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=vmware.vscode-boot-dev-pack). Please also check out the [User Guide](https://github.com/spring-projects/sts4/wiki) to make the most of it.
 
 ### Eclipse MicroProfile
 

--- a/src/ext-guide/index.ts
+++ b/src/ext-guide/index.ts
@@ -191,8 +191,8 @@ function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string
                           <tr>
                             <td>
                               <div class="form-check">
-                                <input class="form-check-input" type="checkbox" value="pivotal.vscode-boot-dev-pack" id="chk.pivotal.vscode-boot-dev-pack">
-                                <label class="form-check-label" for="chk.pivotal.vscode-boot-dev-pack">
+                                <input class="form-check-input" type="checkbox" value="vmware.vscode-boot-dev-pack" id="chk.vmware.vscode-boot-dev-pack">
+                                <label class="form-check-label" for="chk.vmware.vscode-boot-dev-pack">
                                   Spring Boot Extension Pack
                                 </label>
                               </div>

--- a/src/overview/index.ts
+++ b/src/overview/index.ts
@@ -205,7 +205,7 @@ function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string
               <div>
                 <a href="command:java.helper.openUrl?%22https%3A%2F%2Fgithub.com%2Fspring-projects%2Fspring-petclinic%22" title="Run PetClinic sample app in VS Code">Spring PetClinic Sample Application</a>
               </div>
-              <div ext="pivotal.vscode-boot-dev-pack" displayName="Spring Boot Extension Pack">
+              <div ext="vmware.vscode-boot-dev-pack" displayName="Spring Boot Extension Pack">
                 <a href="#" title="Install Spring Boot Extension Pack...">Install Spring Boot Extension Pack</a>
               </div>
             </div>

--- a/src/welcome/assets/components/NavigationPanel.tsx
+++ b/src/welcome/assets/components/NavigationPanel.tsx
@@ -34,7 +34,7 @@ export default class NavigationPanel extends React.Component<{
       actions: [
         { name: "Spring Boot with VS Code", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-spring-boot"] },
         { name: "Spring PetClinic Sample Application", command: "java.helper.openUrl", args: ["https://github.com/spring-projects/spring-petclinic"] },
-        { name: "Install Spring Boot Extension Pack ...", command: "java.helper.installExtension", args: ["pivotal.vscode-boot-dev-pack", "Spring Boot Extension Pack"] }
+        { name: "Install Spring Boot Extension Pack ...", command: "java.helper.installExtension", args: ["vmware.vscode-boot-dev-pack", "Spring Boot Extension Pack"] }
       ]
     },
     {


### PR DESCRIPTION
`pivotal.vscode-boot-dev-pack` is no longer available in the extensions market, it has been replaced by `vmware.vscode-boot-dev-pack`