### PR TITLE
calculate snapshot id of symbol at reading to prevent unexpected behavior if modifying at inspecting

### DIFF
--- a/src/copilot/Copilot.ts
+++ b/src/copilot/Copilot.ts
@@ -10,6 +10,7 @@ export default class Copilot {
     public static readonly NOT_CANCELLABEL: CancellationToken = { isCancellationRequested: false, onCancellationRequested: () => Disposable.from() };
 
     public constructor(
+        private readonly systemMessagesOrSamples: LanguageModelChatMessage[],
         private readonly modelSelector: LanguageModelChatSelector = Copilot.DEFAULT_MODEL,
         private readonly modelOptions: LanguageModelChatRequestOptions = Copilot.DEFAULT_MODEL_OPTIONS,
         private readonly maxRounds: number = Copilot.DEFAULT_MAX_ROUNDS,
@@ -18,14 +19,13 @@ export default class Copilot {
     }
 
     private async doSend(
-        systemMessagesOrSamples: LanguageModelChatMessage[],
         userMessage: string,
         modelOptions: LanguageModelChatRequestOptions = Copilot.DEFAULT_MODEL_OPTIONS,
         cancellationToken: CancellationToken = Copilot.NOT_CANCELLABEL
     ): Promise<string> {
         let answer: string = '';
         let rounds: number = 0;
-        const messages = [...systemMessagesOrSamples];
+        const messages = [...this.systemMessagesOrSamples];
         const _send = async (message: string): Promise<boolean> => {
             rounds++;
             logger.debug(`User: \n`, message);
@@ -37,7 +37,8 @@ export default class Copilot {
             try {
                 const model = (await lm.selectChatModels(this.modelSelector))?.[0];
                 if (!model) {
-                    throw new Error('No model selected');
+                    const models = await lm.selectChatModels();
+                    throw new Error(`No model selected, available models: [${models.map(m => m.name).join(', ')}]`);
                 }
                 const response = await model.sendRequest(messages, modelOptions ?? this.modelOptions, cancellationToken);
                 for await (const item of response.text) {
@@ -65,11 +66,10 @@ export default class Copilot {
     }
 
     public async send(
-        systemMessagesOrSamples: LanguageModelChatMessage[],
         userMessage: string,
         modelOptions: LanguageModelChatRequestOptions = Copilot.DEFAULT_MODEL_OPTIONS,
         cancellationToken: CancellationToken = Copilot.NOT_CANCELLABEL
     ): Promise<string> {
-        return fixedInstrumentSimpleOperation("java.copilot.sendRequest", this.doSend.bind(this))(systemMessagesOrSamples, userMessage, modelOptions, cancellationToken);
+        return fixedInstrumentSimpleOperation("java.copilot.sendRequest", this.doSend.bind(this))(userMessage, modelOptions, cancellationToken);
     }
 }

--- a/src/copilot/Copilot.ts
+++ b/src/copilot/Copilot.ts
@@ -1,6 +1,6 @@
 import { LanguageModelChatMessage, lm, Disposable, CancellationToken, LanguageModelChatRequestOptions, LanguageModelChatMessageRole, LanguageModelChatSelector } from "vscode";
-import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
-import { logger } from "./utils";
+import { fixedInstrumentSimpleOperation, logger } from "./utils";
+import { sendInfo } from "vscode-extension-telemetry-wrapper";
 
 export default class Copilot {
     public static readonly DEFAULT_END_MARK = '<|endofresponse|>';
@@ -44,8 +44,10 @@ export default class Copilot {
                     rawAnswer += item;
                 }
             } catch (e) {
-                logger.error(`Failed to send request to copilot`, e);
-                throw new Error(`Failed to send request to copilot: ${e}`);
+                //@ts-ignore
+                const cause = e.cause || e;
+                logger.error(`Failed to send request to copilot`, cause);
+                throw new Error(`Failed to send request to copilot: ${cause}`);
             }
             messages.push(new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, rawAnswer));
             logger.debug(`Copilot: \n`, rawAnswer);
@@ -68,6 +70,6 @@ export default class Copilot {
         modelOptions: LanguageModelChatRequestOptions = Copilot.DEFAULT_MODEL_OPTIONS,
         cancellationToken: CancellationToken = Copilot.NOT_CANCELLABEL
     ): Promise<string> {
-        return instrumentSimpleOperation("java.copilot.sendRequest", this.doSend.bind(this))(systemMessagesOrSamples, userMessage, modelOptions, cancellationToken);
+        return fixedInstrumentSimpleOperation("java.copilot.sendRequest", this.doSend.bind(this))(systemMessagesOrSamples, userMessage, modelOptions, cancellationToken);
     }
 }

--- a/src/copilot/Copilot.ts
+++ b/src/copilot/Copilot.ts
@@ -47,7 +47,7 @@ export default class Copilot {
                 //@ts-ignore
                 const cause = e.cause || e;
                 logger.error(`Failed to chat with copilot`, cause);
-                throw new Error(`Failed to chat with copilot: ${cause}`);
+                throw cause;
             }
             messages.push(new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, rawAnswer));
             logger.debug(`Copilot: \n`, rawAnswer);

--- a/src/copilot/Copilot.ts
+++ b/src/copilot/Copilot.ts
@@ -46,8 +46,8 @@ export default class Copilot {
             } catch (e) {
                 //@ts-ignore
                 const cause = e.cause || e;
-                logger.error(`Failed to send request to copilot`, cause);
-                throw new Error(`Failed to send request to copilot: ${cause}`);
+                logger.error(`Failed to chat with copilot`, cause);
+                throw new Error(`Failed to chat with copilot: ${cause}`);
             }
             messages.push(new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, rawAnswer));
             logger.debug(`Copilot: \n`, rawAnswer);

--- a/src/copilot/Copilot.ts
+++ b/src/copilot/Copilot.ts
@@ -38,7 +38,7 @@ export default class Copilot {
                 const model = (await lm.selectChatModels(this.modelSelector))?.[0];
                 if (!model) {
                     const models = await lm.selectChatModels();
-                    throw new Error(`No model selected, available models: [${models.map(m => m.name).join(', ')}]`);
+                    throw new Error(`No suitable model, available models: [${models.map(m => m.name).join(', ')}]. Please make sure you have installed the latest "GitHub Copilot Chat" (v0.16.0 or later).`);
                 }
                 const response = await model.sendRequest(messages, modelOptions ?? this.modelOptions, cancellationToken);
                 for await (const item of response.text) {

--- a/src/copilot/inspect/InspectActionCodeLensProvider.ts
+++ b/src/copilot/inspect/InspectActionCodeLensProvider.ts
@@ -22,7 +22,7 @@ export class InspectActionCodeLensProvider implements CodeLensProvider {
         const topLevelCodeLenses: CodeLens[] = [];
         const classes = await getTopLevelClassesOfDocument(document);
         classes.map(clazz => new CodeLens(clazz.range, {
-            title: "Rewrite with new Java syntax",
+            title: "✨ Rewrite with new Java syntax",
             command: COMMAND_INSPECT_CLASS,
             arguments: [document, clazz]
         })).forEach(codeLens => topLevelCodeLenses.push(codeLens));

--- a/src/copilot/inspect/Inspection.ts
+++ b/src/copilot/inspect/Inspection.ts
@@ -39,7 +39,7 @@ export namespace Inspection {
     export function revealFirstLineOfInspection(inspection: Inspection) {
         inspection.document && void workspace.openTextDocument(inspection.document.uri).then(document => {
             void window.showTextDocument(document).then(editor => {
-                const range = document.lineAt(inspection.problem.position.line).range;
+                const range = getIndicatorRangeOfInspection(inspection.problem);
                 editor.selection = new Selection(range.start, range.end);
                 editor.revealRange(range);
             });

--- a/src/copilot/inspect/InspectionCache.ts
+++ b/src/copilot/inspect/InspectionCache.ts
@@ -5,9 +5,9 @@ import { SymbolNode } from './SymbolNode';
 
 /**
  * A map based cache for inspections of a document.
- * format: `Map<documentKey, Map<symbolQualifiedName, [symbolVersionId, Inspection[]]`
+ * format: `Map<documentKey, Map<symbolQualifiedName, [symbolSnapshotId, Inspection[]]`
  */
-const DOC_SYMBOL_VERSION_INSPECTIONS: Map<string, Map<string, [string, Inspection[]]>> = new Map();
+const DOC_SYMBOL_SNAPSHOT_INSPECTIONS: Map<string, Map<string, [string, Inspection[]]>> = new Map();
 
 export default class InspectionCache {
     /**
@@ -17,14 +17,14 @@ export default class InspectionCache {
     public static async hasCache(document: TextDocument, symbol?: SymbolNode): Promise<boolean> {
         const documentKey = document.uri.fsPath;
         if (!symbol) {
-            return DOC_SYMBOL_VERSION_INSPECTIONS.has(documentKey);
+            return DOC_SYMBOL_SNAPSHOT_INSPECTIONS.has(documentKey);
         }
-        const symbolInspections = DOC_SYMBOL_VERSION_INSPECTIONS.get(documentKey);
+        const symbolInspections = DOC_SYMBOL_SNAPSHOT_INSPECTIONS.get(documentKey);
         // check if the symbol or its contained symbols are cached
         const symbols = await getClassesAndMethodsContainedInRange(symbol.range, document);
         for (const s of symbols) {
-            const versionInspections = symbolInspections?.get(s.qualifiedName);
-            if (versionInspections?.[0] === s.versionId) {
+            const snapshotInspections = symbolInspections?.get(s.qualifiedName);
+            if (snapshotInspections?.[0] === s.snapshotId) {
                 return true;
             }
         }
@@ -52,11 +52,11 @@ export default class InspectionCache {
      */
     public static getCachedInspectionsOfSymbol(document: TextDocument, symbol: SymbolNode): Inspection[] {
         const documentKey = document.uri.fsPath;
-        const symbolInspections = DOC_SYMBOL_VERSION_INSPECTIONS.get(documentKey);
-        const versionInspections = symbolInspections?.get(symbol.qualifiedName);
-        if (versionInspections?.[0] === symbol.versionId) {
+        const symbolInspections = DOC_SYMBOL_SNAPSHOT_INSPECTIONS.get(documentKey);
+        const snapshotInspections = symbolInspections?.get(symbol.qualifiedName);
+        if (snapshotInspections?.[0] === symbol.snapshotId) {
             logger.debug(`cache hit for ${SymbolKind[symbol.kind]} ${symbol.qualifiedName} of ${document.uri.fsPath}`);
-            const inspections = versionInspections[1];
+            const inspections = snapshotInspections[1];
             inspections.forEach(s => {
                 s.document = document;
                 s.problem.position.line = s.problem.position.relativeLine + symbol.range.start.line;
@@ -90,13 +90,13 @@ export default class InspectionCache {
      */
     public static invalidateInspectionCache(document?: TextDocument, symbol?: SymbolNode, inspeciton?: Inspection): void {
         if (!document) {
-            DOC_SYMBOL_VERSION_INSPECTIONS.clear();
+            DOC_SYMBOL_SNAPSHOT_INSPECTIONS.clear();
         } else if (!symbol) {
             const documentKey = document.uri.fsPath;
-            DOC_SYMBOL_VERSION_INSPECTIONS.delete(documentKey);
+            DOC_SYMBOL_SNAPSHOT_INSPECTIONS.delete(documentKey);
         } else if (!inspeciton) {
             const documentKey = document.uri.fsPath;
-            const symbolInspections = DOC_SYMBOL_VERSION_INSPECTIONS.get(documentKey);
+            const symbolInspections = DOC_SYMBOL_SNAPSHOT_INSPECTIONS.get(documentKey);
             // remove the cached inspections of the symbol
             symbolInspections?.delete(symbol.qualifiedName);
             // remove the cached inspections of contained symbols
@@ -107,10 +107,10 @@ export default class InspectionCache {
             });
         } else {
             const documentKey = document.uri.fsPath;
-            const symbolInspections = DOC_SYMBOL_VERSION_INSPECTIONS.get(documentKey);
-            const versionInspections = symbolInspections?.get(symbol.qualifiedName);
-            if (versionInspections?.[0] === symbol.versionId) {
-                const inspections = versionInspections[1];
+            const symbolInspections = DOC_SYMBOL_SNAPSHOT_INSPECTIONS.get(documentKey);
+            const snapshotInspections = symbolInspections?.get(symbol.qualifiedName);
+            if (snapshotInspections?.[0] === symbol.snapshotId) {
+                const inspections = snapshotInspections[1];
                 // remove the inspection
                 inspections.splice(inspections.indexOf(inspeciton), 1);
             }
@@ -120,13 +120,13 @@ export default class InspectionCache {
     private static cacheSymbolInspections(document: TextDocument, symbol: SymbolNode, inspections: Inspection[]): void {
         logger.debug(`cache ${inspections.length} inspections for ${SymbolKind[symbol.kind]} ${symbol.qualifiedName} of ${document.uri.fsPath}`);
         const documentKey = document.uri.fsPath;
-        const cachedSymbolInspections = DOC_SYMBOL_VERSION_INSPECTIONS.get(documentKey) ?? new Map();
+        const cachedSymbolInspections = DOC_SYMBOL_SNAPSHOT_INSPECTIONS.get(documentKey) ?? new Map();
         inspections.forEach(s => {
             s.document = document;
             s.symbol = symbol;
         });
         // use qualified name to prevent conflicts between symbols with the same signature in same document
-        cachedSymbolInspections.set(symbol.qualifiedName, [symbol.versionId, inspections]);
-        DOC_SYMBOL_VERSION_INSPECTIONS.set(documentKey, cachedSymbolInspections);
+        cachedSymbolInspections.set(symbol.qualifiedName, [symbol.snapshotId, inspections]);
+        DOC_SYMBOL_SNAPSHOT_INSPECTIONS.set(documentKey, cachedSymbolInspections);
     }
 }

--- a/src/copilot/inspect/InspectionCache.ts
+++ b/src/copilot/inspect/InspectionCache.ts
@@ -25,7 +25,7 @@ export default class InspectionCache {
         for (const s of symbols) {
             const snapshotInspections = symbolInspections?.get(s.qualifiedName);
             if (snapshotInspections?.[0] === s.snapshotId) {
-                return true;
+                return snapshotInspections[1].length > 0;
             }
         }
         return false;

--- a/src/copilot/inspect/InspectionCache.ts
+++ b/src/copilot/inspect/InspectionCache.ts
@@ -1,5 +1,5 @@
 import { SymbolKind, TextDocument } from 'vscode';
-import { METHOD_KINDS, getClassesAndMethodsContainedInRange, getClassesAndMethodsOfDocument, logger } from '../utils';
+import { METHOD_KINDS, getSymbolsContainedInRange, getSymbolsOfDocument, logger } from '../utils';
 import { Inspection } from './Inspection';
 import { SymbolNode } from './SymbolNode';
 
@@ -21,7 +21,7 @@ export default class InspectionCache {
         }
         const symbolInspections = DOC_SYMBOL_SNAPSHOT_INSPECTIONS.get(documentKey);
         // check if the symbol or its contained symbols are cached
-        const symbols = await getClassesAndMethodsContainedInRange(symbol.range, document);
+        const symbols = await getSymbolsContainedInRange(symbol.range, document);
         for (const s of symbols) {
             const snapshotInspections = symbolInspections?.get(s.qualifiedName);
             if (snapshotInspections?.[0] === s.snapshotId) {
@@ -37,7 +37,7 @@ export default class InspectionCache {
      * their content has changed.
      */
     public static async getCachedInspectionsOfDoc(document: TextDocument): Promise<Inspection[]> {
-        const symbols: SymbolNode[] = await getClassesAndMethodsOfDocument(document);
+        const symbols: SymbolNode[] = await getSymbolsOfDocument(document);
         const inspections: Inspection[] = [];
         // we don't get cached inspections directly from the cache, because we need to filter out outdated symbols
         for (const symbol of symbols) {
@@ -75,7 +75,7 @@ export default class InspectionCache {
                 return isMethod ?
                     // NOTE: method inspections are inspections whose `position.line` is within the method's range
                     inspectionLine >= symbol.range.start.line && inspectionLine <= symbol.range.end.line :
-                    // NOTE: class inspections are inspections whose `position.line` is exactly the first line number of the class
+                    // NOTE: class/field inspections are inspections whose `position.line` is exactly the first line number of the class/field
                     inspectionLine === symbol.range.start.line;
             });
             // re-calculate `relativeLine` of method inspections, `relativeLine` is the relative line number to the start of the method

--- a/src/copilot/inspect/InspectionCache.ts
+++ b/src/copilot/inspect/InspectionCache.ts
@@ -24,8 +24,8 @@ export default class InspectionCache {
         const symbols = await getSymbolsContainedInRange(symbol.range, document);
         for (const s of symbols) {
             const snapshotInspections = symbolInspections?.get(s.qualifiedName);
-            if (snapshotInspections?.[0] === s.snapshotId) {
-                return snapshotInspections[1].length > 0;
+            if (snapshotInspections?.[0] === s.snapshotId && snapshotInspections[1].length > 0) {
+                return true;
             }
         }
         return false;

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -14,15 +14,16 @@ export default class InspectionCopilot extends Copilot {
     ${code}
     `;
     public static readonly SYSTEM_MESSAGE = `
-    Your role is to identify and suggest improvements for Java code blocks that can be optimized using newer features of Java. Keep the following guidelines in mind:
+    **You are expert at Java and promoting newer built-in features of Java.**
+    Your identify and suggest improvements for Java code blocks that can be optimized using newer features of Java. Keep the following guidelines in mind:
     - Focus on utilizing built-in features from recent Java versions (Java 8 and onwards) to make the code more readable, efficient, and concise.
     - Do not suggest the use of third-party libraries or frameworks.
     - Comment directly on the code that can be improved. Use the following format for comments:
     \`\`\`
     other code...
-    // @PROBLEM: Briefly describe the issue in the code, preferably in less than 10 words. Start your comment with a gerund/noun word, e.g., "Using".
-    // @SOLUTION: Suggest a solution to the problem in less than 10 words. Start your solution with a verb.
-    // @INDICATOR: Identify the problematic code block with a single word contained in the block. It could be a Java keyword, a method/field/variable name, or a value (e.g., magic number). Use '<null>' if an indicator cannot be identified.
+    // @PROBLEM: Briefly describe the issue in the code, preferably in less than 10 words. Start with a gerund/noun word, e.g., "Using".
+    // @SOLUTION: Suggest a solution to the problem in less than 10 words. Start with a verb.
+    // @INDICATOR: Identify the problematic code block with a single word contained in the block. It could be a Java keyword, a method/field/variable name, or a value (e.g., magic number). Use '<null>' if cannot be identified.
     // @SEVERITY: Rate the severity of the problem as either HIGH, MIDDLE, or LOW.
     the original code that can be improved...
     \`\`\`
@@ -32,7 +33,7 @@ export default class InspectionCopilot extends Copilot {
     - Do not comment on code that is well-written or simple enough to understand.
     - Do not add any explanations, do not format the output, and do not output markdown.
     - Conclude your response with "//${Copilot.DEFAULT_END_MARK}".
-    Remember, your aim is to enhance the code using compatible new features from used Java versions.
+    Remember, your aim is to enhance the code, and promote the use of newer built-in Java features at the same time!
     `;
     public static readonly EXAMPLE_USER_MESSAGE = this.FORMAT_CODE({ javaVersion: '17' }, `
     @Entity

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -12,9 +12,9 @@ import { randomUUID } from "crypto";
 export default class InspectionCopilot extends Copilot {
 
     public static readonly SYSTEM_MESSAGE = (context: ProjectContext) => `
-    You are expert at Java and code refactoring. Please identify code blocks that can be rewritten with
-    new features/syntaxes/grammar sugar of Java ${context.javaVersion} and earlier versions to make them more **readable**,
-    **efficient** and **concise** for given code.
+    You are expert at Java and familiar with all newly added syntaxes/grammar sugars of each version. Please identify code blocks 
+    that can be rewritten with new syntaxes/grammar sugar of Java ${context.javaVersion} and earlier versions to make them more 
+    **readable**, **efficient** and **concise** for given code.
     I prefer \`Stream\` to loop, \`Optional\` to null, \`record\` to POJO, \`switch\` to if-else, etc.
     Please comment on the rewritable code directly in the original source code in the following format:
     \`\`\`
@@ -29,7 +29,7 @@ export default class InspectionCopilot extends Copilot {
     Your reply must be the complete original code sent to you plus your comments, without any other modifications.
     Never comment on undertermined problems.
     Never comment on code that is well-written or simple enough.
-    Don't add any explanation, don't format logger. Don't output markdown.
+    Don't add any explanation, don't format output. Don't output markdown.
     You must end your response with "//${Copilot.DEFAULT_END_MARK}".
     `;
     public static readonly EXAMPLE_USER_MESSAGE = `
@@ -49,13 +49,6 @@ export default class InspectionCopilot extends Copilot {
                 result = "FTE";
             }
             return result;
-        }
-        public void test(String[] arr) {
-            try {
-                Integer.parseInt(arr[0]);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
         }
     }
     `;
@@ -84,17 +77,6 @@ export default class InspectionCopilot extends Copilot {
                 result = "FTE";
             }
             return result;
-        }
-        public void test(String[] arr) {
-            try {
-                Integer.parseInt(arr[0]);
-            } catch (Exception e) {
-                // @PROBLEM: Print stack trace in case of an exception
-                // @SOLUTION: Log errors to a logger
-                // @INDICATOR: ex.printStackTrace
-                // @SEVERITY: LOW
-                e.printStackTrace();
-            }
         }
     }
     //${Copilot.DEFAULT_END_MARK}

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -12,20 +12,25 @@ import { randomUUID } from "crypto";
 export default class InspectionCopilot extends Copilot {
 
     public static readonly SYSTEM_MESSAGE = (context: ProjectContext) => `
-    You are expert at Java and familiar with all newly added syntaxes/grammar sugars of each version. Please identify code blocks 
-    that can be rewritten with new syntaxes/grammar sugar of Java ${context.javaVersion} and earlier versions to make them more 
-    **readable**, **efficient** and **concise** for given code.
-    I prefer \`Stream\` to loop, \`Optional\` to null, \`record\` to POJO, \`switch\` to if-else, etc.
+    **You are expert at Java and promoting new features of Java.**
+    Each Java version has added some new language features or syntaxes to make the code **more readable, efficient, and concise**. e.g. 
+    Java 8 added lambda expressions, Stream, Optional API, and also a set of functional style APIs for collections...;
+    Java 9 added new operation for Collections, Stream, and Optional APIs. and also brought a new HTTPClient...;
+    Java 10 introduced var type inference, and also added some new APIs for Collections...;
+    Java 11 - 21 added..., etc.
+    Please identify code blocks that can be rewritten with these new features of Java itself for given code.
+    Dont't suggest using third-party libraries or frameworks, only suggest using the new features of Java itself.
+    Becareful that current project uses Java ${context.javaVersion}, and the solution you provide **must** be compatible with this version.
     Please comment on the rewritable code directly in the original source code in the following format:
     \`\`\`
     other code...
     // @PROBLEM: problem of the code in less than 10 words, should be as short as possible, starts with a gerund/noun word, e.g., "Using".
     // @SOLUTION: solution to fix the problem in less than 10 words, should be as short as possible, starts with a verb.
-    // @INDICATOR: indicator of the problematic code block, must be a single word contained by the problematic code. it's usually a Java keyword, a method/field/variable name, or a value(e.g. magic number)... but NOT multiple, '<null>' if cannot be identified
+    // @INDICATOR: indicator of the rewriteable code block, must be a single word contained by the rewriteable code. it's usually a Java keyword, a method/field/variable name, or a value(e.g. magic number)... but NOT multiple, '<null>' if cannot be identified
     // @SEVERITY: severity of the problem, must be one of **[HIGH, MIDDLE, LOW]**
-    the original problematic code...
+    the original rewriteable code...
     \`\`\`
-    The comment must be placed directly above the problematic code, and the problematic code must be kept unchanged.
+    The comment must be placed directly above the rewriteable code, and the rewriteable code must be kept unchanged.
     Your reply must be the complete original code sent to you plus your comments, without any other modifications.
     Never comment on undertermined problems.
     Never comment on code that is well-written or simple enough.

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -151,9 +151,10 @@ export default class InspectionCopilot extends Copilot {
             // inspect the expanded union range
             const symbolName = symbols[0].symbol.name;
             const symbolKind = SymbolKind[symbols[0].kind].toLowerCase();
+            const target = symbols.length > 1 ? `${symbolKind} ${symbolName}, etc.` : `${symbolKind} ${symbolName}`;
             const inspections = await window.withProgress({
                 location: ProgressLocation.Notification,
-                title: `Inspecting ${symbolKind} ${symbolName}...`,
+                title: `Inspecting ${target}...`,
                 cancellable: false
             }, (_progress) => {
                 return this.doInspectRange(document, expandedRange);
@@ -161,14 +162,14 @@ export default class InspectionCopilot extends Copilot {
 
             // show message based on the number of inspections
             if (inspections.length < 1) {
-                void window.showInformationMessage(`Inspected ${symbolKind} ${symbolName}, etc. and got 0 suggestions.`);
+                void window.showInformationMessage(`Inspected ${target}, and got 0 suggestions.`);
             } else if (inspections.length == 1) {
                 // apply the only suggestion automatically
                 void commands.executeCommand(COMMAND_FIX_INSPECTION, inspections[0], 'auto');
             } else {
                 // show message to go to the first suggestion
                 // inspected a, ..., etc. and got n suggestions.
-                void window.showInformationMessage(`Inspected ${symbolKind} ${symbolName}, etc. and got ${inspections.length} suggestions.`, "Go to").then(selection => {
+                void window.showInformationMessage(`Inspected ${target}, and got ${inspections.length} suggestions.`, "Go to").then(selection => {
                     selection === "Go to" && void Inspection.revealFirstLineOfInspection(inspections[0]);
                 });
             }
@@ -344,9 +345,9 @@ export default class InspectionCopilot extends Copilot {
     }
 
     async collectProjectContext(document: TextDocument): Promise<ProjectContext> {
-        logger.info('colleteting project context info (java version)...');  
+        logger.info('colleteting project context info (java version)...');
         const javaVersion = await getProjectJavaVersion(document);
-        logger.info('project java version:', javaVersion);  
+        logger.info('project java version:', javaVersion);
         return { javaVersion };
     }
 }

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -1,4 +1,4 @@
-import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
+import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import Copilot from "../Copilot";
 import { fixedInstrumentSimpleOperation, getClassesContainedInRange, getInnermostClassContainsRange, getIntersectionMethodsOfRange, getProjectJavaVersion, getUnionRange, logger } from "../utils";
 import { Inspection } from "./Inspection";
@@ -22,7 +22,7 @@ export default class InspectionCopilot extends Copilot {
     // @PROBLEM: problem of the code in less than 10 words, should be as short as possible, starts with a gerund/noun word, e.g., "Using".
     // @SOLUTION: solution to fix the problem in less than 10 words, should be as short as possible, starts with a verb.
     // @INDICATOR: indicator of the problematic code block, must be a single word contained by the problematic code. it's usually a Java keyword, a method/field/variable name, or a value(e.g. magic number)... but NOT multiple, '<null>' if cannot be identified
-    // @SEVERITY: severity of the problem, must be one of **[HIGH, MIDDLE, LOW]**, *HIGH* for Probable bugs, Security risks, Exception handling or Resource management(e.g. memory leaks); *MIDDLE* for Error handling, Performance, Reflective accesses issues and Verbose or redundant code; *LOW* for others
+    // @SEVERITY: severity of the problem, must be one of **[HIGH, MIDDLE, LOW]**
     the original problematic code...
     \`\`\`
     The comment must be placed directly above the problematic code, and the problematic code must be kept unchanged.
@@ -162,7 +162,7 @@ export default class InspectionCopilot extends Copilot {
             const symbolKind = SymbolKind[symbols[0].kind].toLowerCase();
             const inspections = await window.withProgress({
                 location: ProgressLocation.Notification,
-                title: `Inspecting ${symbolKind} ${symbolName}... of "${path.basename(document.fileName)}"`,
+                title: `Inspecting ${symbolKind} ${symbolName}...`,
                 cancellable: false
             }, (_progress) => {
                 return this.doInspectRange(document, expandedRange);
@@ -173,7 +173,7 @@ export default class InspectionCopilot extends Copilot {
                 void window.showInformationMessage(`Inspected ${symbolKind} ${symbolName}... of "${path.basename(document.fileName)}" and got 0 suggestions.`);
             } else if (inspections.length == 1) {
                 // apply the only suggestion automatically
-                void commands.executeCommand(COMMAND_FIX_INSPECTION, inspections[0].problem, inspections[0].solution, 'auto');
+                void commands.executeCommand(COMMAND_FIX_INSPECTION, inspections[0], 'auto');
             } else {
                 // show message to go to the first suggestion
                 void window.showInformationMessage(`Inspected ${symbolKind} ${symbolName}... of "${path.basename(document.fileName)}" and got ${inspections.length} suggestions.`, "Go to").then(selection => {

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -344,11 +344,13 @@ export default class InspectionCopilot extends Copilot {
     }
 
     async collectProjectContext(document: TextDocument): Promise<ProjectContext> {
+        logger.info('colleteting project context info (java version)...');  
         const javaVersion = await getProjectJavaVersion(document);
+        logger.info('project java version:', javaVersion);  
         return { javaVersion };
     }
 }
 
 export interface ProjectContext {
-    javaVersion: number;
+    javaVersion: string;
 }

--- a/src/copilot/inspect/InspectionCopilot.ts
+++ b/src/copilot/inspect/InspectionCopilot.ts
@@ -1,6 +1,6 @@
 import { instrumentSimpleOperation, sendInfo } from "vscode-extension-telemetry-wrapper";
 import Copilot from "../Copilot";
-import { getClassesContainedInRange, getInnermostClassContainsRange, getIntersectionMethodsOfRange, getProjectJavaVersion, getUnionRange, logger } from "../utils";
+import { fixedInstrumentSimpleOperation, getClassesContainedInRange, getInnermostClassContainsRange, getIntersectionMethodsOfRange, getProjectJavaVersion, getUnionRange, logger } from "../utils";
 import { Inspection } from "./Inspection";
 import path from "path";
 import { TextDocument, SymbolKind, ProgressLocation, commands, Position, Range, Selection, window, LanguageModelChatMessage } from "vscode";
@@ -197,7 +197,7 @@ export default class InspectionCopilot extends Copilot {
      * @returns inspections provided by copilot
      */
     public inspectCode(code: string, context: ProjectContext, key?: string, wait: number = 3000): Promise<Inspection[]> {
-        const _doInspectCode: (code: string, context: ProjectContext) => Promise<Inspection[]> = instrumentSimpleOperation("java.copilot.inspect.code", this.doInspectCode.bind(this));
+        const _doInspectCode: (code: string, context: ProjectContext) => Promise<Inspection[]> = fixedInstrumentSimpleOperation("java.copilot.inspect.code", this.doInspectCode.bind(this));
         if (!key) { // inspect code immediately without debounce
             return this.doInspectCode(code, context);
         }

--- a/src/copilot/inspect/SymbolNode.ts
+++ b/src/copilot/inspect/SymbolNode.ts
@@ -48,4 +48,8 @@ export class SymbolNode {
         const body = document.getText(symbol.range);
         return crypto.createHash('md5').update(body).digest("hex")
     }
+
+    public toString(): string {
+        return `${SymbolKind[this.kind]} ${this.qualifiedName}`;
+    }
 }

--- a/src/copilot/inspect/SymbolNode.ts
+++ b/src/copilot/inspect/SymbolNode.ts
@@ -1,4 +1,5 @@
-import { DocumentSymbol, SymbolKind, Range } from "vscode";
+import { DocumentSymbol, SymbolKind, Range, TextDocument } from "vscode";
+import * as crypto from "crypto";
 
 /**
  * A wrapper class for DocumentSymbol to provide additional functionalities:
@@ -6,10 +7,15 @@ import { DocumentSymbol, SymbolKind, Range } from "vscode";
  * - qualifiedName: the fully qualified name of the symbol
  */
 export class SymbolNode {
+    public readonly versionId: string;
+
     public constructor(
+        public readonly document: TextDocument,
         public readonly symbol: DocumentSymbol,
         public readonly parent?: SymbolNode
     ) {
+        // calculate the version id of the symbol immediately because the symbol content may change.
+        this.versionId = SymbolNode.calculateSymbolVersionId(document, symbol);
     }
 
     public get range(): Range {
@@ -32,6 +38,14 @@ export class SymbolNode {
     }
 
     public get children(): SymbolNode[] {
-        return this.symbol.children.map(symbol => new SymbolNode(symbol, this));
+        return this.symbol.children.map(symbol => new SymbolNode(this.document, symbol, this));
+    }
+
+    /**
+     * generate a unique id for the symbol based on its content, so that we can detect if the symbol has changed
+     */
+    private static calculateSymbolVersionId(document: TextDocument, symbol: DocumentSymbol): string {
+        const body = document.getText(symbol.range);
+        return crypto.createHash('md5').update(body).digest("hex")
     }
 }

--- a/src/copilot/inspect/SymbolNode.ts
+++ b/src/copilot/inspect/SymbolNode.ts
@@ -50,6 +50,6 @@ export class SymbolNode {
     }
 
     public toString(): string {
-        return `${SymbolKind[this.kind]} ${this.qualifiedName}`;
+        return `${SymbolKind[this.kind].toLowerCase()} ${this.symbol.name}`;
     }
 }

--- a/src/copilot/inspect/SymbolNode.ts
+++ b/src/copilot/inspect/SymbolNode.ts
@@ -7,15 +7,15 @@ import * as crypto from "crypto";
  * - qualifiedName: the fully qualified name of the symbol
  */
 export class SymbolNode {
-    public readonly versionId: string;
+    public readonly snapshotId: string;
 
     public constructor(
         public readonly document: TextDocument,
         public readonly symbol: DocumentSymbol,
         public readonly parent?: SymbolNode
     ) {
-        // calculate the version id of the symbol immediately because the symbol content may change.
-        this.versionId = SymbolNode.calculateSymbolVersionId(document, symbol);
+        // calculate the snapshot id of the symbol immediately because the symbol content may change.
+        this.snapshotId = SymbolNode.calculateSymbolSnapshotId(document, symbol);
     }
 
     public get range(): Range {
@@ -44,7 +44,7 @@ export class SymbolNode {
     /**
      * generate a unique id for the symbol based on its content, so that we can detect if the symbol has changed
      */
-    private static calculateSymbolVersionId(document: TextDocument, symbol: DocumentSymbol): string {
+    private static calculateSymbolSnapshotId(document: TextDocument, symbol: DocumentSymbol): string {
         const body = document.getText(symbol.range);
         return crypto.createHash('md5').update(body).digest("hex")
     }

--- a/src/copilot/inspect/commands.ts
+++ b/src/copilot/inspect/commands.ts
@@ -18,7 +18,7 @@ export function registerCommands(copilot: InspectionCopilot, renderer: DocumentR
         try {
             await copilot.inspectClass(document, clazz);
         } catch (e) {
-            window.showErrorMessage(`Failed to inspect class "${clazz.symbol.name}" with error ${e}.`);
+            window.showErrorMessage(`Failed to inspect class "${clazz.symbol.name}", ${e}.`);
             logger.error(`Failed to inspect class "${clazz.symbol.name}".`, e);
             throw e;
         }
@@ -29,7 +29,7 @@ export function registerCommands(copilot: InspectionCopilot, renderer: DocumentR
         try {
             await copilot.inspectRange(document, range);
         } catch (e) {
-            window.showErrorMessage(`Failed to inspect range of "${path.basename(document.fileName)}" with error ${e}.`);
+            window.showErrorMessage(`Failed to inspect range of "${path.basename(document.fileName)}", ${e}.`);
             logger.error(`Failed to inspect range of "${path.basename(document.fileName)}".`, e);
             throw e;
         }

--- a/src/copilot/inspect/commands.ts
+++ b/src/copilot/inspect/commands.ts
@@ -1,4 +1,4 @@
-import { TextDocument, Range, Selection, commands, window } from "vscode";
+import { TextDocument, Range, Selection, commands, window, Uri, env } from "vscode";
 import { instrumentOperationAsVsCodeCommand, sendInfo } from "vscode-extension-telemetry-wrapper";
 import InspectionCopilot from "./InspectionCopilot";
 import { Inspection, InspectionProblem } from "./Inspection";
@@ -13,12 +13,14 @@ export const COMMAND_INSPECT_RANGE = 'java.copilot.inspect.range';
 export const COMMAND_FIX_INSPECTION = 'java.copilot.inspection.fix';
 export const COMMAND_IGNORE_INSPECTIONS = 'java.copilot.inspection.ignore';
 
+const LEARN_MORE_RESPONSE_FILTERED = 'https://docs.github.com/en/copilot/configuring-github-copilot/configuring-github-copilot-settings-on-githubcom#enabling-or-disabling-duplication-detection';
+
 export function registerCommands(copilot: InspectionCopilot, renderer: DocumentRenderer) {
     instrumentOperationAsVsCodeCommand(COMMAND_INSPECT_CLASS, async (document: TextDocument, clazz: SymbolNode) => {
         try {
             await copilot.inspectClass(document, clazz);
         } catch (e) {
-            window.showErrorMessage(`Failed to inspect class "${clazz.symbol.name}", ${e}.`);
+            showErrorMessage(e, document, clazz);
             logger.error(`Failed to inspect class "${clazz.symbol.name}".`, e);
             throw e;
         }
@@ -29,7 +31,7 @@ export function registerCommands(copilot: InspectionCopilot, renderer: DocumentR
         try {
             await copilot.inspectRange(document, range);
         } catch (e) {
-            window.showErrorMessage(`Failed to inspect range of "${path.basename(document.fileName)}", ${e}.`);
+            showErrorMessage(e, document, range);
             logger.error(`Failed to inspect range of "${path.basename(document.fileName)}".`, e);
             throw e;
         }
@@ -55,5 +57,22 @@ export function registerCommands(copilot: InspectionCopilot, renderer: DocumentR
         }
         InspectionCache.invalidateInspectionCache(document, symbol, inspection);
         renderer.rerender(document);
+    });
+}
+
+function showErrorMessage(e: unknown, document: TextDocument, target: SymbolNode | Range) {
+    let message = target instanceof Range ?
+        `Failed to inspect range of "${path.basename(document.fileName)}", ${e}` :
+        `Failed to inspect class "${target.symbol.name}", ${e}`;
+
+    const actions = new Map<string, () => void>();
+    if (e instanceof Error && e.message.toLowerCase().includes('response got filtered')) {
+        actions.set('Learn more', () => env.openExternal(Uri.parse(LEARN_MORE_RESPONSE_FILTERED)));
+        message += ', possibly because it matches existing public code';
+    }
+    window.showErrorMessage(`${message}.`, ...actions.keys()).then(choice => {
+        if (choice) {
+            actions.get(choice)!();
+        }
     });
 }

--- a/src/copilot/inspect/commands.ts
+++ b/src/copilot/inspect/commands.ts
@@ -43,9 +43,9 @@ export function registerCommands(copilot: InspectionCopilot, renderer: DocumentR
         void commands.executeCommand('vscode.editorChat.start', {
             autoSend: true,
             message: `/fix ${problem.description}, maybe ${uncapitalize(solution)}`,
-            position: range.start,
-            initialSelection: new Selection(range.start, range.end),
-            initialRange: range
+            position: range?.start,
+            initialSelection: new Selection(range!.start, range!.start),
+            initialRange: new Range(range!.start, range!.start)
         });
     });
 

--- a/src/copilot/inspect/render/DiagnosticRenderer.ts
+++ b/src/copilot/inspect/render/DiagnosticRenderer.ts
@@ -71,6 +71,7 @@ export async function fixDiagnostic(document: TextDocument, _range: Range | Sele
             title: inspection.solution,
             diagnostics: [diagnostic],
             kind: CodeActionKind.RefactorRewrite,
+            isPreferred: true,
             command: {
                 title: diagnostic.message,
                 command: COMMAND_FIX_INSPECTION,
@@ -78,17 +79,6 @@ export async function fixDiagnostic(document: TextDocument, _range: Range | Sele
             }
         };
         actions.push(fixAction);
-        const ignoreAction: CodeAction = {
-            title: `Ignore "${uncapitalize(inspection.problem.description)}"`,
-            diagnostics: [diagnostic],
-            kind: CodeActionKind.RefactorRewrite,
-            command: {
-                title: `Ignore "${uncapitalize(inspection.problem.description)}"`,
-                command: COMMAND_IGNORE_INSPECTIONS,
-                arguments: [document, inspection.symbol, inspection]
-            }
-        };
-        actions.push(ignoreAction);
     }
     return actions;
 }

--- a/src/copilot/inspect/render/DiagnosticRenderer.ts
+++ b/src/copilot/inspect/render/DiagnosticRenderer.ts
@@ -2,8 +2,8 @@
 import { CancellationToken, CodeAction, CodeActionContext, CodeActionKind, Diagnostic, DiagnosticCollection, DiagnosticSeverity, ExtensionContext, Range, Selection, TextDocument, languages } from "vscode";
 import { Inspection } from "../Inspection";
 import { InspectionRenderer } from "./InspectionRenderer";
-import { logger, uncapitalize } from "../../../copilot/utils";
-import { COMMAND_IGNORE_INSPECTIONS, COMMAND_FIX_INSPECTION } from "../commands";
+import { logger } from "../../../copilot/utils";
+import { COMMAND_FIX_INSPECTION } from "../commands";
 import _ from "lodash";
 
 const DIAGNOSTICS_GROUP = 'java.copilot.inspection.diagnostics';

--- a/src/copilot/utils.ts
+++ b/src/copilot/utils.ts
@@ -1,4 +1,4 @@
-import { LogOutputChannel, SymbolKind, TextDocument, commands, window, Range, Selection, workspace, DocumentSymbol, ProgressLocation, version } from "vscode";
+import { LogOutputChannel, SymbolKind, TextDocument, commands, window, Range, Selection, workspace, DocumentSymbol, version } from "vscode";
 import { SymbolNode } from "./inspect/SymbolNode";
 import { SemVer } from "semver";
 import { createUuid, sendOperationEnd, sendOperationError, sendOperationStart } from "vscode-extension-telemetry-wrapper";
@@ -53,7 +53,7 @@ export function getUnionRange(symbols: SymbolNode[]): Range {
  * get all classes (classes inside methods are not considered) and methods of a document in a pre-order traversal manner
  */
 export async function getClassesAndMethodsOfDocument(document: TextDocument): Promise<SymbolNode[]> {
-    const stack = ((await commands.executeCommand<DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', document.uri)) ?? []).reverse().map(symbol => new SymbolNode(symbol));
+    const stack = ((await commands.executeCommand<DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', document.uri)) ?? []).reverse().map(symbol => new SymbolNode(document, symbol));
 
     const result: SymbolNode[] = [];
     while (stack.length > 0) {
@@ -70,7 +70,7 @@ export async function getClassesAndMethodsOfDocument(document: TextDocument): Pr
 
 export async function getTopLevelClassesOfDocument(document: TextDocument): Promise<SymbolNode[]> {
     const symbols = ((await commands.executeCommand<DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', document.uri)) ?? []);
-    return symbols.filter(symbol => CLASS_KINDS.includes(symbol.kind)).map(symbol => new SymbolNode(symbol));
+    return symbols.filter(symbol => CLASS_KINDS.includes(symbol.kind)).map(symbol => new SymbolNode(document, symbol));
 }
 
 export function uncapitalize(str: string): string {

--- a/src/copilot/utils.ts
+++ b/src/copilot/utils.ts
@@ -5,6 +5,7 @@ import { createUuid, sendOperationEnd, sendOperationError, sendOperationStart } 
 
 export const CLASS_KINDS: SymbolKind[] = [SymbolKind.Class, SymbolKind.Interface, SymbolKind.Enum];
 export const METHOD_KINDS: SymbolKind[] = [SymbolKind.Method, SymbolKind.Constructor];
+export const FIELD_KINDS: SymbolKind[] = [SymbolKind.Field, SymbolKind.Property, SymbolKind.Constant];
 
 export const logger: LogOutputChannel = window.createOutputChannel("Java Rewriting Suggestions", { log: true });
 
@@ -12,13 +13,13 @@ export const logger: LogOutputChannel = window.createOutputChannel("Java Rewriti
  * get all the class symbols contained in the `range` in the `document`
  */
 export async function getClassesContainedInRange(range: Range | Selection, document: TextDocument): Promise<SymbolNode[]> {
-    const symbols = await getClassesAndMethodsOfDocument(document);
+    const symbols = await getSymbolsOfDocument(document);
     return symbols.filter(symbol => CLASS_KINDS.includes(symbol.kind))
         .filter(clazz => range.contains(clazz.range));
 }
 
-export async function getClassesAndMethodsContainedInRange(range: Range | Selection, document: TextDocument): Promise<SymbolNode[]> {
-    const symbols = await getClassesAndMethodsOfDocument(document);
+export async function getSymbolsContainedInRange(range: Range | Selection, document: TextDocument): Promise<SymbolNode[]> {
+    const symbols = await getSymbolsOfDocument(document);
     return symbols.filter(symbol => range.contains(symbol.range));
 }
 
@@ -26,18 +27,18 @@ export async function getClassesAndMethodsContainedInRange(range: Range | Select
  * get the innermost class symbol that completely contains the `range` in the `document`
  */
 export async function getInnermostClassContainsRange(range: Range | Selection, document: TextDocument): Promise<SymbolNode> {
-    const symbols = await getClassesAndMethodsOfDocument(document);
+    const symbols = await getSymbolsOfDocument(document);
     return symbols.filter(symbol => CLASS_KINDS.includes(symbol.kind))
         // reverse the classes to get the innermost class first
         .reverse().filter(clazz => clazz.range.contains(range))[0];
 }
 
 /**
- * get all the method symbols that are completely or partially contained in the `range` in the `document`
+ * get all the method/field symbols that are completely or partially contained in the `range` in the `document`
  */
-export async function getIntersectionMethodsOfRange(range: Range | Selection, document: TextDocument): Promise<SymbolNode[]> {
-    const symbols = await getClassesAndMethodsOfDocument(document);
-    return symbols.filter(symbol => METHOD_KINDS.includes(symbol.kind))
+export async function getIntersectionSymbolsOfRange(range: Range | Selection, document: TextDocument): Promise<SymbolNode[]> {
+    const symbols = await getSymbolsOfDocument(document);
+    return symbols.filter(symbol => METHOD_KINDS.includes(symbol.kind) || FIELD_KINDS.includes(symbol.kind))
         .filter(method => method.range.intersection(range));
 }
 
@@ -52,7 +53,7 @@ export function getUnionRange(symbols: SymbolNode[]): Range {
 /**
  * get all classes (classes inside methods are not considered) and methods of a document in a pre-order traversal manner
  */
-export async function getClassesAndMethodsOfDocument(document: TextDocument): Promise<SymbolNode[]> {
+export async function getSymbolsOfDocument(document: TextDocument): Promise<SymbolNode[]> {
     const stack = ((await commands.executeCommand<DocumentSymbol[]>('vscode.executeDocumentSymbolProvider', document.uri)) ?? []).reverse().map(symbol => new SymbolNode(document, symbol));
 
     const result: SymbolNode[] = [];
@@ -61,7 +62,7 @@ export async function getClassesAndMethodsOfDocument(document: TextDocument): Pr
         if (CLASS_KINDS.includes(symbol.kind)) {
             result.push(symbol);
             stack.push(...symbol.children.reverse());
-        } else if (METHOD_KINDS.includes(symbol.kind)) {
+        } else if (METHOD_KINDS.includes(symbol.kind) || FIELD_KINDS.includes(symbol.kind)) {
             result.push(symbol);
         }
     }

--- a/src/copilot/utils.ts
+++ b/src/copilot/utils.ts
@@ -84,14 +84,14 @@ export function isCodeLensDisabled(): boolean {
     return enabled === false;
 }
 
-export async function getProjectJavaVersion(document: TextDocument): Promise<number> {
+export async function getProjectJavaVersion(document: TextDocument): Promise<string> {
     const uri = document.uri.toString();
     const key = "org.eclipse.jdt.core.compiler.source";
     try {
         const settings: { [key]: string } = await retryOnFailure(async () => {
             return await commands.executeCommand("java.project.getSettings", uri, [key]);
         });
-        return parseInt(settings[key]) || 17;
+        return settings[key] ?? '17';
     } catch (e) {
         throw new Error(`Failed to get Java version, please check if the project is loaded normally: ${e}`);
     }


### PR DESCRIPTION
all inspections will be saved with wrong snapshot id if user modifying document at inspecting (**causing all inspections are judged as invalid**), because we read symbols and saved them in variables before inspecting, but we try to cache them with snapshot id calculated with old range after inspecting, which are certainly wrong.
I fixed this problem by calculating the snapshot id immediately when reading symbols before inspecting.

also fixed other issues:
1. fix: vscode-telemetry-wrapper swallows exception
2. adjust the position and initial range of inline chat for fixing.
3. add emoji icon in `Rewrite...` codelens