### PR TITLE
error handling, messaging and refactoring.

### DIFF
--- a/src/copilot/Copilot.ts
+++ b/src/copilot/Copilot.ts
@@ -28,7 +28,8 @@ export default class Copilot {
         const messages = [...systemMessagesOrSamples];
         const _send = async (message: string): Promise<boolean> => {
             rounds++;
-            logger.info(`User: \n`, message);
+            logger.debug(`User: \n`, message);
+            logger.info(`User: ${message.split('\n')[0]}...`);
             messages.push(new LanguageModelChatMessage(LanguageModelChatMessageRole.User, message));
             logger.info('Copilot: thinking...');
 
@@ -47,7 +48,8 @@ export default class Copilot {
                 throw new Error(`Failed to send request to copilot: ${e}`);
             }
             messages.push(new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, rawAnswer));
-            logger.info(`Copilot: \n`, rawAnswer);
+            logger.debug(`Copilot: \n`, rawAnswer);
+            logger.debug(`Copilot: ${rawAnswer.split('\n')[0]}...`);
             answer += rawAnswer;
             return answer.trim().endsWith(this.endMark);
         };

--- a/src/copilot/Copilot.ts
+++ b/src/copilot/Copilot.ts
@@ -49,7 +49,7 @@ export default class Copilot {
             }
             messages.push(new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, rawAnswer));
             logger.debug(`Copilot: \n`, rawAnswer);
-            logger.debug(`Copilot: ${rawAnswer.split('\n')[0]}...`);
+            logger.info(`Copilot: ${rawAnswer.split('\n')[0]}...`);
             answer += rawAnswer;
             return answer.trim().endsWith(this.endMark);
         };

--- a/src/copilot/inspect/DocumentRenderer.ts
+++ b/src/copilot/inspect/DocumentRenderer.ts
@@ -104,7 +104,11 @@ export class DocumentRenderer {
         if (settings.length === 0) {
             settings.push('diagnostics');
             settings.push('rulerhighlights');
-            settings.push(isCodeLensDisabled() ? 'guttericons' : 'codelenses');
+            const disabled = isCodeLensDisabled();
+            if (disabled) {
+                logger.warn('CodeLens is disabled, fallback to GutterIcons');
+            }
+            settings.push(disabled ? 'guttericons' : 'codelenses');
         }
         return settings;
     }

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -220,8 +220,8 @@ export default class InspectionCopilot extends Copilot {
         const adjustedRange = new Range(new Position(range.start.line, 0), new Position(range.end.line, document.lineAt(range.end.line).text.length));
         const content: string = document.getText(adjustedRange);
         const startLine = range.start.line;
-        const context = await this.collectProjectContext(document);
-        const inspections = await this.inspectCode(content, context);
+        const projectContext = await this.collectProjectContext(document);
+        const inspections = await this.inspectCode(content, projectContext);
         inspections.forEach(s => {
             s.document = document;
             // real line index to the start of the document

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { scheduleAction } from "./utils/scheduler";
 import { showWelcomeWebview, WelcomeViewSerializer } from "./welcome";
 import { activateCopilotInspection } from "./copilot/inspect";
 import { ProjectSettingsViewSerializer } from "./project-settings/projectSettingsView";
+import { isLlmApiReady } from "./copilot/utils";
 
 let cleanJavaWorkspaceIndicator: string;
 let activatedTimestamp: number;
@@ -47,7 +48,7 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
   initDaemon(context);
 
   activatedTimestamp = performance.now();
-  if(context.storageUri) {
+  if (context.storageUri) {
     const javaWorkspaceStoragePath = path.join(context.storageUri.fsPath, "..", "redhat.java");
     cleanJavaWorkspaceIndicator = path.join(javaWorkspaceStoragePath, "jdt_ws", ".cleanWorkspace");
   }
@@ -83,7 +84,9 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
     });
   }
 
-  activateCopilotInspection(context);
+  if (isLlmApiReady()) {
+    activateCopilotInspection(context);
+  }
 }
 
 async function presentFirstView(context: vscode.ExtensionContext) {


### PR DESCRIPTION
1. only activate the copilot related feature on 1.90.0-insider or later.
2. simplify messages/logs.
3. show error message on command failures.
4. retry when failed to getting java settings (if inspect before project loaded)
5. checking extension installed using event instead of polling.