### PR TITLE
Fix process watcher path detection

### DIFF
--- a/src/daemon/processWatcher.ts
+++ b/src/daemon/processWatcher.ts
@@ -41,7 +41,7 @@ export class ProcessWatcher {
       
       // If user has explicitly configured a Java home, use that
       if (configJavaHome) {
-         if (await this.isValidJdkPath(configJavaHome)) {
+         if (await this.isValidJpsPath(configJavaHome)) {
             jreHome = configJavaHome;
          } else {
             // Log warning but continue with fallback
@@ -56,14 +56,14 @@ export class ProcessWatcher {
             // First look for one marked as default
             const defaultRuntime = runtimes.find(r => r.default === true);
             if (defaultRuntime && defaultRuntime.path) {
-               if (await this.isValidJdkPath(defaultRuntime.path)) {
+               if (await this.isValidJpsPath(defaultRuntime.path)) {
                   jreHome = defaultRuntime.path;
                }
             } 
             
             // If no default is set or default is invalid, try the first one
             if (!jreHome && runtimes[0].path) {
-               if (await this.isValidJdkPath(runtimes[0].path)) {
+               if (await this.isValidJpsPath(runtimes[0].path)) {
                   jreHome = runtimes[0].path;
                }
             }
@@ -134,7 +134,7 @@ export class ProcessWatcher {
       return [y, o].join(os.EOL);
    }
 
-   private async isValidJdkPath(jdkPath: string): Promise<boolean> {
+   private async isValidJpsPath(jdkPath: string): Promise<boolean> {
       try {
          // Check if path exists
          await fs.promises.access(jdkPath, fs.constants.R_OK);

--- a/src/daemon/processWatcher.ts
+++ b/src/daemon/processWatcher.ts
@@ -34,17 +34,55 @@ export class ProcessWatcher {
       if (!javaExt) {
          return false;
       }
-      // get embedded JRE Home
+      
+      // First check java.jdt.ls.java.home setting
       let jreHome: string | undefined;
-      try {
-         const jreFolder = path.join(javaExt.extensionPath, "jre");
-         const jreDistros = await fs.promises.readdir(jreFolder);
-         if (jreDistros.length > 0) {
-            jreHome = path.join(jreFolder, jreDistros[0]);
+      let configJavaHome = vscode.workspace.getConfiguration().get<string>('java.jdt.ls.java.home');
+      
+      // If user has explicitly configured a Java home, use that
+      if (configJavaHome) {
+         if (await this.isValidJdkPath(configJavaHome)) {
+            jreHome = configJavaHome;
+         } else {
+            // Log warning but continue with fallback
+            console.warn(`Configured Java home ${configJavaHome} is not valid or not accessible. Checking other options.`);
          }
-      } catch (error) {
-         // do nothing when jre is not embedded, to avoid spamming logs
       }
+      
+      // If not found, check for default runtime in java.configuration.runtimes
+      if (!jreHome) {
+         const runtimes = vscode.workspace.getConfiguration().get<any[]>('java.configuration.runtimes');
+         if (Array.isArray(runtimes) && runtimes.length > 0) {
+            // First look for one marked as default
+            const defaultRuntime = runtimes.find(r => r.default === true);
+            if (defaultRuntime && defaultRuntime.path) {
+               if (await this.isValidJdkPath(defaultRuntime.path)) {
+                  jreHome = defaultRuntime.path;
+               }
+            } 
+            
+            // If no default is set or default is invalid, try the first one
+            if (!jreHome && runtimes[0].path) {
+               if (await this.isValidJdkPath(runtimes[0].path)) {
+                  jreHome = runtimes[0].path;
+               }
+            }
+         }
+      }
+      
+      // If no valid JDK is found in settings, fall back to embedded JRE
+      if (!jreHome) {
+         try {
+            const jreFolder = path.join(javaExt.extensionPath, "jre");
+            const jreDistros = await fs.promises.readdir(jreFolder);
+            if (jreDistros.length > 0) {
+               jreHome = path.join(jreFolder, jreDistros[0]);
+            }
+         } catch (error) {
+            // do nothing when jre is not embedded, to avoid spamming logs
+         }
+      }
+      
       if (!jreHome) {
          return false;
       }
@@ -94,6 +132,21 @@ export class ProcessWatcher {
       const rold = /ParOldGen\s+total \d+K, used \d+K/;
       const o = execRes.stdout.match(rold)?.toString();
       return [y, o].join(os.EOL);
+   }
+
+   private async isValidJdkPath(jdkPath: string): Promise<boolean> {
+      try {
+         // Check if path exists
+         await fs.promises.access(jdkPath, fs.constants.R_OK);
+         
+         // Check if the jps tool exists in the bin directory
+         const jpsPath = path.join(jdkPath, "bin", "jps" + (os.platform() === 'win32' ? '.exe' : ''));
+         await fs.promises.access(jpsPath, fs.constants.X_OK);
+         
+         return true;
+      } catch (err) {
+         return false;
+      }
    }
 
    private onDidJdtlsCrash(lastHeartbeat?: string) {


### PR DESCRIPTION
This pull request enhances the logic for determining the Java Runtime Environment (JRE) home in the `ProcessWatcher` class, prioritizing user-configured settings and improving fallback mechanisms. It also introduces a utility method to validate JDK paths. Below are the key changes:

### Improvements to JRE home detection:

* Added logic to prioritize the `java.jdt.ls.java.home` setting if explicitly configured by the user. If the configured path is invalid, a warning is logged, and fallback options are considered. (`src/daemon/processWatcher.ts`, [src/daemon/processWatcher.tsL37-R74](diffhunk://#diff-d5d7740968692065c82c7db7dc5bebc1d29fcabc6021f3d39a953e16a5718e91L37-R74))
* Extended fallback mechanisms to check the `java.configuration.runtimes` setting for a default runtime or the first available runtime if no default is set. (`src/daemon/processWatcher.ts`, [src/daemon/processWatcher.tsL37-R74](diffhunk://#diff-d5d7740968692065c82c7db7dc5bebc1d29fcabc6021f3d39a953e16a5718e91L37-R74))
* Retained the embedded JRE as the final fallback option if no valid JRE is found in user settings. (`src/daemon/processWatcher.ts`, [[1]](diffhunk://#diff-d5d7740968692065c82c7db7dc5bebc1d29fcabc6021f3d39a953e16a5718e91L37-R74) [[2]](diffhunk://#diff-d5d7740968692065c82c7db7dc5bebc1d29fcabc6021f3d39a953e16a5718e91R84-R85)

### Utility method for JDK path validation:

* Introduced a new private method `isValidJpsPath` to check if a given JDK path is valid by verifying its existence and the presence of the `jps` tool in the `bin` directory. (`src/daemon/processWatcher.ts`, [src/daemon/processWatcher.tsR137-R151](diffhunk://#diff-d5d7740968692065c82c7db7dc5bebc1d29fcabc6021f3d39a953e16a5718e91R137-R151))