### PR TITLE
Trace lsp perf from sampling

### DIFF
--- a/src/exp/TreatmentVariables.ts
+++ b/src/exp/TreatmentVariables.ts
@@ -4,5 +4,6 @@
 export class TreatmentVariables {
     public static readonly VSCodeConfig = 'vscode';
     public static readonly PresentWelcomePageByDefault = 'presentWelcomePageByDefault';
-    public static readonly JavaWalkthroughEnabled = "gettingStarted.overrideCategory.vscjava.vscode-java-pack.javaWelcome.when"
+    public static readonly JavaWalkthroughEnabled = "gettingStarted.overrideCategory.vscjava.vscode-java-pack.javaWelcome.when";
+    public static readonly JavaCompletionSampling = "javaCompletionSampling";
 }


### PR DESCRIPTION
- If Java extension is pre-release version, always log its completion perf.
- If it's a non pre-release version, then log its completion perf based on sampling.