### PR TITLE
Monitor the sessions that exit with unsaved changes

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -48,6 +48,7 @@ async function checkJavaExtActivated(_context: vscode.ExtensionContext): Promise
       return false;
    }
 
+   traceSessionStatus(javaExt);
    traceJavaExtension(javaExt);
    traceLSPPerformance(javaExt);
 
@@ -165,6 +166,26 @@ async function traceJavaExtension(javaExt: vscode.Extension<any>) {
          }
       }
       sendInfo("", metrics);
+   });
+}
+
+function traceSessionStatus(javaExt: vscode.Extension<any>) {
+   let initHandled: boolean = false;
+   javaExt.exports?.onDidRequestEnd?.((traceEvent: any) => {
+      if (initHandled) {
+         return;
+      }
+
+      if (traceEvent?.type === "initialize") {
+         initHandled = true;
+         daemon.logWatcher.checkIfUnsavedWorkspace().then((unsaved) => {
+            if (unsaved) {
+               sendInfo("", {
+                  name: "unsaved-workspace",
+               });
+            }
+         });
+      }
    });
 }
 

--- a/src/daemon/serverLog/logUtils.ts
+++ b/src/daemon/serverLog/logUtils.ts
@@ -40,6 +40,8 @@ const MESSAGE_BUILD_JOBS_FINISHED = "!MESSAGE >> build jobs finished";
 const STACK_INDICATOR = `${EOL}!STACK `;
 const MESSAGE_INDICATOR = `${EOL}!MESSAGE `;
 const CORRUPTED_WORKSPACE_INDICATOR = "Caused by: org.eclipse.core.internal.dtree.ObjectNotFoundException:";
+const ENTRY_RESOURCE_PLUGIN = "!ENTRY org.eclipse.core.resources";
+const MESSAGE_UNSAVED_WORKSPACE = "!MESSAGE The workspace exited with unsaved changes in the previous session; refreshing workspace to recover changes.";
 
 export async function logsForLatestSession(logFilepath: string): Promise<string> {
     const content = await fs.promises.readFile(logFilepath, { encoding: 'utf-8' });
@@ -140,6 +142,12 @@ export function containsCorruptedException(log: string): boolean {
     const lines = log.split(`${EOL}`);
     const find = lines.find(line => line.startsWith(CORRUPTED_WORKSPACE_INDICATOR));
     return !!find;
+}
+
+export function isUnsavedWorkspace(log: string): boolean {
+    const entries = log.split(LOG_ENTRY_SEPARATOR);
+    const resourcePluginStartEntry = entries.find(e => e.startsWith(ENTRY_RESOURCE_PLUGIN));
+    return !!resourcePluginStartEntry?.includes(MESSAGE_UNSAVED_WORKSPACE);
 }
 
 function getMessage(entry: string) {

--- a/src/daemon/serverLog/logWatcher.ts
+++ b/src/daemon/serverLog/logWatcher.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { LSDaemon } from "../daemon";
-import { collectErrors, collectErrorsSince, containsCorruptedException, logsForLatestSession, sessionMetadata } from "./logUtils";
+import { collectErrors, collectErrorsSince, containsCorruptedException, isUnsavedWorkspace, logsForLatestSession, sessionMetadata } from "./logUtils";
 import { toElapsed } from "./utils";
 import { redact } from "./whitelist";
 
@@ -131,6 +131,15 @@ export class LogWatcher {
         if (this.serverLogUri) {
             const logs = await logsForLatestSession(path.join(this.serverLogUri?.fsPath, ".log"));
             return containsCorruptedException(logs);
+        }
+
+        return false;
+    }
+
+    public async checkIfUnsavedWorkspace(): Promise<boolean> {
+        if (this.serverLogUri) {
+            const logs = await logsForLatestSession(path.join(this.serverLogUri?.fsPath, ".log"));
+            return isUnsavedWorkspace(logs);
         }
 
         return false;


### PR DESCRIPTION
>!ENTRY org.eclipse.core.resources 2 10035 2023-05-31 15:32:35.082
!MESSAGE The workspace exited with unsaved changes in the previous session; refreshing workspace to recover changes.

When the workspace is not saved before exiting in the previous session, you will see the above message when you reopen the workspace.