### PR TITLE
Fix the focus issue when triggering 'Configure Java Runtime'

### DIFF
--- a/src/project-settings/assets/mainpage/features/ProjectSettingView.tsx
+++ b/src/project-settings/assets/mainpage/features/ProjectSettingView.tsx
@@ -44,8 +44,6 @@ const ProjectSettingView = (): JSX.Element => {
       if (routes.length > 1) {
         switch (routes[0]) {
           case SectionId.Classpath:
-            // TODO: sometimes when directly trigger 'Configure Java Runtime', the tab won't
-            // focus to the JDK part, need to investigate
             dispatch(updateActiveTab(routes[1]));
             break;
           default:

--- a/src/project-settings/projectSettingsView.ts
+++ b/src/project-settings/projectSettingsView.ts
@@ -27,10 +27,15 @@ class ProjectSettingView {
         }
 
         projectSettingsPanel.reveal();
-        projectSettingsPanel.webview.postMessage({
-            command: "main.onWillChangeRoute",
-            route: sectionId
-        });
+        const oneTimeHook = projectSettingsPanel.webview.onDidReceiveMessage(() => {
+            // send the route change msg once react component is ready.
+            // and dispose it once it's done.
+            projectSettingsPanel!.webview.postMessage({
+                command: "main.onWillChangeRoute",
+                route: sectionId
+            });
+            oneTimeHook.dispose();
+        })
     }
 
     public async initializeWebview(context: vscode.ExtensionContext): Promise<void> {


### PR DESCRIPTION
- Makes sure the route change notification is sent after the react component is ready.

fix #1330