### PR TITLE
add `inspectRange`/`inspectClass` based on `inspectCode`.

### DIFF
--- a/src/copilot/inspect/Inspection.ts
+++ b/src/copilot/inspect/Inspection.ts
@@ -29,3 +29,13 @@ export interface Inspection {
     solution: string;
     severity: string;
 }
+
+export namespace Inspection {
+    export function fix(inspection: Inspection, source: string) {
+        //TODO: implement me
+    }
+
+    export function highlight(inspection: Inspection) {
+        //TODO: implement me
+    }
+}

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -1,7 +1,9 @@
 import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import Copilot from "../Copilot";
-import { logger } from "../utils";
+import { getContainedClassesOfRange, getContainingClassOfRange, getIntersectionMethodsOfRange, getUnionRange, logger } from "../utils";
 import { Inspection } from "./Inspection";
+import path from "path";
+import { TextDocument, DocumentSymbol, SymbolKind, ProgressLocation, Position, Range, Selection, window } from "vscode";
 
 export default class InspectionCopilot extends Copilot {
 
@@ -110,6 +112,61 @@ export default class InspectionCopilot extends Copilot {
         super(messages);
     }
 
+    public async inspectDocument(document: TextDocument): Promise<Inspection[]> {
+        logger.info('inspecting document:', document.fileName);
+        const range = new Range(document.lineAt(0).range.start, document.lineAt(document.lineCount - 1).range.end);
+        return this.inspectRange(document, range);
+    }
+
+    public async inspectClass(document: TextDocument, clazz: DocumentSymbol): Promise<Inspection[]> {
+        logger.info('inspecting class:', clazz.name);
+        return this.inspectRange(document, clazz.range);
+    }
+
+    public async inspectSymbol(document: TextDocument, symbol: DocumentSymbol): Promise<Inspection[]> {
+        logger.info(`inspecting symbol ${SymbolKind[symbol.kind]} ${symbol.name}`);
+        return this.inspectRange(document, symbol.range);
+    }
+
+    public async inspectRange(document: TextDocument, range: Range | Selection): Promise<Inspection[]> {
+        // ajust the range to the minimal container class or (multiple) method symbols
+        const methods: DocumentSymbol[] = await getIntersectionMethodsOfRange(range, document);
+        const classes: DocumentSymbol[] = await getContainedClassesOfRange(range, document);
+        const symbols: DocumentSymbol[] = [...classes, ...methods];
+        if (symbols.length < 1) {
+            const containingClass: DocumentSymbol = await getContainingClassOfRange(range, document);
+            symbols.push(containingClass);
+        }
+
+        // get the union range of the container symbols, which will be insepcted by copilot
+        const expandedRange: Range = getUnionRange(symbols);
+
+        // inspect the expanded union range
+        const symbolName = symbols[0].name;
+        const symbolKind = SymbolKind[symbols[0].kind].toLowerCase();
+        const inspections = await window.withProgress({
+            location: ProgressLocation.Notification,
+            title: `Inspecting ${symbolKind} ${symbolName}... of \"${path.basename(document.fileName)}\"`,
+            cancellable: false
+        }, (_progress) => {
+            return this.doInspectRange(document, expandedRange);
+        });
+
+        // show message based on the number of inspections
+        if (inspections.length < 1) {
+            void window.showInformationMessage(`Inspected ${symbolKind} ${symbolName}... of \"${path.basename(document.fileName)}\" and got 0 suggestions.`);
+        } else if (inspections.length == 1) {
+            // apply the only suggestion automatically
+            void Inspection.fix(inspections[0], 'auto');
+        } else {
+            // show message to go to the first suggestion
+            void window.showInformationMessage(`Inspected ${symbolKind} ${symbolName}... of \"${path.basename(document.fileName)}\" and got ${inspections.length} suggestions.`, "Go to").then(selection => {
+                selection === "Go to" && void Inspection.highlight(inspections[0]);
+            });
+        }
+        return inspections;
+    }
+
     /**
      * inspect the given code (debouncely if `key` is provided) using copilot and return the inspections
      * @param code code to inspect
@@ -137,6 +194,19 @@ export default class InspectionCopilot extends Copilot {
                 });
             }, wait <= 0 ? 3000 : wait));
         });
+    }
+
+    private async doInspectRange(document: TextDocument, range: Range | Selection): Promise<Inspection[]> {
+        const adjustedRange = new Range(new Position(range.start.line, 0), new Position(range.end.line, document.lineAt(range.end.line).text.length));
+        const content: string = document.getText(adjustedRange);
+        const offset = range.start.line;
+        const inspections = await this.inspectCode(content);
+        inspections.forEach(s => {
+            s.document = document;
+            // real line index to the start of the document
+            s.problem.position.line = s.problem.position.relativeLine + offset;
+        });
+        return inspections;
     }
 
     private async doInspectCode(code: string): Promise<Inspection[]> {

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -1,6 +1,6 @@
 import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import Copilot from "../Copilot";
-import { getContainedClassesOfRange, getContainerClassOfRange, getIntersectionMethodsOfRange, getUnionRange, logger } from "../utils";
+import { getClassesContainedInRange, getInnermostClassContainsRange, getIntersectionMethodsOfRange, getUnionRange, logger } from "../utils";
 import { Inspection } from "./Inspection";
 import path from "path";
 import { TextDocument, DocumentSymbol, SymbolKind, ProgressLocation, Position, Range, Selection, window } from "vscode";
@@ -131,10 +131,10 @@ export default class InspectionCopilot extends Copilot {
     public async inspectRange(document: TextDocument, range: Range | Selection): Promise<Inspection[]> {
         // ajust the range to the minimal container class or (multiple) method symbols
         const methods: DocumentSymbol[] = await getIntersectionMethodsOfRange(range, document);
-        const classes: DocumentSymbol[] = await getContainedClassesOfRange(range, document);
+        const classes: DocumentSymbol[] = await getClassesContainedInRange(range, document);
         const symbols: DocumentSymbol[] = [...classes, ...methods];
         if (symbols.length < 1) {
-            const containingClass: DocumentSymbol = await getContainerClassOfRange(range, document);
+            const containingClass: DocumentSymbol = await getInnermostClassContainsRange(range, document);
             symbols.push(containingClass);
         }
 

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -1,6 +1,6 @@
 import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import Copilot from "../Copilot";
-import { getContainedClassesOfRange, getContainingClassOfRange, getIntersectionMethodsOfRange, getUnionRange, logger } from "../utils";
+import { getContainedClassesOfRange, getContainerClassOfRange, getIntersectionMethodsOfRange, getUnionRange, logger } from "../utils";
 import { Inspection } from "./Inspection";
 import path from "path";
 import { TextDocument, DocumentSymbol, SymbolKind, ProgressLocation, Position, Range, Selection, window } from "vscode";
@@ -134,7 +134,7 @@ export default class InspectionCopilot extends Copilot {
         const classes: DocumentSymbol[] = await getContainedClassesOfRange(range, document);
         const symbols: DocumentSymbol[] = [...classes, ...methods];
         if (symbols.length < 1) {
-            const containingClass: DocumentSymbol = await getContainingClassOfRange(range, document);
+            const containingClass: DocumentSymbol = await getContainerClassOfRange(range, document);
             symbols.push(containingClass);
         }
 
@@ -199,12 +199,12 @@ export default class InspectionCopilot extends Copilot {
     private async doInspectRange(document: TextDocument, range: Range | Selection): Promise<Inspection[]> {
         const adjustedRange = new Range(new Position(range.start.line, 0), new Position(range.end.line, document.lineAt(range.end.line).text.length));
         const content: string = document.getText(adjustedRange);
-        const offset = range.start.line;
+        const startLine = range.start.line;
         const inspections = await this.inspectCode(content);
         inspections.forEach(s => {
             s.document = document;
             // real line index to the start of the document
-            s.problem.position.line = s.problem.position.relativeLine + offset;
+            s.problem.position.line = s.problem.position.relativeLine + startLine;
         });
         return inspections;
     }

--- a/src/copilot/utils.ts
+++ b/src/copilot/utils.ts
@@ -1,3 +1,49 @@
-import { LogOutputChannel, window } from "vscode";
+import { DocumentSymbol, LogOutputChannel, SymbolKind, TextDocument, commands, window, Range, Selection } from "vscode";
+
+export const CLASS_KINDS: SymbolKind[] = [SymbolKind.Class, SymbolKind.Interface, SymbolKind.Enum];
+export const METHOD_KINDS: SymbolKind[] = [SymbolKind.Method, SymbolKind.Constructor];
 
 export const logger: LogOutputChannel = window.createOutputChannel("Java Rewriting Suggestions", { log: true });
+
+export async function getContainedClassesOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol[]> {
+    const stack = ((await commands.executeCommand<DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', document.uri)) ?? []).reverse();
+    const classes = getClassesAndMethodsOfSymbols(stack).filter(symbol => CLASS_KINDS.includes(symbol.kind));
+    return classes.filter(clazz => range.contains(clazz.range));
+}
+
+export async function getIntersectionMethodsOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol[]> {
+    const stack = ((await commands.executeCommand<DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', document.uri)) ?? []).reverse();
+    const methods = getClassesAndMethodsOfSymbols(stack).filter(symbol => METHOD_KINDS.includes(symbol.kind));
+    return methods.filter(method => method.range.intersection(range));
+}
+
+export async function getContainingClassOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol> {
+    const stack = ((await commands.executeCommand<DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', document.uri)) ?? []).reverse();
+    const classes = getClassesAndMethodsOfSymbols(stack).filter(symbol => CLASS_KINDS.includes(symbol.kind));
+    // reverse the classes to get the innermost class first
+    return classes.reverse().filter(clazz => clazz.range.contains(range))[0];
+}
+
+export function getUnionRange(symbols: DocumentSymbol[]): Range {
+    let result: Range = new Range(symbols[0].range.start, symbols[0].range.end);
+    for (const method of symbols) {
+        result = result.union(method.range);
+    }
+    return result;
+}
+
+function getClassesAndMethodsOfSymbols(symbols: DocumentSymbol[]): DocumentSymbol[] {
+    const stack = symbols;
+
+    const result: DocumentSymbol[] = [];
+    while (stack.length > 0) {
+        const symbol = stack.pop() as DocumentSymbol;
+        if (CLASS_KINDS.includes(symbol.kind)) {
+            result.push(symbol);
+            stack.push(...symbol.children.reverse());
+        } else if (METHOD_KINDS.includes(symbol.kind)) {
+            result.push(symbol);
+        }
+    }
+    return result;
+}

--- a/src/copilot/utils.ts
+++ b/src/copilot/utils.ts
@@ -5,29 +5,38 @@ export const METHOD_KINDS: SymbolKind[] = [SymbolKind.Method, SymbolKind.Constru
 
 export const logger: LogOutputChannel = window.createOutputChannel("Java Rewriting Suggestions", { log: true });
 
+/**
+ * get all the class symbols contained in the `range` in the `document`
+ */
 export async function getContainedClassesOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol[]> {
     const symbols = await getClassesAndMethodsOfDocument(document);
     return symbols.filter(symbol => CLASS_KINDS.includes(symbol.kind))
         .filter(clazz => range.contains(clazz.range));
 }
 
-export async function getIntersectionMethodsOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol[]> {
-    const symbols = await getClassesAndMethodsOfDocument(document);
-    return symbols.filter(symbol => METHOD_KINDS.includes(symbol.kind))
-        .filter(method => method.range.intersection(range));
-}
-
-export async function getContainingClassOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol> {
+/**
+ * get the innermost class symbol that completely contains the `range` in the `document`
+ */
+export async function getContainerClassOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol> {
     const symbols = await getClassesAndMethodsOfDocument(document);
     return symbols.filter(symbol => CLASS_KINDS.includes(symbol.kind))
         // reverse the classes to get the innermost class first
         .reverse().filter(clazz => clazz.range.contains(range))[0];
 }
 
+/**
+ * get all the method symbols that are completely or partially contained in the `range` in the `document`
+ */
+export async function getIntersectionMethodsOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol[]> {
+    const symbols = await getClassesAndMethodsOfDocument(document);
+    return symbols.filter(symbol => METHOD_KINDS.includes(symbol.kind))
+        .filter(method => method.range.intersection(range));
+}
+
 export function getUnionRange(symbols: DocumentSymbol[]): Range {
     let result: Range = new Range(symbols[0].range.start, symbols[0].range.end);
-    for (const method of symbols) {
-        result = result.union(method.range);
+    for (const symbol of symbols) {
+        result = result.union(symbol.range);
     }
     return result;
 }

--- a/src/copilot/utils.ts
+++ b/src/copilot/utils.ts
@@ -8,7 +8,7 @@ export const logger: LogOutputChannel = window.createOutputChannel("Java Rewriti
 /**
  * get all the class symbols contained in the `range` in the `document`
  */
-export async function getContainedClassesOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol[]> {
+export async function getClassesContainedInRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol[]> {
     const symbols = await getClassesAndMethodsOfDocument(document);
     return symbols.filter(symbol => CLASS_KINDS.includes(symbol.kind))
         .filter(clazz => range.contains(clazz.range));
@@ -17,7 +17,7 @@ export async function getContainedClassesOfRange(range: Range | Selection, docum
 /**
  * get the innermost class symbol that completely contains the `range` in the `document`
  */
-export async function getContainerClassOfRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol> {
+export async function getInnermostClassContainsRange(range: Range | Selection, document: TextDocument): Promise<DocumentSymbol> {
     const symbols = await getClassesAndMethodsOfDocument(document);
     return symbols.filter(symbol => CLASS_KINDS.includes(symbol.kind))
         // reverse the classes to get the innermost class first


### PR DESCRIPTION
* inspecting class/symbol will both go to `inspectRange`
* for random selections, we will adjust(expand) it to the union range of container symbols first before inspecting it. e.g. if user selection covers bodies of two methods, then the range will be expanded to the full range of these two methods.