### PR TITLE
fix: improve issuelens labeling rules

### DIFF
--- a/.github/agents/issuelens.agent.md
+++ b/.github/agents/issuelens.agent.md
@@ -98,6 +98,10 @@ def close_as_duplicate(owner, repo, issue_number):
 close_as_duplicate("<owner>", "<repo>", <issue_number>)
 ```
 
+## Step 4: Apply the `ai-triaged` Label
+
+After completing all triage steps, always apply the `ai-triaged` label to the issue to indicate it has been processed by the AI agent.
+
 ## Notes
 - Use `gh` CLI as a fallback if you encounter issues with MCP tools.
 - Always use available tools to complete each step before moving to the next.

--- a/.github/llms.md
+++ b/.github/llms.md
@@ -23,7 +23,7 @@ Extension Pack for Java is a collection of popular extensions that can help writ
 ## Label
 When labeling an issue, follow the rules below per label category:
 ### General Rules
-- Analyze if the issue is related with the scope of using extensions for Java development. If not, STOP labelling IMMEDIATELY.
+- Analyze if the issue is related with the scope of using extensions for Java development. If not, apply the `needs more info` label and stop labelling other categories.
 - Assign label per category.
 - If a category is not applicable or you're unsure, you may skip it.
 - Do not assign multiple labels within the same category, unless explicitly allowed as an exception.


### PR DESCRIPTION
## Summary

Improves the AI IssueLens agent labeling behavior with two changes:

### Changes

- **`llms.md`**: Out-of-scope issues now receive the `needs more info` label instead of hard-stopping with no label applied. This ensures every issue gets some feedback rather than being silently skipped.

- **`issuelens.agent.md`**: Added a new **Step 4** that always applies the `ai-triaged` label after all triage steps are complete, making it easy to track which issues have been processed by the AI agent.