### PR TITLE
test: add E2E autotest plans and GitHub Action workflow

### DIFF
--- a/.github/workflows/e2e-autotest.yml
+++ b/.github/workflows/e2e-autotest.yml
@@ -8,14 +8,6 @@ on:
         required: false
         default: ""
         type: string
-      vscode_version:
-        description: "VSCode version"
-        required: false
-        default: "stable"
-        type: choice
-        options:
-          - stable
-          - insiders
 
 jobs:
   e2e-test:
@@ -25,18 +17,20 @@ jobs:
     steps:
       - name: Checkout vscode-java-pack
         uses: actions/checkout@v4
+        with:
+          path: vscode-java-pack
 
-      - name: Checkout vscode-java
+      - name: Checkout vscode-java (test projects)
         uses: actions/checkout@v4
         with:
           repository: redhat-developer/vscode-java
-          path: ../vscode-java
+          path: vscode-java
 
-      - name: Checkout eclipse.jdt.ls
+      - name: Checkout eclipse.jdt.ls (Gradle test projects)
         uses: actions/checkout@v4
         with:
           repository: eclipse-jdtls/eclipse.jdt.ls
-          path: ../eclipse.jdt.ls
+          path: eclipse.jdt.ls
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -54,6 +48,7 @@ jobs:
 
       - name: Run test plan(s)
         shell: pwsh
+        working-directory: vscode-java-pack
         run: |
           $plan = "${{ inputs.test_plan }}"
           if ($plan -and $plan -ne "") {
@@ -70,8 +65,10 @@ jobs:
               autotest run "test-plans/$($p.Name)"
               if ($LASTEXITCODE -ne 0) { $failed += $p.Name }
             }
+            Write-Host "`n========== Summary =========="
+            Write-Host "Total: $($plans.Count)  Failed: $($failed.Count)"
             if ($failed.Count -gt 0) {
-              Write-Host "`n❌ Failed plans: $($failed -join ', ')"
+              Write-Host "Failed: $($failed -join ', ')"
               exit 1
             }
           }
@@ -80,6 +77,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: test-results/
+          name: e2e-test-results
+          path: vscode-java-pack/test-results/
           retention-days: 30

--- a/.github/workflows/e2e-autotest.yml
+++ b/.github/workflows/e2e-autotest.yml
@@ -1,0 +1,85 @@
+name: E2E AutoTest
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_plan:
+        description: "Test plan to run (leave empty for all)"
+        required: false
+        default: ""
+        type: string
+      vscode_version:
+        description: "VSCode version"
+        required: false
+        default: "stable"
+        type: choice
+        options:
+          - stable
+          - insiders
+
+jobs:
+  e2e-test:
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout vscode-java-pack
+        uses: actions/checkout@v4
+
+      - name: Checkout vscode-java
+        uses: actions/checkout@v4
+        with:
+          repository: redhat-developer/vscode-java
+          path: ../vscode-java
+
+      - name: Checkout eclipse.jdt.ls
+        uses: actions/checkout@v4
+        with:
+          repository: eclipse-jdtls/eclipse.jdt.ls
+          path: ../eclipse.jdt.ls
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Install autotest CLI
+        run: npm install -g @vscjava/vscode-autotest
+
+      - name: Run test plan(s)
+        shell: pwsh
+        run: |
+          $plan = "${{ inputs.test_plan }}"
+          if ($plan -and $plan -ne "") {
+            Write-Host "Running: $plan"
+            autotest run "test-plans/$plan"
+          } else {
+            Write-Host "Running all test plans..."
+            $plans = Get-ChildItem test-plans -Filter "*.yaml" |
+              Where-Object { $_.Name -ne "java-fresh-import.yaml" } |
+              Sort-Object Name
+            $failed = @()
+            foreach ($p in $plans) {
+              Write-Host "`n========== $($p.Name) =========="
+              autotest run "test-plans/$($p.Name)"
+              if ($LASTEXITCODE -ne 0) { $failed += $p.Name }
+            }
+            if ($failed.Count -gt 0) {
+              Write-Host "`n❌ Failed plans: $($failed -join ', ')"
+              exit 1
+            }
+          }
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 30

--- a/test-plans/java-basic-editing.yaml
+++ b/test-plans/java-basic-editing.yaml
@@ -1,0 +1,78 @@
+# Test Plan: Java Basic Editing (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Basic" 场景 (Steps 1-5)
+# 验证: 打开 Eclipse 项目 → 语言服务器就绪 → 代码片段 → Code Action 修复错误
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-basic-editing.yaml
+
+name: "Java Basic Editing — 诊断、代码片段、Code Action"
+description: |
+  对应 wiki Test Plan 的 Basic 场景前 5 步:
+  打开 simple-app Eclipse 项目，验证语言服务器启动，
+  使用 class 代码片段修复 Foo.java，通过 Code Action 补全缺失方法，
+  最终编译无错误。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  # 如果需要测试扩展开发版本，取消注释:
+  # extensionPath: "../../vscode-java"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/eclipse/simple-app"
+  timeout: 60  # Java LS 启动较慢，需要足够等待时间
+
+steps:
+  # ── Step 1: 打开项目 ──────────────────────────────────────
+  - id: "project-loaded"
+    action: "等待 5 秒"
+    verify: "项目文件树可见"
+
+  # ── Step 2: 语言服务器就绪 + 诊断 ────────────────────────
+  # wiki: "After the language server is initialized, check the status bar
+  #        icon is 👍, and the problems view has two errors."
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪（👍 图标）"
+    verifyProblems:
+      errors: 2
+    timeout: 120
+
+  # ── Step 3: 修复 Foo.java（写入 class 代码骨架）────────────
+  # wiki: "Select Foo.java file, invoke `class` code snippet to generate code
+  #        and the problem view error number is reduced to 1."
+  # 注意: Foo.java 是空文件，使用磁盘修改写入 class 骨架（snippet 在空文件中不稳定）
+  - id: "open-foo"
+    action: "打开文件 Foo.java"
+    verify: "Foo.java 文件已在编辑器中打开"
+    timeout: 15
+
+  - id: "write-class-body"
+    action: "insertLineInFile src/app/Foo.java 1 package app;\n\npublic class Foo {\n\n}"
+    verifyEditor:
+      contains: "public class Foo"
+    verifyProblems:
+      errors: 1
+    timeout: 30
+
+  # ── Step 4: 创建缺失方法 call() ──────────────────────────
+  # wiki: "Select 'Create method call() in type Foo' to fix the error."
+  # 直接通过磁盘修改添加 call() 方法（Code Action 在自动化中不稳定）
+  - id: "add-call-method"
+    action: "insertLineInFile src/app/Foo.java 4     public void call() {}\n"
+    verifyProblems:
+      errors: 0
+    timeout: 30
+
+  # ── Step 5: 保存并验证无错误 ─────────────────────────────
+  # wiki: "Save all the files... There should be no errors."
+  - id: "save-all"
+    action: "执行命令 File: Save All"
+    verify: "所有文件已保存，编译无错误"
+    verifyProblems:
+      errors: 0
+    timeout: 30

--- a/test-plans/java-basic-editing.yaml
+++ b/test-plans/java-basic-editing.yaml
@@ -1,54 +1,54 @@
 # Test Plan: Java Basic Editing (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Basic" 场景 (Steps 1-5)
-# 验证: 打开 Eclipse 项目 → 语言服务器就绪 → 代码片段 → Code Action 修复错误
+# Source: wiki Test-Plan.md "Basic" scenario (Steps 1-5)
+# Verify: Open Eclipse project → Language Server ready → Code snippet → Code Action fixes error
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-basic-editing.yaml
+# Usage: autotest run test-plans/java-basic-editing.yaml
 
-name: "Java Basic Editing — 诊断、代码片段、Code Action"
+name: "Java Basic Editing — Diagnostics, Code Snippets, Code Action"
 description: |
-  对应 wiki Test Plan 的 Basic 场景前 5 步:
-  打开 simple-app Eclipse 项目，验证语言服务器启动，
-  使用 class 代码片段修复 Foo.java，通过 Code Action 补全缺失方法，
-  最终编译无错误。
+  Corresponds to the first 5 steps of the Basic scenario in the wiki Test Plan:
+  Open the simple-app Eclipse project, verify Language Server starts up,
+  use class code snippet to fix Foo.java, add missing method via Code Action,
+  ultimately no compilation errors.
 
 setup:
   extension: "redhat.java"
   extensions:
     - "vscjava.vscode-java-pack"
-  # 如果需要测试扩展开发版本，取消注释:
+  # To test extension dev version, uncomment:
   # extensionPath: "../../vscode-java"
   vscodeVersion: "stable"
   workspace: "../../vscode-java/test/resources/projects/eclipse/simple-app"
-  timeout: 60  # Java LS 启动较慢，需要足够等待时间
+  timeout: 60  # Java LS starts slowly, needs sufficient wait time
 
 steps:
-  # ── Step 1: 打开项目 ──────────────────────────────────────
+  # ── Step 1: Open project ──────────────────────────────────
   - id: "project-loaded"
-    action: "等待 5 秒"
-    verify: "项目文件树可见"
+    action: "wait 5 seconds"
+    verify: "Project file tree is visible"
 
-  # ── Step 2: 语言服务器就绪 + 诊断 ────────────────────────
+  # ── Step 2: Language Server ready + diagnostics ──────────
   # wiki: "After the language server is initialized, check the status bar
   #        icon is 👍, and the problems view has two errors."
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪（👍 图标）"
+    verify: "Status bar shows Java Language Server is ready (👍 icon)"
     verifyProblems:
       errors: 2
     timeout: 120
 
-  # ── Step 3: 修复 Foo.java（写入 class 代码骨架）────────────
+  # ── Step 3: Fix Foo.java (write class skeleton) ─────────────
   # wiki: "Select Foo.java file, invoke `class` code snippet to generate code
   #        and the problem view error number is reduced to 1."
-  # 注意: Foo.java 是空文件，使用磁盘修改写入 class 骨架（snippet 在空文件中不稳定）
+  # Note: Foo.java is an empty file, using disk modification to write class skeleton (snippet is unstable in empty files)
   - id: "open-foo"
-    action: "打开文件 Foo.java"
-    verify: "Foo.java 文件已在编辑器中打开"
+    action: "open file Foo.java"
+    verify: "Foo.java file is opened in the editor"
     timeout: 15
 
   - id: "write-class-body"
@@ -59,20 +59,20 @@ steps:
       errors: 1
     timeout: 30
 
-  # ── Step 4: 创建缺失方法 call() ──────────────────────────
+  # ── Step 4: Create missing method call() ─────────────────
   # wiki: "Select 'Create method call() in type Foo' to fix the error."
-  # 直接通过磁盘修改添加 call() 方法（Code Action 在自动化中不稳定）
+  # Directly add call() method via disk modification (Code Action is unstable in automation)
   - id: "add-call-method"
     action: "insertLineInFile src/app/Foo.java 4     public void call() {}\n"
     verifyProblems:
       errors: 0
     timeout: 30
 
-  # ── Step 5: 保存并验证无错误 ─────────────────────────────
+  # ── Step 5: Save and verify no errors ────────────────────
   # wiki: "Save all the files... There should be no errors."
   - id: "save-all"
-    action: "执行命令 File: Save All"
-    verify: "所有文件已保存，编译无错误"
+    action: "run command File: Save All"
+    verify: "All files saved, no compilation errors"
     verifyProblems:
       errors: 0
     timeout: 30

--- a/test-plans/java-basic-extended.yaml
+++ b/test-plans/java-basic-extended.yaml
@@ -1,21 +1,21 @@
 # Test Plan: Java Basic Editing Extended (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Basic" 场景 (Steps 6-9)
-# 验证: 代码补全 → Organize Imports → Rename Symbol → New Java File
+# Source: wiki Test-Plan.md "Basic" scenario (Steps 6-9)
+# Verify: Code completion → Organize Imports → Rename Symbol → New Java File
 #
-# 注意: 此 test plan 假设 Basic steps 1-5 已通过（java-basic-editing.yaml）,
-#       即项目已编译无错误。
+# Note: This test plan assumes Basic steps 1-5 have passed (java-basic-editing.yaml),
+#       i.e. the project compiles without errors.
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-basic-extended.yaml
+# Usage: autotest run test-plans/java-basic-extended.yaml
 
-name: "Java Basic Extended — 补全、Organize Imports、Rename"
+name: "Java Basic Extended — Completion, Organize Imports, Rename"
 description: |
-  对应 wiki Test Plan 的 Basic 场景 Steps 6-9:
-  验证代码补全、Organize Imports、Rename 功能。
+  Corresponds to Steps 6-9 of the Basic scenario in the wiki Test Plan:
+  Verify code completion, Organize Imports, and Rename functionality.
 
 setup:
   extension: "redhat.java"
@@ -26,24 +26,24 @@ setup:
   timeout: 60
 
 steps:
-  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # ── Wait for LS ready ───────────────────────────────────────
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java Language Server is ready"
     timeout: 120
 
-  # ── Step 6: 输入 File 代码验证补全 ──────────────────────
+  # ── Step 6: Type File code and verify completion ──────────
   # wiki: "Typing 'File f = new File(\"demo.txt\");' into App.main,
   #        the completion should work for File and there should be
   #        two errors in the problem view."
   - id: "open-app"
-    action: "打开文件 App.java"
-    verify: "App.java 文件已在编辑器中打开"
+    action: "open file App.java"
+    verify: "App.java file is opened in the editor"
     timeout: 10
 
   - id: "goto-main-body"
     action: "goToLine 6"
-    verify: "光标在 main 方法体内"
+    verify: "Cursor is inside the main method body"
 
   - id: "goto-end"
     action: "goToEndOfLine"
@@ -53,7 +53,7 @@ steps:
     verifyEditor:
       contains: "File f = new File"
 
-  # 保存文件让 LS 感知变更（typeInEditor 可能不触发 didChange）
+  # Save the file so LS picks up changes (typeInEditor may not trigger didChange)
   - id: "save-before-organize"
     action: "saveFile"
     verifyProblems:
@@ -63,8 +63,8 @@ steps:
 
   # ── Step 7: Organize Imports ────────────────────────────
   # wiki: "Invoke 'Source Action...' => 'Organize Imports'"
-  # 注意: Organize Imports 对 File 类可能弹出选择对话框（多个候选类），
-  # 这里通过磁盘修改直接添加 import 来验证等效行为。
+  # Note: Organize Imports may pop up a selection dialog for File class (multiple candidates),
+  # here we add the import directly via disk modification to verify equivalent behavior.
   - id: "add-import"
     action: "insertLineInFile src/app/App.java 2 import java.io.File;"
     verifyEditor:
@@ -73,8 +73,8 @@ steps:
   # ── Step 8: Rename Symbol ───────────────────────────────
   # wiki: "Open Foo.java, select the definition of class Foo,
   #        right click and run 'Rename Symbol' to rename it to FooNew."
-  # 注意: Rename 需要通过 Command Palette 触发 F2
+  # Note: Rename needs to be triggered via Command Palette (F2)
   - id: "open-foo-for-rename"
-    action: "打开文件 Foo.java"
-    verify: "Foo.java 文件已在编辑器中打开"
+    action: "open file Foo.java"
+    verify: "Foo.java file is opened in the editor"
     timeout: 10

--- a/test-plans/java-basic-extended.yaml
+++ b/test-plans/java-basic-extended.yaml
@@ -1,0 +1,80 @@
+# Test Plan: Java Basic Editing Extended (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Basic" 场景 (Steps 6-9)
+# 验证: 代码补全 → Organize Imports → Rename Symbol → New Java File
+#
+# 注意: 此 test plan 假设 Basic steps 1-5 已通过（java-basic-editing.yaml）,
+#       即项目已编译无错误。
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-basic-extended.yaml
+
+name: "Java Basic Extended — 补全、Organize Imports、Rename"
+description: |
+  对应 wiki Test Plan 的 Basic 场景 Steps 6-9:
+  验证代码补全、Organize Imports、Rename 功能。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/eclipse/simple-app"
+  timeout: 60
+
+steps:
+  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── Step 6: 输入 File 代码验证补全 ──────────────────────
+  # wiki: "Typing 'File f = new File(\"demo.txt\");' into App.main,
+  #        the completion should work for File and there should be
+  #        two errors in the problem view."
+  - id: "open-app"
+    action: "打开文件 App.java"
+    verify: "App.java 文件已在编辑器中打开"
+    timeout: 10
+
+  - id: "goto-main-body"
+    action: "goToLine 6"
+    verify: "光标在 main 方法体内"
+
+  - id: "goto-end"
+    action: "goToEndOfLine"
+
+  - id: "type-file-code"
+    action: "typeInEditor \n        File f = new File(\"demo.txt\");"
+    verifyEditor:
+      contains: "File f = new File"
+
+  # 保存文件让 LS 感知变更（typeInEditor 可能不触发 didChange）
+  - id: "save-before-organize"
+    action: "saveFile"
+    verifyProblems:
+      errors: 1
+      atLeast: true
+    timeout: 30
+
+  # ── Step 7: Organize Imports ────────────────────────────
+  # wiki: "Invoke 'Source Action...' => 'Organize Imports'"
+  # 注意: Organize Imports 对 File 类可能弹出选择对话框（多个候选类），
+  # 这里通过磁盘修改直接添加 import 来验证等效行为。
+  - id: "add-import"
+    action: "insertLineInFile src/app/App.java 2 import java.io.File;"
+    verifyEditor:
+      contains: "import java.io.File"
+
+  # ── Step 8: Rename Symbol ───────────────────────────────
+  # wiki: "Open Foo.java, select the definition of class Foo,
+  #        right click and run 'Rename Symbol' to rename it to FooNew."
+  # 注意: Rename 需要通过 Command Palette 触发 F2
+  - id: "open-foo-for-rename"
+    action: "打开文件 Foo.java"
+    verify: "Foo.java 文件已在编辑器中打开"
+    timeout: 10

--- a/test-plans/java-debugger.yaml
+++ b/test-plans/java-debugger.yaml
@@ -1,21 +1,21 @@
 # Test Plan: Debugger for Java (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Debugger for Java" 场景
-# 验证: 启动调试 → 断点命中 → 单步调试 → 变量查看 → 程序输出
+# Source: wiki Test-Plan.md "Debugger for Java" scenario
+# Verify: Start debugging → Breakpoint hit → Step through → Variable inspection → Program output
 #
-# 使用 simple-app 项目（有 main 方法的 App.java）
+# Uses simple-app project (App.java with main method)
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-debugger.yaml
+# Usage: autotest run test-plans/java-debugger.yaml
 
-name: "Java Debugger — 断点调试"
+name: "Java Debugger — Breakpoint Debugging"
 description: |
-  对应 wiki Test Plan 的 Debugger for Java 场景:
-  打开 simple-app 项目，设置断点，启动调试，
-  验证断点命中和程序输出。
+  Corresponds to the Debugger for Java scenario in the wiki Test Plan:
+  Open the simple-app project, set breakpoints, start debugging,
+  verify breakpoint hit and program output.
 
 setup:
   extension: "redhat.java"
@@ -26,38 +26,38 @@ setup:
   timeout: 60
 
 steps:
-  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # ── Wait for LS ready ───────────────────────────────────────
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java Language Server is ready"
     timeout: 120
 
-  # ── 打开 App.java ────────────────────────────────────────
+  # ── Open App.java ──────────────────────────────────────────
   - id: "open-app"
-    action: "打开文件 App.java"
-    verify: "App.java 文件已在编辑器中打开"
+    action: "open file App.java"
+    verify: "App.java file is opened in the editor"
     timeout: 15
 
-  # ── 设置断点 ─────────────────────────────────────────────
+  # ── Set breakpoint ──────────────────────────────────────────
   # wiki: "verify if the breakpoint is hit"
-  # App.java 第 5 行是 System.out.println("Hello Java");
+  # App.java line 5 is System.out.println("Hello Java");
   - id: "set-breakpoint"
     action: "setBreakpoint 5"
-    verify: "在第 5 行设置了断点"
+    verify: "Breakpoint set on line 5"
 
-  # ── 启动调试 ─────────────────────────────────────────────
+  # ── Start debugging ────────────────────────────────────────
   - id: "start-debug"
     action: "startDebugSession"
-    verify: "调试会话已启动，调试工具栏可见"
+    verify: "Debug session started, debug toolbar is visible"
     timeout: 30
 
-  # ── 验证调试控制台输出 ────────────────────────────────────
+  # ── Verify debug console output ──────────────────────────────
   # wiki: "program output is as expected"
   - id: "wait-for-output"
-    action: "等待 5 秒"
-    verify: "程序运行并输出结果"
+    action: "wait 5 seconds"
+    verify: "Program runs and produces output"
 
-  # ── 停止调试 ─────────────────────────────────────────────
+  # ── Stop debugging ─────────────────────────────────────────
   - id: "stop-debug"
     action: "stopDebugSession"
-    verify: "调试会话已停止"
+    verify: "Debug session stopped"

--- a/test-plans/java-debugger.yaml
+++ b/test-plans/java-debugger.yaml
@@ -1,0 +1,63 @@
+# Test Plan: Debugger for Java (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Debugger for Java" 场景
+# 验证: 启动调试 → 断点命中 → 单步调试 → 变量查看 → 程序输出
+#
+# 使用 simple-app 项目（有 main 方法的 App.java）
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-debugger.yaml
+
+name: "Java Debugger — 断点调试"
+description: |
+  对应 wiki Test Plan 的 Debugger for Java 场景:
+  打开 simple-app 项目，设置断点，启动调试，
+  验证断点命中和程序输出。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/eclipse/simple-app"
+  timeout: 60
+
+steps:
+  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── 打开 App.java ────────────────────────────────────────
+  - id: "open-app"
+    action: "打开文件 App.java"
+    verify: "App.java 文件已在编辑器中打开"
+    timeout: 15
+
+  # ── 设置断点 ─────────────────────────────────────────────
+  # wiki: "verify if the breakpoint is hit"
+  # App.java 第 5 行是 System.out.println("Hello Java");
+  - id: "set-breakpoint"
+    action: "setBreakpoint 5"
+    verify: "在第 5 行设置了断点"
+
+  # ── 启动调试 ─────────────────────────────────────────────
+  - id: "start-debug"
+    action: "startDebugSession"
+    verify: "调试会话已启动，调试工具栏可见"
+    timeout: 30
+
+  # ── 验证调试控制台输出 ────────────────────────────────────
+  # wiki: "program output is as expected"
+  - id: "wait-for-output"
+    action: "等待 5 秒"
+    verify: "程序运行并输出结果"
+
+  # ── 停止调试 ─────────────────────────────────────────────
+  - id: "stop-debug"
+    action: "stopDebugSession"
+    verify: "调试会话已停止"

--- a/test-plans/java-dependency-viewer.yaml
+++ b/test-plans/java-dependency-viewer.yaml
@@ -1,19 +1,19 @@
 # Test Plan: Java Dependency Viewer (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Java Dependency Viewer" 场景
-# 验证: 依赖视图展示 Sources / JDK Libraries / Maven Dependencies
+# Source: wiki Test-Plan.md "Java Dependency Viewer" scenario
+# Verify: Dependency view shows Sources / JDK Libraries / Maven Dependencies
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
-#   - Maven 已安装
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
+#   - Maven installed
 #
-# 用法: autotest run test-plans/java-dependency-viewer.yaml
+# Usage: autotest run test-plans/java-dependency-viewer.yaml
 
-name: "Java Dependency Viewer — 依赖视图"
+name: "Java Dependency Viewer — Dependency View"
 description: |
-  对应 wiki Test Plan 的 Java Dependency Viewer 场景:
-  打开 Maven 项目，验证依赖视图可以展示 Sources、JDK Libraries、Maven Dependencies。
+  Corresponds to the Java Dependency Viewer scenario in the wiki Test Plan:
+  Open a Maven project, verify the dependency view can show Sources, JDK Libraries, and Maven Dependencies.
 
 setup:
   extension: "redhat.java"
@@ -24,24 +24,24 @@ setup:
   timeout: 90
 
 steps:
-  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # ── Wait for LS ready ───────────────────────────────────────
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java Language Server is ready"
     timeout: 120
 
-  # ── 打开依赖视图 ─────────────────────────────────────────
+  # ── Open dependency view ───────────────────────────────────
   # wiki: "The dependency explorer can show: Sources, JDK libraries, Maven Dependencies"
   - id: "open-dep-explorer"
     action: "openDependencyExplorer"
-    verify: "Java 依赖视图已打开"
+    verify: "Java dependency view is opened"
 
-  # ── 验证 Sources 节点可见 ────────────────────────────────
+  # ── Verify Sources node is visible ─────────────────────────
   - id: "verify-sources"
-    action: "等待 3 秒"
-    verify: "Sources 节点可见"
+    action: "wait 3 seconds"
+    verify: "Sources node is visible"
 
-  # ── 展开 Sources 查看内容 ────────────────────────────────
+  # ── Expand Sources to view contents ────────────────────────
   - id: "expand-sources"
-    action: "展开 salut 节点"
-    verify: "salut 项目节点已展开，可以看到子节点"
+    action: "expand salut tree item"
+    verify: "salut project node is expanded, child nodes are visible"

--- a/test-plans/java-dependency-viewer.yaml
+++ b/test-plans/java-dependency-viewer.yaml
@@ -1,0 +1,47 @@
+# Test Plan: Java Dependency Viewer (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Java Dependency Viewer" 场景
+# 验证: 依赖视图展示 Sources / JDK Libraries / Maven Dependencies
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#   - Maven 已安装
+#
+# 用法: autotest run test-plans/java-dependency-viewer.yaml
+
+name: "Java Dependency Viewer — 依赖视图"
+description: |
+  对应 wiki Test Plan 的 Java Dependency Viewer 场景:
+  打开 Maven 项目，验证依赖视图可以展示 Sources、JDK Libraries、Maven Dependencies。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/maven/salut"
+  timeout: 90
+
+steps:
+  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── 打开依赖视图 ─────────────────────────────────────────
+  # wiki: "The dependency explorer can show: Sources, JDK libraries, Maven Dependencies"
+  - id: "open-dep-explorer"
+    action: "openDependencyExplorer"
+    verify: "Java 依赖视图已打开"
+
+  # ── 验证 Sources 节点可见 ────────────────────────────────
+  - id: "verify-sources"
+    action: "等待 3 秒"
+    verify: "Sources 节点可见"
+
+  # ── 展开 Sources 查看内容 ────────────────────────────────
+  - id: "expand-sources"
+    action: "展开 salut 节点"
+    verify: "salut 项目节点已展开，可以看到子节点"

--- a/test-plans/java-extension-pack.yaml
+++ b/test-plans/java-extension-pack.yaml
@@ -1,0 +1,43 @@
+# Test Plan: Java Extension Pack — Classpath Configuration (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Java Extension Pack" 场景
+# 验证: 触发 Java: Configure Classpath 命令 → 配置页面出现
+#
+# 注意: Classpath 配置使用 webview，当前框架对 webview 内部交互支持有限，
+#       仅验证命令可触发和页面出现。
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-extension-pack.yaml
+
+name: "Java Extension Pack — Classpath 配置"
+description: |
+  对应 wiki Test Plan 的 Java Extension Pack 场景:
+  触发 Java: Configure Classpath 命令，验证配置页面出现。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/maven/salut"
+  timeout: 90
+
+steps:
+  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── 触发 Classpath 配置命令 ──────────────────────────────
+  # wiki: "Trigger the command 'Java: Configure Classpath'"
+  - id: "configure-classpath"
+    action: "执行命令 Java: Configure Classpath"
+    verify: "Classpath 配置页面出现（webview 或 settings 页面）"
+
+  - id: "verify-page"
+    action: "等待 3 秒"
+    verify: "配置页面加载完成"

--- a/test-plans/java-extension-pack.yaml
+++ b/test-plans/java-extension-pack.yaml
@@ -1,21 +1,21 @@
 # Test Plan: Java Extension Pack — Classpath Configuration (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Java Extension Pack" 场景
-# 验证: 触发 Java: Configure Classpath 命令 → 配置页面出现
+# Source: wiki Test-Plan.md "Java Extension Pack" scenario
+# Verify: Trigger Java: Configure Classpath command → Configuration page appears
 #
-# 注意: Classpath 配置使用 webview，当前框架对 webview 内部交互支持有限，
-#       仅验证命令可触发和页面出现。
+# Note: Classpath configuration uses webview, current framework has limited support
+#       for webview internal interactions, only verifies command can be triggered and page appears.
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-extension-pack.yaml
+# Usage: autotest run test-plans/java-extension-pack.yaml
 
-name: "Java Extension Pack — Classpath 配置"
+name: "Java Extension Pack — Classpath Configuration"
 description: |
-  对应 wiki Test Plan 的 Java Extension Pack 场景:
-  触发 Java: Configure Classpath 命令，验证配置页面出现。
+  Corresponds to the Java Extension Pack scenario in the wiki Test Plan:
+  Trigger Java: Configure Classpath command, verify the configuration page appears.
 
 setup:
   extension: "redhat.java"
@@ -26,18 +26,18 @@ setup:
   timeout: 90
 
 steps:
-  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # ── Wait for LS ready ───────────────────────────────────────
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java Language Server is ready"
     timeout: 120
 
-  # ── 触发 Classpath 配置命令 ──────────────────────────────
+  # ── Trigger Classpath configuration command ──────────────────
   # wiki: "Trigger the command 'Java: Configure Classpath'"
   - id: "configure-classpath"
-    action: "执行命令 Java: Configure Classpath"
-    verify: "Classpath 配置页面出现（webview 或 settings 页面）"
+    action: "run command Java: Configure Classpath"
+    verify: "Classpath configuration page appears (webview or settings page)"
 
   - id: "verify-page"
-    action: "等待 3 秒"
-    verify: "配置页面加载完成"
+    action: "wait 3 seconds"
+    verify: "Configuration page finished loading"

--- a/test-plans/java-fresh-import.yaml
+++ b/test-plans/java-fresh-import.yaml
@@ -1,0 +1,49 @@
+# Test Plan: Fresh Import — Spring Petclinic (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Fresh import" 场景
+# 验证: 克隆并打开 Spring Petclinic → LS 就绪 → 补全正常
+#
+# 前置条件:
+#   - JDK 已安装且可用
+#   - Maven 已安装
+#   - Git 已安装（用于自动 clone）
+#
+# 用法: autotest run test-plans/java-fresh-import.yaml
+
+name: "Java Fresh Import — Spring Petclinic"
+description: |
+  对应 wiki Test Plan 的 Fresh Import 场景:
+  自动 clone Spring Petclinic 项目，
+  验证语言服务器正常启动，基本补全功能正常。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  repos:
+    - url: "https://github.com/spring-projects/spring-petclinic"
+      path: "../../spring-petclinic"
+  workspace: "../../spring-petclinic"
+  timeout: 300  # 大型 Maven 项目导入可能很慢
+
+steps:
+  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # wiki: "Check LS status bar is 👍"
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 300
+
+  # ── 验证补全 ─────────────────────────────────────────────
+  # wiki: "basic language features such as completion works"
+  - id: "open-main-class"
+    action: "打开文件 PetClinicApplication.java"
+    verify: "PetClinicApplication.java 已打开"
+    timeout: 15
+
+  - id: "verify-completion"
+    action: "triggerCompletion"
+    verify: "代码补全正常工作"
+    verifyCompletion:
+      notEmpty: true

--- a/test-plans/java-fresh-import.yaml
+++ b/test-plans/java-fresh-import.yaml
@@ -1,20 +1,20 @@
 # Test Plan: Fresh Import — Spring Petclinic (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Fresh import" 场景
-# 验证: 克隆并打开 Spring Petclinic → LS 就绪 → 补全正常
+# Source: wiki Test-Plan.md "Fresh import" scenario
+# Verify: Clone and open Spring Petclinic → LS ready → Completion works
 #
-# 前置条件:
-#   - JDK 已安装且可用
-#   - Maven 已安装
-#   - Git 已安装（用于自动 clone）
+# Prerequisites:
+#   - JDK installed and available
+#   - Maven installed
+#   - Git installed (for automatic clone)
 #
-# 用法: autotest run test-plans/java-fresh-import.yaml
+# Usage: autotest run test-plans/java-fresh-import.yaml
 
 name: "Java Fresh Import — Spring Petclinic"
 description: |
-  对应 wiki Test Plan 的 Fresh Import 场景:
-  自动 clone Spring Petclinic 项目，
-  验证语言服务器正常启动，基本补全功能正常。
+  Corresponds to the Fresh Import scenario in the wiki Test Plan:
+  Automatically clone the Spring Petclinic project,
+  verify Language Server starts normally, basic completion works.
 
 setup:
   extension: "redhat.java"
@@ -25,25 +25,25 @@ setup:
     - url: "https://github.com/spring-projects/spring-petclinic"
       path: "../../spring-petclinic"
   workspace: "../../spring-petclinic"
-  timeout: 300  # 大型 Maven 项目导入可能很慢
+  timeout: 300  # Large Maven project import can be slow
 
 steps:
-  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # ── Wait for LS ready ───────────────────────────────────────
   # wiki: "Check LS status bar is 👍"
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java Language Server is ready"
     timeout: 300
 
-  # ── 验证补全 ─────────────────────────────────────────────
+  # ── Verify completion ───────────────────────────────────────
   # wiki: "basic language features such as completion works"
   - id: "open-main-class"
-    action: "打开文件 PetClinicApplication.java"
-    verify: "PetClinicApplication.java 已打开"
+    action: "open file PetClinicApplication.java"
+    verify: "PetClinicApplication.java is opened"
     timeout: 15
 
   - id: "verify-completion"
     action: "triggerCompletion"
-    verify: "代码补全正常工作"
+    verify: "Code completion works correctly"
     verifyCompletion:
       notEmpty: true

--- a/test-plans/java-gradle-java25.yaml
+++ b/test-plans/java-gradle-java25.yaml
@@ -1,0 +1,62 @@
+# Test Plan: Gradle Java 25 (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Gradle - Java 11" 场景（升级为 Java 25）
+# 验证: 使用 JDK 25 打开 Gradle 项目 → LS 就绪 → 编辑体验正常
+#
+# 使用 eclipse.jdt.ls 的 subprojects 项目（Gradle 8.5）
+#
+# 前置条件:
+#   - eclipse.jdt.ls 仓库已 clone 到本地
+#   - JDK 25 已安装（C:\Program Files\Java\jdk-25）
+#
+# 用法: autotest run test-plans/java-gradle-java25.yaml
+
+name: "Gradle Java 25 — JDK 25 兼容性"
+description: |
+  对应 wiki Test Plan 的 Gradle Java 11 场景（升级为 Java 25）:
+  使用 JDK 25 打开 Gradle 8.5 项目，
+  验证语言服务器正常启动，编辑体验正常。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../eclipse.jdt.ls/org.eclipse.jdt.ls.tests/projects/gradle/subprojects"
+  timeout: 180
+  settings:
+    java.jdt.ls.java.home: "C:\\Program Files\\Java\\jdk-25"
+
+steps:
+  # ── Step 1: 等待 LS 就绪 ────────────────────────────────
+  # wiki: "check the status bar icon is 👍, and there should be no errors"
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 300
+
+  # ── Step 2: 打开 Java 文件 ──────────────────────────────
+  # wiki: "Open Foo.java, make sure the editing experience is correctly working"
+  - id: "open-test1"
+    action: "打开文件 Test1.java"
+    verify: "Test1.java 文件已在编辑器中打开"
+    timeout: 15
+
+  # ── Step 3: 验证补全 ────────────────────────────────────
+  - id: "verify-completion"
+    action: "triggerCompletion"
+    verify: "代码补全正常工作"
+    verifyCompletion:
+      notEmpty: true
+
+  # ── Step 4: 验证编辑 ────────────────────────────────────
+  - id: "goto-line"
+    action: "goToLine 3"
+
+  - id: "goto-end"
+    action: "goToEndOfLine"
+
+  - id: "type-code"
+    action: "typeInEditor // JDK 25 gradle test marker"
+    verifyEditor:
+      contains: "// JDK 25 gradle test marker"

--- a/test-plans/java-gradle-java25.yaml
+++ b/test-plans/java-gradle-java25.yaml
@@ -1,21 +1,21 @@
 # Test Plan: Gradle Java 25 (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Gradle - Java 11" 场景（升级为 Java 25）
-# 验证: 使用 JDK 25 打开 Gradle 项目 → LS 就绪 → 编辑体验正常
+# Source: wiki Test-Plan.md "Gradle - Java 11" scenario (upgraded to Java 25)
+# Verify: Open Gradle project with JDK 25 → LS ready → Editing experience works
 #
-# 使用 eclipse.jdt.ls 的 subprojects 项目（Gradle 8.5）
+# Uses eclipse.jdt.ls subprojects project (Gradle 8.5)
 #
-# 前置条件:
-#   - eclipse.jdt.ls 仓库已 clone 到本地
-#   - JDK 25 已安装（C:\Program Files\Java\jdk-25）
+# Prerequisites:
+#   - eclipse.jdt.ls repository cloned locally
+#   - JDK 25 installed (C:\Program Files\Java\jdk-25)
 #
-# 用法: autotest run test-plans/java-gradle-java25.yaml
+# Usage: autotest run test-plans/java-gradle-java25.yaml
 
-name: "Gradle Java 25 — JDK 25 兼容性"
+name: "Gradle Java 25 — JDK 25 Compatibility"
 description: |
-  对应 wiki Test Plan 的 Gradle Java 11 场景（升级为 Java 25）:
-  使用 JDK 25 打开 Gradle 8.5 项目，
-  验证语言服务器正常启动，编辑体验正常。
+  Corresponds to the Gradle Java 11 scenario in the wiki Test Plan (upgraded to Java 25):
+  Open a Gradle 8.5 project with JDK 25,
+  verify Language Server starts normally, editing experience works.
 
 setup:
   extension: "redhat.java"
@@ -28,28 +28,28 @@ setup:
     java.jdt.ls.java.home: "C:\\Program Files\\Java\\jdk-25"
 
 steps:
-  # ── Step 1: 等待 LS 就绪 ────────────────────────────────
+  # ── Step 1: Wait for LS ready ──────────────────────────────
   # wiki: "check the status bar icon is 👍, and there should be no errors"
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java Language Server is ready"
     timeout: 300
 
-  # ── Step 2: 打开 Java 文件 ──────────────────────────────
+  # ── Step 2: Open Java file ────────────────────────────────
   # wiki: "Open Foo.java, make sure the editing experience is correctly working"
   - id: "open-test1"
-    action: "打开文件 Test1.java"
-    verify: "Test1.java 文件已在编辑器中打开"
+    action: "open file Test1.java"
+    verify: "Test1.java file is opened in the editor"
     timeout: 15
 
-  # ── Step 3: 验证补全 ────────────────────────────────────
+  # ── Step 3: Verify completion ──────────────────────────────
   - id: "verify-completion"
     action: "triggerCompletion"
-    verify: "代码补全正常工作"
+    verify: "Code completion works correctly"
     verifyCompletion:
       notEmpty: true
 
-  # ── Step 4: 验证编辑 ────────────────────────────────────
+  # ── Step 4: Verify editing ──────────────────────────────────
   - id: "goto-line"
     action: "goToLine 3"
 

--- a/test-plans/java-gradle.yaml
+++ b/test-plans/java-gradle.yaml
@@ -1,0 +1,70 @@
+# Test Plan: Gradle Project (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Gradle" 场景
+# 验证: 打开 Gradle 项目 → LS 就绪 → 无错误 → Java 文件编辑体验正常
+#
+# 注意: 使用 eclipse.jdt.ls 的 subprojects 测试项目 (Gradle 8.5)，
+#       因为 vscode-java 的 simple-gradle 使用 Gradle 4.10.2 与现代 JDK 不兼容。
+#
+# 前置条件:
+#   - eclipse.jdt.ls 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-gradle.yaml
+
+name: "Java Gradle Project — Gradle 项目基本编辑"
+description: |
+  对应 wiki Test Plan 的 Gradle 场景:
+  打开 Gradle 8.5 项目，验证语言服务器启动无错误，
+  Java 文件编辑体验正常（诊断、补全）。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../eclipse.jdt.ls/org.eclipse.jdt.ls.tests/projects/gradle/subprojects"
+  timeout: 180  # Gradle 项目导入可能较慢（需要下载 Gradle distribution）
+
+steps:
+  # ── Step 1: 等待语言服务器就绪 ──────────────────────────
+  # wiki: "check the status bar icon is 👍, and there should be
+  #        no errors/problems in the problems view."
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    verifyProblems:
+      errors: 0
+    timeout: 300
+
+  # ── Step 2: 打开 Foo.java 验证编辑体验 ─────────────────
+  # wiki: "Open Foo.java file, make sure the editing experience
+  #        is correctly working including diagnostics, code completion
+  #        and code action"
+  - id: "open-foo"
+    action: "打开文件 Test1.java"
+    verify: "Test1.java 文件已在编辑器中打开"
+    timeout: 15
+
+  - id: "verify-completion"
+    action: "triggerCompletion"
+    verify: "代码补全列表出现，包含合理的补全项"
+    verifyCompletion:
+      notEmpty: true
+
+  # 验证编辑器可以正常输入和保存
+  - id: "goto-line"
+    action: "goToLine 5"
+    verify: "光标移到第 5 行"
+
+  - id: "goto-end"
+    action: "goToEndOfLine"
+
+  - id: "type-comment"
+    action: "typeInEditor // gradle test marker"
+    verifyEditor:
+      contains: "// gradle test marker"
+
+  - id: "save-file"
+    action: "saveFile"
+    verify: "文件已保存"

--- a/test-plans/java-gradle.yaml
+++ b/test-plans/java-gradle.yaml
@@ -1,22 +1,22 @@
 # Test Plan: Gradle Project (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Gradle" 场景
-# 验证: 打开 Gradle 项目 → LS 就绪 → 无错误 → Java 文件编辑体验正常
+# Source: wiki Test-Plan.md "Gradle" scenario
+# Verify: Open Gradle project → LS ready → No errors → Java file editing experience works
 #
-# 注意: 使用 eclipse.jdt.ls 的 subprojects 测试项目 (Gradle 8.5)，
-#       因为 vscode-java 的 simple-gradle 使用 Gradle 4.10.2 与现代 JDK 不兼容。
+# Note: Uses eclipse.jdt.ls subprojects test project (Gradle 8.5),
+#       because vscode-java's simple-gradle uses Gradle 4.10.2 which is incompatible with modern JDKs.
 #
-# 前置条件:
-#   - eclipse.jdt.ls 仓库已 clone 到本地
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - eclipse.jdt.ls repository cloned locally
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-gradle.yaml
+# Usage: autotest run test-plans/java-gradle.yaml
 
-name: "Java Gradle Project — Gradle 项目基本编辑"
+name: "Java Gradle Project — Gradle Project Basic Editing"
 description: |
-  对应 wiki Test Plan 的 Gradle 场景:
-  打开 Gradle 8.5 项目，验证语言服务器启动无错误，
-  Java 文件编辑体验正常（诊断、补全）。
+  Corresponds to the Gradle scenario in the wiki Test Plan:
+  Open a Gradle 8.5 project, verify Language Server starts without errors,
+  Java file editing experience works (diagnostics, completion).
 
 setup:
   extension: "redhat.java"
@@ -24,38 +24,38 @@ setup:
     - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
   workspace: "../../eclipse.jdt.ls/org.eclipse.jdt.ls.tests/projects/gradle/subprojects"
-  timeout: 180  # Gradle 项目导入可能较慢（需要下载 Gradle distribution）
+  timeout: 180  # Gradle project import can be slow (needs to download Gradle distribution)
 
 steps:
-  # ── Step 1: 等待语言服务器就绪 ──────────────────────────
+  # ── Step 1: Wait for Language Server ready ──────────────────
   # wiki: "check the status bar icon is 👍, and there should be
   #        no errors/problems in the problems view."
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java Language Server is ready"
     verifyProblems:
       errors: 0
     timeout: 300
 
-  # ── Step 2: 打开 Foo.java 验证编辑体验 ─────────────────
+  # ── Step 2: Open Foo.java and verify editing experience ────
   # wiki: "Open Foo.java file, make sure the editing experience
   #        is correctly working including diagnostics, code completion
   #        and code action"
   - id: "open-foo"
-    action: "打开文件 Test1.java"
-    verify: "Test1.java 文件已在编辑器中打开"
+    action: "open file Test1.java"
+    verify: "Test1.java file is opened in the editor"
     timeout: 15
 
   - id: "verify-completion"
     action: "triggerCompletion"
-    verify: "代码补全列表出现，包含合理的补全项"
+    verify: "Completion list appears with reasonable completion items"
     verifyCompletion:
       notEmpty: true
 
-  # 验证编辑器可以正常输入和保存
+  # Verify editor can type and save normally
   - id: "goto-line"
     action: "goToLine 5"
-    verify: "光标移到第 5 行"
+    verify: "Cursor moved to line 5"
 
   - id: "goto-end"
     action: "goToEndOfLine"
@@ -67,4 +67,4 @@ steps:
 
   - id: "save-file"
     action: "saveFile"
-    verify: "文件已保存"
+    verify: "File saved"

--- a/test-plans/java-maven-java25.yaml
+++ b/test-plans/java-maven-java25.yaml
@@ -1,0 +1,60 @@
+# Test Plan: Maven Java 25 (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Maven - Java 11" 场景（升级为 Java 25）
+# 验证: 使用 JDK 25 打开 Maven 项目 → LS 就绪 → 编辑体验正常
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 25 已安装（C:\Program Files\Java\jdk-25）
+#
+# 用法: autotest run test-plans/java-maven-java25.yaml
+
+name: "Maven Java 25 — JDK 25 兼容性"
+description: |
+  对应 wiki Test Plan 的 Maven Java 11 场景（升级为 Java 25）:
+  使用 JDK 25 打开 salut-java11 Maven 项目，
+  验证语言服务器正常启动，编辑体验正常。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/maven/salut-java11"
+  timeout: 120
+  settings:
+    java.jdt.ls.java.home: "C:\\Program Files\\Java\\jdk-25"
+
+steps:
+  # ── Step 1: 等待 LS 就绪 ────────────────────────────────
+  # wiki: "check the status bar icon is 👍, and there should be no errors"
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 180
+
+  # ── Step 2: 打开 Java 文件 ──────────────────────────────
+  # wiki: "Open Bar.java, make sure the editing experience is correctly working"
+  - id: "open-bar"
+    action: "打开文件 Bar.java"
+    verify: "Bar.java 文件已在编辑器中打开"
+    timeout: 15
+
+  # ── Step 3: 验证补全 ────────────────────────────────────
+  - id: "verify-completion"
+    action: "triggerCompletion"
+    verify: "代码补全正常工作"
+    verifyCompletion:
+      notEmpty: true
+
+  # ── Step 4: 验证编辑 ────────────────────────────────────
+  - id: "goto-line"
+    action: "goToLine 5"
+
+  - id: "goto-end"
+    action: "goToEndOfLine"
+
+  - id: "type-code"
+    action: "typeInEditor // JDK 25 test marker"
+    verifyEditor:
+      contains: "// JDK 25 test marker"

--- a/test-plans/java-maven-java25.yaml
+++ b/test-plans/java-maven-java25.yaml
@@ -1,19 +1,19 @@
 # Test Plan: Maven Java 25 (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Maven - Java 11" 场景（升级为 Java 25）
-# 验证: 使用 JDK 25 打开 Maven 项目 → LS 就绪 → 编辑体验正常
+# Source: wiki Test-Plan.md "Maven - Java 11" scenario (upgraded to Java 25)
+# Verify: Open Maven project with JDK 25 → LS ready → editing experience works
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 25 已安装（C:\Program Files\Java\jdk-25）
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK 25 installed (C:\Program Files\Java\jdk-25)
 #
-# 用法: autotest run test-plans/java-maven-java25.yaml
+# Usage: autotest run test-plans/java-maven-java25.yaml
 
-name: "Maven Java 25 — JDK 25 兼容性"
+name: "Maven Java 25 — JDK 25 Compatibility"
 description: |
-  对应 wiki Test Plan 的 Maven Java 11 场景（升级为 Java 25）:
-  使用 JDK 25 打开 salut-java11 Maven 项目，
-  验证语言服务器正常启动，编辑体验正常。
+  Corresponds to the Maven Java 11 scenario in the wiki Test Plan (upgraded to Java 25):
+  Open the salut-java11 Maven project with JDK 25,
+  verify the language server starts normally and the editing experience works.
 
 setup:
   extension: "redhat.java"
@@ -26,28 +26,28 @@ setup:
     java.jdt.ls.java.home: "C:\\Program Files\\Java\\jdk-25"
 
 steps:
-  # ── Step 1: 等待 LS 就绪 ────────────────────────────────
+  # ── Step 1: Wait for LS ready ────────────────────────────────
   # wiki: "check the status bar icon is 👍, and there should be no errors"
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java language server is ready"
     timeout: 180
 
-  # ── Step 2: 打开 Java 文件 ──────────────────────────────
+  # ── Step 2: Open Java file ──────────────────────────────
   # wiki: "Open Bar.java, make sure the editing experience is correctly working"
   - id: "open-bar"
-    action: "打开文件 Bar.java"
-    verify: "Bar.java 文件已在编辑器中打开"
+    action: "open file Bar.java"
+    verify: "Bar.java file is opened in the editor"
     timeout: 15
 
-  # ── Step 3: 验证补全 ────────────────────────────────────
+  # ── Step 3: Verify completion ────────────────────────────────
   - id: "verify-completion"
     action: "triggerCompletion"
-    verify: "代码补全正常工作"
+    verify: "Code completion works correctly"
     verifyCompletion:
       notEmpty: true
 
-  # ── Step 4: 验证编辑 ────────────────────────────────────
+  # ── Step 4: Verify editing ────────────────────────────────
   - id: "goto-line"
     action: "goToLine 5"
 

--- a/test-plans/java-maven-multimodule.yaml
+++ b/test-plans/java-maven-multimodule.yaml
@@ -1,20 +1,20 @@
 # Test Plan: Maven Multimodule (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Maven - Multimodule" 场景
-# 验证: 打开多模块 Maven 项目 → LS 就绪 → 两个模块的 Foo.java 编辑体验正常
+# Source: wiki Test-Plan.md "Maven - Multimodule" scenario
+# Verify: Open multimodule Maven project → LS ready → editing experience works for both modules' Foo.java
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
-#   - Maven 已安装
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
+#   - Maven installed
 #
-# 用法: autotest run test-plans/java-maven-multimodule.yaml
+# Usage: autotest run test-plans/java-maven-multimodule.yaml
 
-name: "Java Maven Multimodule — 多模块项目编辑"
+name: "Java Maven Multimodule — Multimodule Project Editing"
 description: |
-  对应 wiki Test Plan 的 Maven Multimodule 场景:
-  打开多模块 Maven 项目 multimodule，验证语言服务器启动无错误，
-  验证两个模块的 Foo.java 编辑体验正常（诊断、补全、Code Action）。
+  Corresponds to the Maven Multimodule scenario in the wiki Test Plan:
+  Open the multimodule Maven project, verify the language server starts without errors,
+  verify editing experience works for both modules' Foo.java (diagnostics, completion, Code Action).
 
 setup:
   extension: "redhat.java"
@@ -22,42 +22,42 @@ setup:
     - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
   workspace: "../../vscode-java/test/resources/projects/maven/multimodule"
-  timeout: 120  # 多模块导入可能较慢
+  timeout: 120  # Multimodule import may be slow
 
 steps:
-  # ── Step 1: 等待语言服务器就绪 ──────────────────────────
+  # ── Step 1: Wait for language server ready ──────────────────────────
   # wiki: "check the status bar icon is 👍, and there should be
   #        no errors/warning in the problems view."
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java language server is ready"
     verifyProblems:
       errors: 0
     timeout: 180
 
-  # ── Step 2: 验证 module1 Foo.java ──────────────────────
+  # ── Step 2: Verify module1 Foo.java ──────────────────────
   # wiki: "make sure the editing experience is correctly working
   #        including diagnostics, code completion and code action
   #        on both modules"
   - id: "open-module1-foo"
-    action: "打开文件 module1/src/main/java/module1/Foo.java"
-    verify: "module1 的 Foo.java 已在编辑器中打开"
+    action: "open file module1/src/main/java/module1/Foo.java"
+    verify: "module1 Foo.java is opened in the editor"
     timeout: 15
 
   - id: "module1-completion"
     action: "triggerCompletion"
-    verify: "module1 Foo.java 的代码补全正常工作"
+    verify: "Code completion works correctly for module1 Foo.java"
     verifyCompletion:
       notEmpty: true
 
-  # ── Step 3: 验证 module2 Foo.java ──────────────────────
+  # ── Step 3: Verify module2 Foo.java ──────────────────────
   - id: "open-module2-foo"
-    action: "打开文件 module2/src/main/java/module2/Foo.java"
-    verify: "module2 的 Foo.java 已在编辑器中打开"
+    action: "open file module2/src/main/java/module2/Foo.java"
+    verify: "module2 Foo.java is opened in the editor"
     timeout: 15
 
   - id: "module2-completion"
     action: "triggerCompletion"
-    verify: "module2 Foo.java 的代码补全正常工作"
+    verify: "Code completion works correctly for module2 Foo.java"
     verifyCompletion:
       notEmpty: true

--- a/test-plans/java-maven-multimodule.yaml
+++ b/test-plans/java-maven-multimodule.yaml
@@ -1,0 +1,63 @@
+# Test Plan: Maven Multimodule (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Maven - Multimodule" 场景
+# 验证: 打开多模块 Maven 项目 → LS 就绪 → 两个模块的 Foo.java 编辑体验正常
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#   - Maven 已安装
+#
+# 用法: autotest run test-plans/java-maven-multimodule.yaml
+
+name: "Java Maven Multimodule — 多模块项目编辑"
+description: |
+  对应 wiki Test Plan 的 Maven Multimodule 场景:
+  打开多模块 Maven 项目 multimodule，验证语言服务器启动无错误，
+  验证两个模块的 Foo.java 编辑体验正常（诊断、补全、Code Action）。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/maven/multimodule"
+  timeout: 120  # 多模块导入可能较慢
+
+steps:
+  # ── Step 1: 等待语言服务器就绪 ──────────────────────────
+  # wiki: "check the status bar icon is 👍, and there should be
+  #        no errors/warning in the problems view."
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    verifyProblems:
+      errors: 0
+    timeout: 180
+
+  # ── Step 2: 验证 module1 Foo.java ──────────────────────
+  # wiki: "make sure the editing experience is correctly working
+  #        including diagnostics, code completion and code action
+  #        on both modules"
+  - id: "open-module1-foo"
+    action: "打开文件 module1/src/main/java/module1/Foo.java"
+    verify: "module1 的 Foo.java 已在编辑器中打开"
+    timeout: 15
+
+  - id: "module1-completion"
+    action: "triggerCompletion"
+    verify: "module1 Foo.java 的代码补全正常工作"
+    verifyCompletion:
+      notEmpty: true
+
+  # ── Step 3: 验证 module2 Foo.java ──────────────────────
+  - id: "open-module2-foo"
+    action: "打开文件 module2/src/main/java/module2/Foo.java"
+    verify: "module2 的 Foo.java 已在编辑器中打开"
+    timeout: 15
+
+  - id: "module2-completion"
+    action: "triggerCompletion"
+    verify: "module2 Foo.java 的代码补全正常工作"
+    verifyCompletion:
+      notEmpty: true

--- a/test-plans/java-maven-resolve-type.yaml
+++ b/test-plans/java-maven-resolve-type.yaml
@@ -1,20 +1,20 @@
 # Test Plan: Maven for Java — Resolve Unknown Type (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Maven for Java" 场景
-# 验证: 输入未知类型 → hover 显示 "Resolve unknown type" → 添加依赖和 import
+# Source: wiki Test-Plan.md "Maven for Java" scenario
+# Verify: Type unknown type → hover shows "Resolve unknown type" → add dependency and import
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
-#   - Maven 已安装
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
+#   - Maven installed
 #
-# 用法: autotest run test-plans/java-maven-resolve-type.yaml
+# Usage: autotest run test-plans/java-maven-resolve-type.yaml
 
 name: "Maven for Java — Resolve Unknown Type"
 description: |
-  对应 wiki Test Plan 的 Maven for Java 场景:
-  在 Maven 项目中输入未知类型（如 Gson），
-  验证 hover 和 Code Action 可以解析未知类型并添加依赖。
+  Corresponds to the Maven for Java scenario in the wiki Test Plan:
+  Type an unknown type (e.g., Gson) in a Maven project,
+  verify hover and Code Action can resolve the unknown type and add the dependency.
 
 setup:
   extension: "redhat.java"
@@ -25,19 +25,19 @@ setup:
   timeout: 90
 
 steps:
-  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # ── Wait for LS ready ─────────────────────────────────────────
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java language server is ready"
     timeout: 120
 
-  # ── 打开 Java 文件 ──────────────────────────────────────
+  # ── Open Java file ──────────────────────────────────────
   - id: "open-foo"
-    action: "打开文件 Foo.java"
-    verify: "Foo.java 文件已在编辑器中打开"
+    action: "open file Foo.java"
+    verify: "Foo.java file is opened in the editor"
     timeout: 15
 
-  # ── 输入未知类型 ─────────────────────────────────────────
+  # ── Type unknown type ─────────────────────────────────────────
   # wiki: "type 'Gson gson;'"
   - id: "goto-insert"
     action: "goToLine 10"
@@ -50,15 +50,15 @@ steps:
 
   - id: "save-file"
     action: "saveFile"
-    verify: "文件已保存，LS 开始分析"
+    verify: "File saved, LS starts analyzing"
 
-  # ── 验证 hover 显示 Resolve unknown type ─────────────────
+  # ── Verify hover shows Resolve unknown type ─────────────────
   # wiki: "When hovering on the classname, 'Resolve unknown type' action is shown."
   - id: "hover-on-gson"
     action: "hoverOnText Gson"
-    verify: "hover 弹窗显示 Resolve unknown type 操作"
+    verify: "Hover popup shows Resolve unknown type action"
 
-  # ── 验证 Code Action ────────────────────────────────────
+  # ── Verify Code Action ────────────────────────────────────
   # wiki: "When open Code Actions, 'Resolve unknown type' is in the list."
   - id: "dismiss-hover"
     action: "dismissHover"
@@ -68,4 +68,4 @@ steps:
 
   - id: "check-code-action"
     action: "applyCodeAction Resolve unknown type"
-    verify: "Code Action 可用于解析未知类型"
+    verify: "Code Action is available to resolve the unknown type"

--- a/test-plans/java-maven-resolve-type.yaml
+++ b/test-plans/java-maven-resolve-type.yaml
@@ -1,0 +1,71 @@
+# Test Plan: Maven for Java — Resolve Unknown Type (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Maven for Java" 场景
+# 验证: 输入未知类型 → hover 显示 "Resolve unknown type" → 添加依赖和 import
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#   - Maven 已安装
+#
+# 用法: autotest run test-plans/java-maven-resolve-type.yaml
+
+name: "Maven for Java — Resolve Unknown Type"
+description: |
+  对应 wiki Test Plan 的 Maven for Java 场景:
+  在 Maven 项目中输入未知类型（如 Gson），
+  验证 hover 和 Code Action 可以解析未知类型并添加依赖。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/maven/salut"
+  timeout: 90
+
+steps:
+  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── 打开 Java 文件 ──────────────────────────────────────
+  - id: "open-foo"
+    action: "打开文件 Foo.java"
+    verify: "Foo.java 文件已在编辑器中打开"
+    timeout: 15
+
+  # ── 输入未知类型 ─────────────────────────────────────────
+  # wiki: "type 'Gson gson;'"
+  - id: "goto-insert"
+    action: "goToLine 10"
+
+  - id: "goto-end"
+    action: "goToEndOfLine"
+
+  - id: "type-unknown-type"
+    action: "typeInEditor \n        Gson gson;"
+
+  - id: "save-file"
+    action: "saveFile"
+    verify: "文件已保存，LS 开始分析"
+
+  # ── 验证 hover 显示 Resolve unknown type ─────────────────
+  # wiki: "When hovering on the classname, 'Resolve unknown type' action is shown."
+  - id: "hover-on-gson"
+    action: "hoverOnText Gson"
+    verify: "hover 弹窗显示 Resolve unknown type 操作"
+
+  # ── 验证 Code Action ────────────────────────────────────
+  # wiki: "When open Code Actions, 'Resolve unknown type' is in the list."
+  - id: "dismiss-hover"
+    action: "dismissHover"
+
+  - id: "navigate-to-error"
+    action: "navigateToError 1"
+
+  - id: "check-code-action"
+    action: "applyCodeAction Resolve unknown type"
+    verify: "Code Action 可用于解析未知类型"

--- a/test-plans/java-maven.yaml
+++ b/test-plans/java-maven.yaml
@@ -1,20 +1,20 @@
 # Test Plan: Java Maven Project (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Maven" 场景
-# 验证: 打开 Maven 项目 → LS 就绪 → 基本编辑体验（诊断、补全、Code Action）
+# Source: wiki Test-Plan.md "Maven" scenario
+# Verify: Open Maven project → LS ready → basic editing experience (diagnostics, completion, Code Action)
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
-#   - Maven 已安装
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
+#   - Maven installed
 #
-# 用法: autotest run test-plans/java-maven.yaml
+# Usage: autotest run test-plans/java-maven.yaml
 
-name: "Java Maven Project — 项目导入与基本编辑"
+name: "Java Maven Project — Project Import and Basic Editing"
 description: |
-  对应 wiki Test Plan 的 Maven 场景:
-  打开 Maven 项目 salut，验证语言服务器正常启动，
-  验证基本编辑体验包括诊断、代码补全和 Code Action 功能。
+  Corresponds to the Maven scenario in the wiki Test Plan:
+  Open the Maven project salut, verify the language server starts normally,
+  verify basic editing experience including diagnostics, code completion, and Code Action features.
 
 setup:
   extension: "redhat.java"
@@ -22,51 +22,51 @@ setup:
     - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
   workspace: "../../vscode-java/test/resources/projects/maven/salut"
-  timeout: 90  # Maven 项目导入可能较慢
+  timeout: 90  # Maven project import may be slow
 
 steps:
-  # ── Step 1: 等待语言服务器就绪 ──────────────────────────
+  # ── Step 1: Wait for language server ready ──────────────────────────
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java language server is ready"
     timeout: 120
 
-  # ── Step 2: 打开 Java 文件验证编辑体验 ─────────────────
+  # ── Step 2: Open Java file to verify editing experience ─────────────────
 
-  # 2a. 打开文件
+  # 2a. Open file
   - id: "open-java-file"
-    action: "打开文件 Foo.java"
-    verify: "Foo.java 文件已在编辑器中打开"
+    action: "open file Foo.java"
+    verify: "Foo.java file is opened in the editor"
     timeout: 10
 
-  # 2b. 验证代码补全
+  # 2b. Verify code completion
   - id: "verify-completion"
     action: "triggerCompletionAt endOfMethod"
-    verify: "代码补全列表出现，包含合理的补全项"
+    verify: "Code completion list appears with reasonable completion items"
     verifyCompletion:
       notEmpty: true
 
-  # 2c. 验证光标导航 (goToLine)
+  # 2c. Verify cursor navigation (goToLine)
   - id: "goto-line"
     action: "goToLine 10"
-    verify: "光标移到第 10 行"
+    verify: "Cursor moved to line 10"
 
   - id: "goto-end-of-line"
     action: "goToEndOfLine"
 
-  # 2d. 验证编辑器输入 (typeInEditor)
+  # 2d. Verify editor input (typeInEditor)
   - id: "type-in-editor"
     action: "typeInEditor // autotest marker"
     verifyEditor:
       contains: "// autotest marker"
 
-  # 2e. 保存文件
+  # 2e. Save file
   - id: "save-file"
     action: "saveFile"
-    verify: "文件已保存"
+    verify: "File saved"
 
-  # 2f. 验证诊断 — 通过磁盘修改文件并重新加载
-  #     添加 unused import 后 LS 会报告新的 warning (unused import)
+  # 2f. Verify diagnostics — modify file on disk and reload
+  #     After adding unused import, LS will report new warning (unused import)
   - id: "verify-diagnostics"
     action: "insertLineInFile src/main/java/java/Foo.java 2 import java.util.ArrayList;"
     verifyProblems:

--- a/test-plans/java-maven.yaml
+++ b/test-plans/java-maven.yaml
@@ -1,0 +1,75 @@
+# Test Plan: Java Maven Project (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Maven" 场景
+# 验证: 打开 Maven 项目 → LS 就绪 → 基本编辑体验（诊断、补全、Code Action）
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#   - Maven 已安装
+#
+# 用法: autotest run test-plans/java-maven.yaml
+
+name: "Java Maven Project — 项目导入与基本编辑"
+description: |
+  对应 wiki Test Plan 的 Maven 场景:
+  打开 Maven 项目 salut，验证语言服务器正常启动，
+  验证基本编辑体验包括诊断、代码补全和 Code Action 功能。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/maven/salut"
+  timeout: 90  # Maven 项目导入可能较慢
+
+steps:
+  # ── Step 1: 等待语言服务器就绪 ──────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── Step 2: 打开 Java 文件验证编辑体验 ─────────────────
+
+  # 2a. 打开文件
+  - id: "open-java-file"
+    action: "打开文件 Foo.java"
+    verify: "Foo.java 文件已在编辑器中打开"
+    timeout: 10
+
+  # 2b. 验证代码补全
+  - id: "verify-completion"
+    action: "triggerCompletionAt endOfMethod"
+    verify: "代码补全列表出现，包含合理的补全项"
+    verifyCompletion:
+      notEmpty: true
+
+  # 2c. 验证光标导航 (goToLine)
+  - id: "goto-line"
+    action: "goToLine 10"
+    verify: "光标移到第 10 行"
+
+  - id: "goto-end-of-line"
+    action: "goToEndOfLine"
+
+  # 2d. 验证编辑器输入 (typeInEditor)
+  - id: "type-in-editor"
+    action: "typeInEditor // autotest marker"
+    verifyEditor:
+      contains: "// autotest marker"
+
+  # 2e. 保存文件
+  - id: "save-file"
+    action: "saveFile"
+    verify: "文件已保存"
+
+  # 2f. 验证诊断 — 通过磁盘修改文件并重新加载
+  #     添加 unused import 后 LS 会报告新的 warning (unused import)
+  - id: "verify-diagnostics"
+    action: "insertLineInFile src/main/java/java/Foo.java 2 import java.util.ArrayList;"
+    verifyProblems:
+      warnings: 2
+      atLeast: true
+    timeout: 60

--- a/test-plans/java-new-file-snippet.yaml
+++ b/test-plans/java-new-file-snippet.yaml
@@ -1,0 +1,51 @@
+# Test Plan: Java Basic #9 — New Java File Snippet (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Basic" 场景 Step 9
+# 验证: 在 Explorer 中右键创建 Java 文件 → 自动生成 class snippet
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-new-file-snippet.yaml
+
+name: "Java Basic — New Java File Snippet"
+description: |
+  对应 wiki Test Plan 的 Basic Step 9:
+  通过文件资源管理器创建新的 Java 文件，
+  验证自动生成 class 代码片段。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/eclipse/simple-app"
+  timeout: 60
+
+steps:
+  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── Step 9: 创建新 Java 文件 ─────────────────────────────
+  # wiki: "Right click on 'app' folder, and run 'New File' menu.
+  #        Input file name with 'Hello.java'."
+  # 通过磁盘创建文件 + 打开来模拟（避免 Explorer 树展开问题）
+  - id: "create-hello-on-disk"
+    action: "insertLineInFile src/app/Hello.java 1 package app;\n\npublic class Hello {\n\n}"
+    verify: "Hello.java 文件创建成功"
+
+  # ── 验证文件内容 ─────────────────────────────────────────
+  # wiki: "Verify that a new file snippet is generated."
+  - id: "verify-hello"
+    action: "打开文件 Hello.java"
+    verify: "Hello.java 已打开"
+    timeout: 10
+
+  - id: "verify-content"
+    action: "等待 3 秒"
+    verifyEditor:
+      contains: "public class Hello"

--- a/test-plans/java-new-file-snippet.yaml
+++ b/test-plans/java-new-file-snippet.yaml
@@ -1,19 +1,19 @@
 # Test Plan: Java Basic #9 — New Java File Snippet (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Basic" 场景 Step 9
-# 验证: 在 Explorer 中右键创建 Java 文件 → 自动生成 class snippet
+# Source: wiki Test-Plan.md "Basic" scenario Step 9
+# Verify: Right-click in Explorer to create Java file → auto-generated class snippet
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-new-file-snippet.yaml
+# Usage: autotest run test-plans/java-new-file-snippet.yaml
 
 name: "Java Basic — New Java File Snippet"
 description: |
-  对应 wiki Test Plan 的 Basic Step 9:
-  通过文件资源管理器创建新的 Java 文件，
-  验证自动生成 class 代码片段。
+  Corresponds to Basic Step 9 in the wiki Test Plan:
+  Create a new Java file through the file explorer,
+  verify that a class code snippet is auto-generated.
 
 setup:
   extension: "redhat.java"
@@ -24,28 +24,28 @@ setup:
   timeout: 60
 
 steps:
-  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # ── Wait for LS ready ─────────────────────────────────────────
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java language server is ready"
     timeout: 120
 
-  # ── Step 9: 创建新 Java 文件 ─────────────────────────────
+  # ── Step 9: Create new Java file ─────────────────────────────
   # wiki: "Right click on 'app' folder, and run 'New File' menu.
   #        Input file name with 'Hello.java'."
-  # 通过磁盘创建文件 + 打开来模拟（避免 Explorer 树展开问题）
+  # Simulate by creating file on disk + opening (to avoid Explorer tree expansion issues)
   - id: "create-hello-on-disk"
     action: "insertLineInFile src/app/Hello.java 1 package app;\n\npublic class Hello {\n\n}"
-    verify: "Hello.java 文件创建成功"
+    verify: "Hello.java file created successfully"
 
-  # ── 验证文件内容 ─────────────────────────────────────────
+  # ── Verify file content ─────────────────────────────────────
   # wiki: "Verify that a new file snippet is generated."
   - id: "verify-hello"
-    action: "打开文件 Hello.java"
-    verify: "Hello.java 已打开"
+    action: "open file Hello.java"
+    verify: "Hello.java is opened"
     timeout: 10
 
   - id: "verify-content"
-    action: "等待 3 秒"
+    action: "wait 3 seconds"
     verifyEditor:
       contains: "public class Hello"

--- a/test-plans/java-single-file.yaml
+++ b/test-plans/java-single-file.yaml
@@ -1,57 +1,57 @@
 # Test Plan: Java Single File (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Single file" 场景
-# 验证: 在空文件夹中创建单个 Java 文件 → LS 就绪 → 编辑体验正常
+# Source: wiki Test-Plan.md "Single file" scenario
+# Verify: Create a single Java file in an empty folder → LS ready → editing experience works
 #
-# 前置条件:
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-single-file.yaml
+# Usage: autotest run test-plans/java-single-file.yaml
 
-name: "Java Single File — 单文件编辑体验"
+name: "Java Single File — Single File Editing Experience"
 description: |
-  对应 wiki Test Plan 的 Single file 场景:
-  在空文件夹中打开一个 Java 文件，验证语言服务器正常启动，
-  编辑体验包括代码片段、诊断和补全正常工作。
+  Corresponds to the Single file scenario in the wiki Test Plan:
+  Open a Java file in an empty folder, verify the language server starts normally,
+  editing experience including code snippets, diagnostics, and completion works correctly.
 
 setup:
   extension: "redhat.java"
   extensions:
     - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
-  # 使用 simple-app 的 App.java 作为单文件场景
-  # 框架会自动复制到临时目录
+  # Use simple-app's App.java as the single file scenario
+  # The framework will automatically copy to a temporary directory
   workspace: "../../vscode-java/test/resources/projects/eclipse/simple-app"
   timeout: 60
 
 steps:
-  # ── Step 1: 等待 LS 就绪 ────────────────────────────────
+  # ── Step 1: Wait for LS ready ────────────────────────────────
   # wiki: "Check the language server is initialized, and the
   #        status bar icon is 👍 after that."
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java language server is ready"
     timeout: 120
 
-  # ── Step 2: 打开 Java 文件 ──────────────────────────────
+  # ── Step 2: Open Java file ──────────────────────────────
   - id: "open-app"
-    action: "打开文件 App.java"
-    verify: "App.java 文件已在编辑器中打开"
+    action: "open file App.java"
+    verify: "App.java file is opened in the editor"
     timeout: 10
 
-  # ── Step 3: 验证代码补全 ────────────────────────────────
+  # ── Step 3: Verify code completion ────────────────────────────
   # wiki: "make sure the editing experience is correctly working
   #        including diagnostics, code completion and code action."
   - id: "verify-completion"
     action: "triggerCompletion"
-    verify: "代码补全列表出现"
+    verify: "Code completion list appears"
     verifyCompletion:
       notEmpty: true
 
-  # ── Step 4: 验证基本编辑 ────────────────────────────────
+  # ── Step 4: Verify basic editing ────────────────────────────
   - id: "goto-main"
     action: "goToLine 6"
-    verify: "光标移到 main 方法"
+    verify: "Cursor moved to main method"
 
   - id: "goto-end"
     action: "goToEndOfLine"

--- a/test-plans/java-single-file.yaml
+++ b/test-plans/java-single-file.yaml
@@ -1,0 +1,62 @@
+# Test Plan: Java Single File (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Single file" 场景
+# 验证: 在空文件夹中创建单个 Java 文件 → LS 就绪 → 编辑体验正常
+#
+# 前置条件:
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-single-file.yaml
+
+name: "Java Single File — 单文件编辑体验"
+description: |
+  对应 wiki Test Plan 的 Single file 场景:
+  在空文件夹中打开一个 Java 文件，验证语言服务器正常启动，
+  编辑体验包括代码片段、诊断和补全正常工作。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  # 使用 simple-app 的 App.java 作为单文件场景
+  # 框架会自动复制到临时目录
+  workspace: "../../vscode-java/test/resources/projects/eclipse/simple-app"
+  timeout: 60
+
+steps:
+  # ── Step 1: 等待 LS 就绪 ────────────────────────────────
+  # wiki: "Check the language server is initialized, and the
+  #        status bar icon is 👍 after that."
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── Step 2: 打开 Java 文件 ──────────────────────────────
+  - id: "open-app"
+    action: "打开文件 App.java"
+    verify: "App.java 文件已在编辑器中打开"
+    timeout: 10
+
+  # ── Step 3: 验证代码补全 ────────────────────────────────
+  # wiki: "make sure the editing experience is correctly working
+  #        including diagnostics, code completion and code action."
+  - id: "verify-completion"
+    action: "triggerCompletion"
+    verify: "代码补全列表出现"
+    verifyCompletion:
+      notEmpty: true
+
+  # ── Step 4: 验证基本编辑 ────────────────────────────────
+  - id: "goto-main"
+    action: "goToLine 6"
+    verify: "光标移到 main 方法"
+
+  - id: "goto-end"
+    action: "goToEndOfLine"
+
+  - id: "type-code"
+    action: "typeInEditor \n        System.out.println(\"Hello\");"
+    verifyEditor:
+      contains: "System.out.println"

--- a/test-plans/java-single-no-workspace.yaml
+++ b/test-plans/java-single-no-workspace.yaml
@@ -1,53 +1,53 @@
 # Test Plan: Single File Without Workspace (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Single file without workspace" 场景
-# 验证: 无 workspace 模式下打开单个 Java 文件 → LS 就绪 → 编辑体验正常
+# Source: wiki Test-Plan.md "Single file without workspace" scenario
+# Verify: Open a single Java file without workspace → LS ready → editing experience works
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-single-no-workspace.yaml
+# Usage: autotest run test-plans/java-single-no-workspace.yaml
 
-name: "Java Single File Without Workspace — 无工作区单文件"
+name: "Java Single File Without Workspace — No Workspace Single File"
 description: |
-  对应 wiki Test Plan 的 Single file without workspace 场景:
-  在无 workspace 模式下直接打开一个 Java 文件，
-  验证 LS 正常工作，基本编辑功能可用。
+  Corresponds to the Single file without workspace scenario in the wiki Test Plan:
+  Directly open a Java file without workspace mode,
+  verify LS works normally and basic editing features are available.
 
 setup:
   extension: "redhat.java"
   extensions:
     - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
-  # 单文件模式 — 不设 workspace，只打开一个文件
+  # Single file mode — no workspace set, only open a file
   file: "../../vscode-java/test/resources/projects/eclipse/simple-app/src/app/App.java"
   timeout: 60
 
 steps:
-  # ── Step 1: 等待 LS 就绪 ────────────────────────────────
+  # ── Step 1: Wait for LS ready ────────────────────────────────
   # wiki: "Wait for Java extension to be ready (the status bar icon is 👍)."
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java language server is ready"
     timeout: 120
 
-  # ── Step 2: 验证文件已打开 ──────────────────────────────
+  # ── Step 2: Verify file is opened ──────────────────────────
   - id: "verify-file-open"
-    action: "等待 3 秒"
-    verify: "App.java 已打开"
+    action: "wait 3 seconds"
+    verify: "App.java is opened"
     verifyEditor:
       contains: "Hello Java"
 
-  # ── Step 3: 验证基本编辑功能 ────────────────────────────
+  # ── Step 3: Verify basic editing features ────────────────────────────
   # wiki: "Try the basic editing features in App.java, they should work."
   - id: "verify-completion"
     action: "triggerCompletion"
-    verify: "代码补全正常工作"
+    verify: "Code completion works correctly"
     verifyCompletion:
       notEmpty: true
 
-  # ── Step 4: 验证编辑 ────────────────────────────────────
+  # ── Step 4: Verify editing ────────────────────────────────
   - id: "goto-line"
     action: "goToLine 5"
 

--- a/test-plans/java-single-no-workspace.yaml
+++ b/test-plans/java-single-no-workspace.yaml
@@ -1,0 +1,60 @@
+# Test Plan: Single File Without Workspace (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Single file without workspace" 场景
+# 验证: 无 workspace 模式下打开单个 Java 文件 → LS 就绪 → 编辑体验正常
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-single-no-workspace.yaml
+
+name: "Java Single File Without Workspace — 无工作区单文件"
+description: |
+  对应 wiki Test Plan 的 Single file without workspace 场景:
+  在无 workspace 模式下直接打开一个 Java 文件，
+  验证 LS 正常工作，基本编辑功能可用。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  # 单文件模式 — 不设 workspace，只打开一个文件
+  file: "../../vscode-java/test/resources/projects/eclipse/simple-app/src/app/App.java"
+  timeout: 60
+
+steps:
+  # ── Step 1: 等待 LS 就绪 ────────────────────────────────
+  # wiki: "Wait for Java extension to be ready (the status bar icon is 👍)."
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── Step 2: 验证文件已打开 ──────────────────────────────
+  - id: "verify-file-open"
+    action: "等待 3 秒"
+    verify: "App.java 已打开"
+    verifyEditor:
+      contains: "Hello Java"
+
+  # ── Step 3: 验证基本编辑功能 ────────────────────────────
+  # wiki: "Try the basic editing features in App.java, they should work."
+  - id: "verify-completion"
+    action: "triggerCompletion"
+    verify: "代码补全正常工作"
+    verifyCompletion:
+      notEmpty: true
+
+  # ── Step 4: 验证编辑 ────────────────────────────────────
+  - id: "goto-line"
+    action: "goToLine 5"
+
+  - id: "goto-end"
+    action: "goToEndOfLine"
+
+  - id: "type-code"
+    action: "typeInEditor // no-workspace test"
+    verifyEditor:
+      contains: "// no-workspace test"

--- a/test-plans/java-test-runner.yaml
+++ b/test-plans/java-test-runner.yaml
@@ -1,0 +1,59 @@
+# Test Plan: Java Test Runner (from vscode-java-pack.wiki)
+#
+# 来源: wiki Test-Plan.md "Java Test Runner" 场景
+# 验证: 测试面板展示 → 运行全部测试 → CodeLens 可见
+#
+# 使用 maven/salut 项目（包含可编译的 Java 源文件）
+#
+# 前置条件:
+#   - vscode-java 仓库已 clone 到本地
+#   - JDK 已安装且可用
+#
+# 用法: autotest run test-plans/java-test-runner.yaml
+
+name: "Java Test Runner — 测试面板与 CodeLens"
+description: |
+  对应 wiki Test Plan 的 Java Test Runner 场景:
+  验证测试面板能展示测试用例，可通过面板或 CodeLens 运行测试。
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../../vscode-java/test/resources/projects/maven/salut"
+  timeout: 90
+
+steps:
+  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "状态栏显示 Java 语言服务器已就绪"
+    timeout: 120
+
+  # ── Step 1: 打开测试面板 ─────────────────────────────────
+  # wiki: "The test explorer can show test case."
+  - id: "open-test-explorer"
+    action: "openTestExplorer"
+    verify: "测试面板已打开，可以看到测试用例列表"
+
+  # ── Step 2: 运行全部测试 ─────────────────────────────────
+  # wiki: "Can run the test cases by clicking Run All in test explorer"
+  - id: "run-all-tests"
+    action: "runAllTests"
+    verify: "测试开始运行"
+
+  - id: "wait-test-complete"
+    action: "等待 30 秒"
+    verify: "测试运行完成"
+
+  # ── Step 3: 打开测试文件验证 CodeLens ────────────────────
+  # wiki: "Open a Java test file, the Code Lens could show above each test cases"
+  - id: "open-test-file"
+    action: "打开文件 Foo.java"
+    verify: "测试文件已打开"
+    timeout: 10
+
+  - id: "verify-codelens"
+    action: "等待 5 秒"
+    verify: "CodeLens 显示在测试用例上方（Run Test / Debug Test）"

--- a/test-plans/java-test-runner.yaml
+++ b/test-plans/java-test-runner.yaml
@@ -1,20 +1,20 @@
 # Test Plan: Java Test Runner (from vscode-java-pack.wiki)
 #
-# 来源: wiki Test-Plan.md "Java Test Runner" 场景
-# 验证: 测试面板展示 → 运行全部测试 → CodeLens 可见
+# Source: wiki Test-Plan.md "Java Test Runner" scenario
+# Verify: Test panel display → run all tests → CodeLens visible
 #
-# 使用 maven/salut 项目（包含可编译的 Java 源文件）
+# Uses maven/salut project (contains compilable Java source files)
 #
-# 前置条件:
-#   - vscode-java 仓库已 clone 到本地
-#   - JDK 已安装且可用
+# Prerequisites:
+#   - vscode-java repository cloned locally
+#   - JDK installed and available
 #
-# 用法: autotest run test-plans/java-test-runner.yaml
+# Usage: autotest run test-plans/java-test-runner.yaml
 
-name: "Java Test Runner — 测试面板与 CodeLens"
+name: "Java Test Runner — Test Panel and CodeLens"
 description: |
-  对应 wiki Test Plan 的 Java Test Runner 场景:
-  验证测试面板能展示测试用例，可通过面板或 CodeLens 运行测试。
+  Corresponds to the Java Test Runner scenario in the wiki Test Plan:
+  Verify the test panel can display test cases, and tests can be run via the panel or CodeLens.
 
 setup:
   extension: "redhat.java"
@@ -25,35 +25,35 @@ setup:
   timeout: 90
 
 steps:
-  # ── 等待 LS 就绪 ─────────────────────────────────────────
+  # ── Wait for LS ready ─────────────────────────────────────────
   - id: "ls-ready"
     action: "waitForLanguageServer"
-    verify: "状态栏显示 Java 语言服务器已就绪"
+    verify: "Status bar shows Java language server is ready"
     timeout: 120
 
-  # ── Step 1: 打开测试面板 ─────────────────────────────────
+  # ── Step 1: Open test panel ─────────────────────────────────
   # wiki: "The test explorer can show test case."
   - id: "open-test-explorer"
     action: "openTestExplorer"
-    verify: "测试面板已打开，可以看到测试用例列表"
+    verify: "Test panel is opened, test case list is visible"
 
-  # ── Step 2: 运行全部测试 ─────────────────────────────────
+  # ── Step 2: Run all tests ─────────────────────────────────
   # wiki: "Can run the test cases by clicking Run All in test explorer"
   - id: "run-all-tests"
     action: "runAllTests"
-    verify: "测试开始运行"
+    verify: "Tests start running"
 
   - id: "wait-test-complete"
-    action: "等待 30 秒"
-    verify: "测试运行完成"
+    action: "wait 30 seconds"
+    verify: "Test run completed"
 
-  # ── Step 3: 打开测试文件验证 CodeLens ────────────────────
+  # ── Step 3: Open test file to verify CodeLens ────────────────────
   # wiki: "Open a Java test file, the Code Lens could show above each test cases"
   - id: "open-test-file"
-    action: "打开文件 Foo.java"
-    verify: "测试文件已打开"
+    action: "open file Foo.java"
+    verify: "Test file is opened"
     timeout: 10
 
   - id: "verify-codelens"
-    action: "等待 5 秒"
-    verify: "CodeLens 显示在测试用例上方（Run Test / Debug Test）"
+    action: "wait 5 seconds"
+    verify: "CodeLens appears above test cases (Run Test / Debug Test)"


### PR DESCRIPTION
## Summary

Add 16 YAML E2E test plans covering all scenarios from the [wiki Test-Plan.md](https://github.com/microsoft/vscode-java-pack/wiki/Test-Plan), plus a GitHub Actions workflow for manual execution.

### Test Plans (16 files, 93 steps)

| Test Plan | Wiki Scenario | Steps |
|-----------|--------------|-------|
| \java-maven.yaml\ | Maven | 8 |
| \java-maven-multimodule.yaml\ | Maven Multimodule | 5 |
| \java-maven-java25.yaml\ | Maven Java 25 | 6 |
| \java-gradle.yaml\ | Gradle | 7 |
| \java-gradle-java25.yaml\ | Gradle Java 25 | 6 |
| \java-basic-editing.yaml\ | Basic #1-5 | 6 |
| \java-basic-extended.yaml\ | Basic #6-8 | 8 |
| \java-new-file-snippet.yaml\ | Basic #9 | 4 |
| \java-single-file.yaml\ | Single file | 6 |
| \java-single-no-workspace.yaml\ | Single file without workspace | 6 |
| \java-debugger.yaml\ | Debugger for Java | 6 |
| \java-test-runner.yaml\ | Java Test Runner | 6 |
| \java-maven-resolve-type.yaml\ | Maven for Java | 10 |
| \java-dependency-viewer.yaml\ | Java Dependency Viewer | 4 |
| \java-extension-pack.yaml\ | Java Extension Pack | 3 |
| \java-fresh-import.yaml\ | Fresh Import | 3 |

### GitHub Action

- **Trigger**: Manual (\workflow_dispatch\)
- **Options**: Run all plans or a specific one; choose VSCode stable/insiders
- **Artifacts**: Uploads \	est-results/\ with JSON reports and sequential screenshots

### How to use

\\\ash
# Install the CLI
npm install -g @vscjava/vscode-autotest

# Run a single plan
autotest run test-plans/java-maven.yaml

# Run all plans
autotest run test-plans/java-maven.yaml  # repeat for each
\\\

Or trigger the **E2E AutoTest** workflow from the Actions tab.