### PR TITLE
fix: checkout test repos as siblings for correct relative paths

### DIFF
--- a/.github/workflows/e2e-autotest.yml
+++ b/.github/workflows/e2e-autotest.yml
@@ -51,13 +51,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: redhat-developer/vscode-java
-          path: vscode-java
+          path: ../vscode-java
 
       - name: Checkout eclipse.jdt.ls (Gradle test projects)
         uses: actions/checkout@v4
         with:
           repository: eclipse-jdtls/eclipse.jdt.ls
-          path: eclipse.jdt.ls
+          path: ../eclipse.jdt.ls
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -137,13 +137,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: redhat-developer/vscode-java
-          path: vscode-java
+          path: ../vscode-java
 
       - name: Checkout eclipse.jdt.ls
         uses: actions/checkout@v4
         with:
           repository: eclipse-jdtls/eclipse.jdt.ls
-          path: eclipse.jdt.ls
+          path: ../eclipse.jdt.ls
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Test plans use '../../vscode-java' and '../../eclipse.jdt.ls' relative to the plan file location, expecting these repos to be siblings of the main repo (matching local dev layout). The previous CI config checked them out inside the repo root, causing all 15 e2e tests to fail with ENOENT.

Change checkout path from 'vscode-java' to '../vscode-java' (and same for eclipse.jdt.ls) so the CI directory structure matches the expected layout.