### PR TITLE
refactor: Migrate webviews from React 16 + react-bootstrap to React 19 + @vscode-elements/elements

### DIFF
--- a/.github/workflows/pr-ui-autotest.yml
+++ b/.github/workflows/pr-ui-autotest.yml
@@ -1,0 +1,51 @@
+name: PR UI AutoTest
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ui-test:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Package PR VSIX
+        run: npx @vscode/vsce@latest package -o extension.vsix
+
+      - name: Install autotest CLI
+        run: npm install -g @vscjava/vscode-autotest
+
+      - name: Run Help Center webview UI test
+        shell: pwsh
+        run: |
+          $vsixPath = Join-Path (Get-Location) "extension.vsix"
+          autotest run test-plans\java-pack-help-center-webview.yaml --vsix $vsixPath --no-llm
+
+      - name: Upload UI test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-ui-autotest-results
+          path: test-results/
+          retention-days: 30

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,12 @@
       "version": "0.30.5",
       "license": "MIT",
       "dependencies": {
-        "@iconify-icons/codicon": "1.2.8",
-        "@iconify/react": "^1.1.4",
-        "@reduxjs/toolkit": "^1.8.6",
+        "@reduxjs/toolkit": "^2.0.0",
+        "@vscode-elements/elements": "^2.5.0",
         "@vscode/codicons": "^0.0.44",
-        "@vscode/webview-ui-toolkit": "1.4.0",
         "@xmldom/xmldom": "^0.8.13",
         "axios": "^1.15.0",
-        "bootstrap": "^4.6.2",
+        "bootstrap": "^5.3.8",
         "compare-versions": "^6.1.1",
         "expand-home-dir": "0.0.3",
         "expand-tilde": "^2.0.2",
@@ -24,12 +22,11 @@
         "hdr-histogram-js": "^3.0.1",
         "highlight.js": "11.11.1",
         "jdk-utils": "^0.4.4",
-        "jquery": "^3.6.1",
+        "jquery": "^4.0.0",
         "lodash": "^4.18.1",
-        "react": "^16.14.0",
-        "react-bootstrap": "^1.6.6",
-        "react-dom": "^16.14.0",
-        "react-redux": "^7.2.9",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-redux": "^9.0.0",
         "semver": "^7.7.4",
         "vscode-extension-telemetry-wrapper": "^0.15.2",
         "vscode-tas-client": "^0.1.75"
@@ -41,9 +38,8 @@
         "@types/lodash": "^4.14.186",
         "@types/node": "20.x",
         "@types/path-exists": "^4.0.2",
-        "@types/react": "^17.0.50",
-        "@types/react-dom": "^16.9.16",
-        "@types/react-redux": "^7.1.24",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "@types/semver": "^7.7.1",
         "@types/vscode": "^1.74.0",
         "@types/winreg": "^1.2.31",
@@ -71,49 +67,29 @@
     "node_modules/@assemblyscript/loader": {
       "version": "0.19.23",
       "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.19.23.tgz",
-      "integrity": "sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw=="
+      "integrity": "sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -128,24 +104,6 @@
       "engines": {
         "node": ">=14.17.0"
       }
-    },
-    "node_modules/@iconify-icons/codicon": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@iconify-icons/codicon/-/codicon-1.2.8.tgz",
-      "integrity": "sha512-+uCWAOuFMxgHtzeB7ESTSuVTaf2VzgbRSeIHO6v16EXQ3WxwiWC/0HxcPCW9hkbN2ySxrWwgYNAogf1tchCKPw==",
-      "dependencies": {
-        "@iconify/types": "^1.1.0"
-      }
-    },
-    "node_modules/@iconify/react": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-1.1.4.tgz",
-      "integrity": "sha512-oxq8IMOq8q3nKGiDHbQPC8FcFuBsKve68JWBo140d5LRnj0bv5TB/FE/y01ZSvEZ7PlI2HIrnb2qivPN8kTDgw=="
-    },
-    "node_modules/@iconify/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-Jh0llaK2LRXQoYsorIH8maClebsnzTcve+7U3rQUSnC11X4jtPnFuyatqFLvMxZ8MLG8dB4zfHsbPfuvxluONw=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -195,6 +153,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.6.tgz",
+      "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.1.0"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@microsoft/1ds-core-js": {
@@ -302,47 +284,6 @@
       "license": "MIT",
       "dependencies": {
         "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
-      }
-    },
-    "node_modules/@microsoft/fast-element": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.13.0.tgz",
-      "integrity": "sha512-iFhzKbbD0cFRo9cEzLS3Tdo9BYuatdxmCEKCpZs1Cro/93zNMpZ/Y9/Z7SknmW6fhDZbpBvtO8lLh9TFEcNVAQ=="
-    },
-    "node_modules/@microsoft/fast-foundation": {
-      "version": "2.49.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.6.tgz",
-      "integrity": "sha512-DZVr+J/NIoskFC1Y6xnAowrMkdbf2d5o7UyWK6gW5AiQ6S386Ql8dw4KcC4kHaeE1yL2CKvweE79cj6ZhJhTvA==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.13.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "tabbable": "^5.2.0",
-        "tslib": "^1.13.0"
-      }
-    },
-    "node_modules/@microsoft/fast-foundation/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@microsoft/fast-react-wrapper": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.24.tgz",
-      "integrity": "sha512-sRnSBIKaO42p4mYoYR60spWVkg89wFxFAgQETIMazAm2TxtlsnsGszJnTwVhXq2Uz+XNiD8eKBkfzK5c/i6/Kw==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.13.0",
-        "@microsoft/fast-foundation": "^2.49.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
-    "node_modules/@microsoft/fast-web-utilities": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-      "dependencies": {
-        "exenv-es6": "^1.1.1"
       }
     },
     "node_modules/@nevware21/ts-async": {
@@ -670,42 +611,33 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/watcher/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
-      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
       "dependencies": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.0.2"
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -716,24 +648,17 @@
         }
       }
     },
-    "node_modules/@restart/context": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
-      "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
-      "peerDependencies": {
-        "react": ">=16.3.2"
-      }
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
-    "node_modules/@restart/hooks": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
-      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@types/bytes": {
       "version": "3.1.5",
@@ -775,7 +700,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha512-wlsMYiapmIR4Eq/Z0qysN8xaDMjSkO6AIDNFx9oxgWGeKVA1jU+NzwPRZErBNP5z6/dx6QNkNpKglBGPO9OkTA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/fs-extra": {
       "version": "11.0.4",
@@ -788,25 +714,12 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
-    "node_modules/@types/invariant": {
-      "version": "2.2.37",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.37.tgz",
-      "integrity": "sha512-IwpIMieE55oGWiXkQPSBY1nw1nFs6bsKXTFskNY8sdS17K24vyEBRQZEwlRS7ZmXCWnJcQtbxWzly+cODWGs2A=="
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsonfile": {
       "version": "6.1.4",
@@ -819,18 +732,20 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
-      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
-      "dev": true
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.15.tgz",
-      "integrity": "sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/path-exists": {
@@ -844,64 +759,25 @@
         "path-exists": "*"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
-    },
     "node_modules/@types/react": {
-      "version": "17.0.80",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-      "integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "16.9.24",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.24.tgz",
-      "integrity": "sha512-Gcmq2JTDheyWn/1eteqyzzWKSqDjYU6KYsIvH7thb7CR5OYInAWOX+7WnKf6PaU/cbdOc4szJItcDEJO7UGmfA==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
-      "dependencies": {
-        "@types/react": "^16"
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/react-dom/node_modules/@types/react": {
-      "version": "16.14.60",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.60.tgz",
-      "integrity": "sha512-wIFmnczGsTcgwCBeIYOuy2mdXEiKZ5znU/jNOnMZPQyCcIxauMGWlX0TNG4lZ7NxRKj7YUIZRneJQSSdB2jKgg==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-redux": {
-      "version": "7.1.33",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.33.tgz",
-      "integrity": "sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
-      }
-    },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
-      "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -910,28 +786,51 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/vscode": {
-      "version": "1.92.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.92.0.tgz",
-      "integrity": "sha512-DcZoCj17RXlzB4XJ7IfKdPTcTGDLYvTOcTNkvtjXWF+K2TlKzHHkBEXNWQRpBIXixNEUgx39cQeTFunY0E2msw==",
-      "dev": true
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
-    "node_modules/@types/warning": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
+      "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/winreg": {
       "version": "1.2.36",
       "resolved": "https://registry.npmjs.org/@types/winreg/-/winreg-1.2.36.tgz",
       "integrity": "sha512-DtafHy5A8hbaosXrbr7YdjQZaqVewXmiasRS5J4tYMzt3s1gkh40ixpxgVFfKiQ0JIYetTJABat47v9cpr/sQg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/xmldom": {
       "version": "0.1.34",
       "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.34.tgz",
       "integrity": "sha512-7eZFfxI9XHYjJJuugddV6N5YNeXgQE1lArWOcd1eCOKWb/FGs5SIjacSYuEJuwhsGS3gy4RuZ5EUIcqYscuPDA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vscode-elements/elements": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-2.5.1.tgz",
+      "integrity": "sha512-HiKgIj9GwlfYkw1LrxG7dM5bMQUr8/GkOqG1HU1+npGHd51nRKCF6ZZ9FtnfoC2wujNN0lc+m0emH/wMpAseYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lit/context": "^1.1.3",
+        "lit": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@vscode/codicons": ">=0.0.40"
+      }
     },
     "node_modules/@vscode/codicons": {
       "version": "0.0.44",
@@ -951,20 +850,6 @@
       },
       "engines": {
         "vscode": "^1.75.0"
-      }
-    },
-    "node_modules/@vscode/webview-ui-toolkit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
-      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4",
-        "@microsoft/fast-react-wrapper": "^0.3.22",
-        "tslib": "^2.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -1199,9 +1084,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1225,10 +1110,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1259,9 +1145,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1287,30 +1173,33 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1319,9 +1208,9 @@
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.24",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
-      "integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
         {
@@ -1339,8 +1228,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001766",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -1356,9 +1245,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -1370,7 +1259,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1389,16 +1279,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/big.js": {
@@ -1406,14 +1300,15 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "funding": [
         {
           "type": "github",
@@ -1426,14 +1321,13 @@
       ],
       "license": "MIT",
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1446,6 +1340,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -1454,9 +1349,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -1474,11 +1369,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1499,6 +1394,7 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1508,6 +1404,7 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1536,9 +1433,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {
@@ -1557,17 +1454,20 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -1591,14 +1491,10 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
@@ -1616,25 +1512,31 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1652,7 +1554,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
@@ -1664,12 +1567,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1693,26 +1597,6 @@
         }
       }
     },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1729,20 +1613,20 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
-      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
+      "integrity": "sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
+        "postcss": "^8.4.40",
         "postcss-modules-extract-imports": "^3.1.0",
         "postcss-modules-local-by-default": "^4.0.5",
         "postcss-modules-scope": "^3.2.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.4"
+        "semver": "^7.6.3"
       },
       "engines": {
         "node": ">= 18.12.0"
@@ -1752,7 +1636,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "webpack": "^5.27.0"
       },
       "peerDependenciesMeta": {
@@ -1769,6 +1653,7 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -1777,9 +1662,11 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1788,14 +1675,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -1810,21 +1689,13 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -1842,9 +1713,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1853,19 +1724,20 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -1882,9 +1754,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1923,9 +1795,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1971,6 +1843,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1980,6 +1853,7 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -1993,6 +1867,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2006,6 +1881,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2018,6 +1894,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -2027,6 +1904,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -2036,24 +1914,22 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
     },
-    "node_modules/exenv-es6": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
-    },
     "node_modules/expand-home-dir": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
-      "integrity": "sha512-f4P4+coDbYiQPui6LHV4DQFEvzINm9de9w7f+4kz5aGM5kcoe8zc7hnrOLAO7+NAlCLJtNhepUqkLDMKRPQoLA=="
+      "integrity": "sha512-f4P4+coDbYiQPui6LHV4DQFEvzINm9de9w7f+4kz5aGM5kcoe8zc7hnrOLAO7+NAlCLJtNhepUqkLDMKRPQoLA==",
+      "license": "BSD"
     },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "license": "MIT",
       "dependencies": {
         "homedir-polyfill": "^1.0.1"
       },
@@ -2065,13 +1941,15 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -2095,6 +1973,7 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -2104,6 +1983,7 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
       "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
@@ -2124,6 +2004,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2136,10 +2017,21 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2205,9 +2097,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2222,12 +2114,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2273,8 +2167,9 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2312,15 +2207,17 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -2351,9 +2248,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2384,18 +2282,11 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "license": "MIT",
       "dependencies": {
         "parse-passwd": "^1.0.0"
       },
@@ -2408,6 +2299,7 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^10 || ^12 || >= 14"
       },
@@ -2416,9 +2308,10 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -2453,6 +2346,7 @@
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -2473,6 +2367,7 @@
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2482,23 +2377,17 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/interpret": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
       "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-arrayish": {
@@ -2509,10 +2398,11 @@
       "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -2553,6 +2443,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2574,7 +2465,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -2590,6 +2482,7 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.4.6.tgz",
       "integrity": "sha512-J4eyuwm4Vdtfcbl/z+xZdQjiOEq3XXGM1fl8YAKZfiKD3FkgCjL5zEEtNVFimWECasFuDogoYTmzu9GlB7ZxGA==",
+      "license": "MIT",
       "bin": {
         "jdk-utils": "bin/cli.js"
       }
@@ -2607,16 +2500,6 @@
       },
       "engines": {
         "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-worker/node_modules/supports-color": {
@@ -2646,24 +2529,26 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -2673,19 +2558,22 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -2694,9 +2582,10 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2719,6 +2608,7 @@
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
       "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2730,10 +2620,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2749,6 +2670,7 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
       "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -2763,6 +2685,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -2775,17 +2698,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2817,10 +2729,24 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2829,6 +2755,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2854,6 +2781,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2863,6 +2791,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -2893,7 +2822,8 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
@@ -2904,25 +2834,18 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -2932,6 +2855,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -2947,6 +2871,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -2959,6 +2884,7 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2966,7 +2892,8 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -3004,17 +2931,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -3022,6 +2951,7 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3031,6 +2961,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3039,7 +2970,8 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3049,13 +2981,14 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -3066,23 +2999,12 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {
@@ -3115,9 +3037,9 @@
       }
     },
     "node_modules/postcss-loader": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.2.0.tgz",
-      "integrity": "sha512-tHX+RkpsXVcc7st4dSdDGliI+r4aAQDuv+v3vFYHixb6YgjreG5AG4SEB0kDK8u2s6htqEEpKlkhSBUTvWKYnA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.2.1.tgz",
+      "integrity": "sha512-k98jtRzthjj3f76MYTs9JTpRqV1RaaMhEU0Lpw9OTmQZQdppg4B30VZ74BojuBHt3F4KyubHJoXCMUeM8Bqeow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3133,7 +3055,7 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
         "postcss": "^7.0.0 || ^8.0.1",
         "webpack": "^5.0.0"
       },
@@ -3151,6 +3073,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
       "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^10 || ^12 || >= 14"
       },
@@ -3159,13 +3082,14 @@
       }
     },
     "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.5.tgz",
-      "integrity": "sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
+        "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.1.0"
       },
       "engines": {
@@ -3176,12 +3100,13 @@
       }
     },
     "node_modules/postcss-modules-scope": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.0.tgz",
-      "integrity": "sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
+        "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
         "node": "^10 || ^12 || >= 14"
@@ -3195,6 +3120,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
       "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "icss-utils": "^5.0.0"
       },
@@ -3206,10 +3132,11 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
-      "integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3222,37 +3149,17 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types-extra": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "dependencies": {
-        "react-is": "^16.3.2",
-        "warning": "^4.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -3269,136 +3176,53 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-bootstrap": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.8.tgz",
-      "integrity": "sha512-yD6uN78XlFOkETQp6GRuVe0s5509x3XYx8PfPbirwFTYCj5/RfmSs9YZGCwkUrhZNFzj7tZPdpb+3k50mK1E4g==",
-      "dependencies": {
-        "@babel/runtime": "^7.14.0",
-        "@restart/context": "^2.1.4",
-        "@restart/hooks": "^0.4.7",
-        "@types/invariant": "^2.2.33",
-        "@types/prop-types": "^15.7.3",
-        "@types/react": ">=16.14.8",
-        "@types/react-transition-group": "^4.4.1",
-        "@types/warning": "^3.0.0",
-        "classnames": "^2.3.1",
-        "dom-helpers": "^5.2.1",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.7.2",
-        "prop-types-extra": "^1.1.0",
-        "react-overlays": "^5.1.2",
-        "react-transition-group": "^4.4.1",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "node_modules/react-overlays": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
-      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.8",
-        "@popperjs/core": "^2.11.6",
-        "@restart/hooks": "^0.4.7",
-        "@types/warning": "^3.0.0",
-        "dom-helpers": "^5.2.0",
-        "prop-types": "^15.7.2",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-redux": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
-      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
-        "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "react-dom": {
+        "@types/react": {
           "optional": true
         },
-        "react-native": {
+        "redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-redux/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/readdirp": {
@@ -3420,6 +3244,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
       "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve": "^1.20.0"
       },
@@ -3428,19 +3253,18 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
       "peerDependencies": {
-        "redux": "^4"
+        "redux": "^5.0.0"
       }
     },
     "node_modules/require-from-string": {
@@ -3454,22 +3278,28 @@
       }
     },
     "node_modules/reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3480,6 +3310,7 @@
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -3492,6 +3323,7 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3507,14 +3339,14 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.97.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -3532,6 +3364,7 @@
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
       "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"
@@ -3566,19 +3399,17 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
       "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -3622,6 +3453,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -3634,17 +3466,19 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -3682,13 +3516,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/style-loader": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
       "integrity": "sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
       },
@@ -3701,15 +3537,16 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -3717,6 +3554,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3724,15 +3562,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
-    },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3743,15 +3576,10 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tas-client": {
-      "version": "0.2.33",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.2.33.tgz",
-      "integrity": "sha512-V+uqV66BOQnWxvI6HjDnE4VkInmYZUQ4dgB7gzaDyFyFSK1i1nF/j7DpS9UbQAgV9NaF1XpcyuavnM1qOeiEIg=="
-    },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3768,9 +3596,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3802,9 +3630,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3863,6 +3691,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -3871,9 +3700,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.5.4",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.4.tgz",
-      "integrity": "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==",
+      "version": "9.5.7",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
+      "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3891,80 +3720,11 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/ts-loader/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ts-loader/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ts-loader/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/ts-loader/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/ts-loader/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ts-loader/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -3998,38 +3758,120 @@
         "typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
       }
     },
+    "node_modules/tslint/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tslint/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/tslint/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tslint/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/tslint/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslint/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tslint/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/tslint/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
-    "node_modules/tslint/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+    "node_modules/tslint/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^1.8.1"
       },
       "peerDependencies": {
         "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
-    },
-    "node_modules/tsutils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -4045,30 +3887,18 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uncontrollable": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
-      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.3",
-        "@types/react": ">=16.9.11",
-        "invariant": "^2.2.4",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0"
-      }
-    },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -4109,15 +3939,26 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-extension-telemetry-wrapper": {
       "version": "0.15.2",
@@ -4130,23 +3971,22 @@
       }
     },
     "node_modules/vscode-tas-client": {
-      "version": "0.1.84",
-      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.84.tgz",
-      "integrity": "sha512-rUTrUopV+70hvx1hW5ebdw1nd6djxubkLvVxjGdyD/r5v/wcVF41LIfiAtbm5qLZDtQdsMH1IaCuDoluoIa88w==",
+      "version": "0.1.86",
+      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.86.tgz",
+      "integrity": "sha512-4P3zjGXTKXknbWOd6EDnD3lWZuc/aFrW8Ixzk0B8gQDBq2BXuKg0NwsZiFeAzBohAxCcsRA4gQipH57Bxf6XXg==",
+      "license": "MIT",
       "dependencies": {
-        "tas-client": "0.2.33"
+        "tas-client": "^0.3.2"
       },
       "engines": {
         "vscode": "^1.85.0"
       }
     },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
+    "node_modules/vscode-tas-client/node_modules/tas-client": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.2.36.tgz",
+      "integrity": "sha512-xXt8f6y+ctykH456yuAD2UMKLqRbZvKxrk2c6TBljVTVE4u6jQjJMsGk/C1pyBLK4AymoyfjQN/qjUNkSu5JOQ==",
+      "license": "MIT"
     },
     "node_modules/watchpack": {
       "version": "2.5.1",
@@ -4163,9 +4003,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
-      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4175,25 +4015,24 @@
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.19.0",
+        "enhanced-resolve": "^5.20.0",
         "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.16",
+        "terser-webpack-plugin": "^5.3.17",
         "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.3"
+        "webpack-sources": "^3.3.4"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -4280,9 +4119,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
+      "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4290,9 +4129,9 @@
       }
     },
     "node_modules/webpack/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4326,6 +4165,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -4351,6 +4200,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -4372,7 +4222,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -347,9 +347,8 @@
     "@types/lodash": "^4.14.186",
     "@types/node": "20.x",
     "@types/path-exists": "^4.0.2",
-    "@types/react": "^17.0.50",
-    "@types/react-dom": "^16.9.16",
-    "@types/react-redux": "^7.1.24",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@types/semver": "^7.7.1",
     "@types/vscode": "^1.74.0",
     "@types/winreg": "^1.2.31",
@@ -379,14 +378,12 @@
     "vscjava.vscode-java-dependency"
   ],
   "dependencies": {
-    "@iconify-icons/codicon": "1.2.8",
-    "@iconify/react": "^1.1.4",
-    "@reduxjs/toolkit": "^1.8.6",
+    "@reduxjs/toolkit": "^2.0.0",
+    "@vscode-elements/elements": "^2.5.0",
     "@vscode/codicons": "^0.0.44",
-    "@vscode/webview-ui-toolkit": "1.4.0",
     "@xmldom/xmldom": "^0.8.13",
     "axios": "^1.15.0",
-    "bootstrap": "^4.6.2",
+    "bootstrap": "^5.3.8",
     "compare-versions": "^6.1.1",
     "expand-home-dir": "0.0.3",
     "expand-tilde": "^2.0.2",
@@ -394,14 +391,16 @@
     "hdr-histogram-js": "^3.0.1",
     "highlight.js": "11.11.1",
     "jdk-utils": "^0.4.4",
-    "jquery": "^3.6.1",
+    "jquery": "^4.0.0",
     "lodash": "^4.18.1",
-    "react": "^16.14.0",
-    "react-bootstrap": "^1.6.6",
-    "react-dom": "^16.14.0",
-    "react-redux": "^7.2.9",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-redux": "^9.0.0",
     "semver": "^7.7.4",
     "vscode-extension-telemetry-wrapper": "^0.15.2",
     "vscode-tas-client": "^0.1.75"
+  },
+  "overrides": {
+    "tas-client": "~0.2.33"
   }
 }

--- a/src/assets/vscode.scss
+++ b/src/assets/vscode.scss
@@ -42,5 +42,353 @@ $code-color: var(--vscode-textPreformat-foreground);
 
 $input-color:var(--vscode-sideBarTitle-foreground);
 $input-bg:var(--vscode-sideBar-background);
-@import "~bootstrap/scss/bootstrap";
+// Base styles (replaces bootstrap)
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
 
+body {
+  margin: 0;
+  font-family: var(--vscode-font-family, sans-serif);
+  font-size: $font-size-base;
+  color: $body-color;
+  background-color: $body-bg;
+  line-height: 1.5;
+}
+
+a {
+  color: $link-color;
+  text-decoration: none;
+  &:hover {
+    color: $link-hover-color;
+    text-decoration: $link-hover-decoration;
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+h1 { font-size: $font-size-base * 2.5; }
+h2 { font-size: $font-size-base * 2; }
+h3 { font-size: $font-size-base * 1.75; }
+h4 { font-size: $font-size-base * 1.5; }
+h5 { font-size: $font-size-base * 1.25; }
+h6 { font-size: $font-size-base; }
+
+p { margin-top: 0; margin-bottom: 1rem; }
+
+small { font-size: 80%; font-weight: 400; }
+
+code {
+  font-size: $code-font-size;
+  color: $code-color;
+}
+
+pre {
+  color: $pre-color;
+}
+
+kbd {
+  padding: 0.2em 0.4em;
+  font-size: 87.5%;
+  color: $kbd-color;
+  background-color: $kbd-bg;
+  border-radius: 0.2rem;
+}
+
+// List group styles
+.list-group {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+}
+
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: $list-group-item-padding-y $list-group-item-padding-x;
+  color: $body-color;
+  background-color: $list-group-bg;
+  border: 1px solid $list-group-border-color;
+  border-radius: $list-group-border-radius;
+  text-decoration: none;
+  width: 100%;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+
+  + .list-group-item {
+    border-top-width: 0;
+  }
+
+  &:hover {
+    background-color: $list-group-hover-bg;
+  }
+  &.active {
+    color: $list-group-active-color;
+    background-color: $list-group-active-bg;
+  }
+  &.list-group-item-action {
+    color: $list-group-action-color;
+    cursor: pointer;
+    text-align: inherit;
+    &:hover, &:focus {
+      color: $list-group-action-color;
+      background-color: $list-group-hover-bg;
+      text-decoration: none;
+    }
+    &:active {
+      color: $list-group-action-color;
+      background-color: $list-group-action-active-bg;
+    }
+  }
+  // When combined with .flex-column, make it a flex container
+  &.flex-column {
+    display: flex;
+  }
+}
+
+// Card styles
+.card {
+  background-color: $card-bg;
+  color: $card-color;
+  border: 1px solid $card-border-color;
+  border-radius: 0.25rem;
+}
+
+.card-body {
+  padding: 1.25rem;
+}
+
+// Input styles
+.form-control {
+  color: $input-color;
+  background-color: $input-bg;
+  border: 1px solid var(--vscode-input-border, transparent);
+  padding: 0.375rem 0.75rem;
+  font-size: inherit;
+  line-height: 1.5;
+  border-radius: 0;
+}
+
+// Utility classes
+.text-center { text-align: center; }
+.text-left { text-align: left; }
+.text-right { text-align: right; }
+.text-muted { color: $text-muted; }
+.text-danger { color: var(--vscode-editorError-foreground, #f44747); }
+.mt-1 { margin-top: 0.25rem; }
+.mt-2 { margin-top: 0.5rem; }
+.mt-3 { margin-top: 1rem; }
+.mt-4 { margin-top: 1.5rem; }
+.mt-5 { margin-top: 3rem; }
+.mb-0 { margin-bottom: 0; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 1rem; }
+.mb-4 { margin-bottom: 1.5rem; }
+.mb-5 { margin-bottom: 3rem; }
+.ml-1 { margin-left: 0.25rem; }
+.mr-1 { margin-right: 0.25rem; }
+.my-0 { margin-top: 0; margin-bottom: 0; }
+.p-0 { padding: 0; }
+.p-2 { padding: 0.5rem; }
+.pl-0 { padding-left: 0; }
+.pl-1 { padding-left: 0.25rem; }
+.pl-3 { padding-left: 1rem; }
+.pr-0 { padding-right: 0; }
+.pr-1 { padding-right: 0.25rem; }
+.pr-3 { padding-right: 1rem; }
+.pt-1 { padding-top: 0.25rem; }
+.pt-3 { padding-top: 1rem; }
+.pb-1 { padding-bottom: 0.25rem; }
+.pb-2 { padding-bottom: 0.5rem; }
+.pb-3 { padding-bottom: 1rem; }
+.py-0 { padding-top: 0; padding-bottom: 0; }
+.font-weight-bold { font-weight: bold; }
+.font-weight-light { font-weight: 300; }
+.d-flex { display: flex; }
+.d-block { display: block; }
+.d-none { display: none; }
+.flex-column { flex-direction: column; }
+.flex-row { flex-direction: row; }
+.flex-wrap { flex-wrap: wrap; }
+.flex-nowrap { flex-wrap: nowrap; }
+.flex-grow-0 { flex-grow: 0; }
+.flex-grow-1 { flex-grow: 1; }
+.align-items-start { align-items: flex-start; }
+.align-items-center { align-items: center; }
+.w-100 { width: 100%; }
+.h-100 { height: 100%; }
+.float-right { float: right; }
+.inline-flex { display: inline-flex; align-items: center; }
+
+@media (min-width: 992px) {
+  .flex-lg-row { flex-direction: row; }
+  .flex-lg-column { flex-direction: column; }
+  .flex-lg-nowrap { flex-wrap: nowrap; }
+}
+
+// Button styles
+.btn {
+  display: inline-block;
+  padding: 0.375rem 0.75rem;
+  font-size: inherit;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+  color: var(--vscode-button-foreground);
+  background-color: var(--vscode-button-background);
+  &:hover { background-color: var(--vscode-button-hoverBackground); }
+  &.btn-primary {
+    color: var(--vscode-button-foreground);
+    background-color: var(--vscode-button-background);
+  }
+  &.btn-link {
+    color: $link-color;
+    background-color: transparent;
+    border-color: transparent;
+    text-decoration: none;
+    text-align: left;
+    &:hover { text-decoration: underline; }
+  }
+  &.btn-sm {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+    border-radius: 0.2rem;
+  }
+}
+
+// Override: when list-group-item is combined with btn/btn-link,
+// list-group styling wins. Must come AFTER .btn rules for specificity.
+.list-group-item.btn-link {
+  background-color: $list-group-bg;
+  color: $list-group-action-color;
+  border-color: $list-group-border-color;
+  text-align: left;
+  &:hover {
+    background-color: $list-group-hover-bg;
+    text-decoration: none;
+  }
+}
+
+// Flexbox grid replacement
+.container, .container-fluid {
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -15px;
+  margin-left: -15px;
+}
+
+.col {
+  flex: 1 0 0%;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@for $i from 1 through 12 {
+  .col-#{$i} {
+    flex: 0 0 calc(#{$i} / 12 * 100%);
+    max-width: calc(#{$i} / 12 * 100%);
+    padding-right: 15px;
+    padding-left: 15px;
+  }
+}
+
+// Nav/Tab styles (for jQuery webviews)
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+
+.nav-item { margin-bottom: -1px; }
+
+.nav-pills {
+  .nav-link {
+    display: block;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    border: none;
+    background: none;
+    color: var(--vscode-foreground);
+    text-decoration: none;
+    border-radius: 0.25rem;
+    &.active {
+      color: var(--vscode-button-foreground);
+      background-color: var(--vscode-button-background);
+    }
+    &:hover:not(.active) {
+      background-color: var(--vscode-list-hoverBackground);
+    }
+  }
+}
+
+// Tab content (bootstrap tab pane)
+.tab-content > .tab-pane { display: none; }
+.tab-content > .tab-pane.active { display: block; }
+.fade { opacity: 0; transition: opacity 0.15s linear; }
+.fade.show { opacity: 1; }
+
+// Table styles
+.table {
+  width: 100%;
+  margin-bottom: 1rem;
+  color: var(--vscode-editor-foreground);
+  border-collapse: collapse;
+
+  th, td {
+    padding: 0.3rem;
+    vertical-align: top;
+  }
+
+  &.table-hover tbody tr:hover {
+    background-color: var(--vscode-list-hoverBackground);
+  }
+
+  &.table-borderless th, &.table-borderless td {
+    border: 0;
+  }
+
+  &.table-sm th, &.table-sm td {
+    padding: 0.15rem;
+  }
+}
+
+// Form check (checkbox)
+.form-check {
+  position: relative;
+  display: block;
+  padding-left: 1.25rem;
+}
+
+.form-check-input {
+  position: absolute;
+  margin-top: 0.3rem;
+  margin-left: -1.25rem;
+}
+
+.form-check-label {
+  margin-bottom: 0;
+  cursor: pointer;
+}

--- a/src/beginner-tips/assets/BeginnerTips.tsx
+++ b/src/beginner-tips/assets/BeginnerTips.tsx
@@ -2,8 +2,9 @@
 // Licensed under the MIT license.
 
 import "./style.scss";
-import { VSCodePanelTab, VSCodePanels, VSCodePanelView } from "@vscode/webview-ui-toolkit/react";
-import React from 'react';
+import "@vscode-elements/elements/dist/vscode-tabs/index.js";
+import "@vscode-elements/elements/dist/vscode-tab-header/index.js";
+import "@vscode-elements/elements/dist/vscode-tab-panel/index.js";
 import CodeEditingPanel from "./tabs/CodeEditingPanel";
 import DebuggingPanel from "./tabs/DebuggingPanel";
 import FaqPanel from "./tabs/FaqPanel";
@@ -17,24 +18,24 @@ export default function BeginnerTips() {
           <h1 className="font-weight-light">Tips for Beginners</h1>
       </div>
       <div className="row">
-        <VSCodePanels activeid="tab-1">
-          <VSCodePanelTab id="tab-1">Quick Start</VSCodePanelTab>
-          <VSCodePanelTab id="tab-2">Code Editing</VSCodePanelTab>
-          <VSCodePanelTab id="tab-3">Debugging</VSCodePanelTab>
-          <VSCodePanelTab id="tab-4">FAQ</VSCodePanelTab>
-          <VSCodePanelView id="view-1">
+        <vscode-tabs selected-index={0}>
+          <vscode-tab-header slot="header">Quick Start</vscode-tab-header>
+          <vscode-tab-header slot="header">Code Editing</vscode-tab-header>
+          <vscode-tab-header slot="header">Debugging</vscode-tab-header>
+          <vscode-tab-header slot="header">FAQ</vscode-tab-header>
+          <vscode-tab-panel>
             <QuickStartPanel />
-          </VSCodePanelView>
-          <VSCodePanelView id="view-2">
+          </vscode-tab-panel>
+          <vscode-tab-panel>
             <CodeEditingPanel />
-          </VSCodePanelView>
-          <VSCodePanelView id="view-3">
+          </vscode-tab-panel>
+          <vscode-tab-panel>
             <DebuggingPanel />
-          </VSCodePanelView>
-          <VSCodePanelView id="view-4">
+          </vscode-tab-panel>
+          <vscode-tab-panel>
             <FaqPanel />
-          </VSCodePanelView>
-        </VSCodePanels>
+          </vscode-tab-panel>
+        </vscode-tabs>
       </div>
     </div>
   );

--- a/src/beginner-tips/assets/index.tsx
+++ b/src/beginner-tips/assets/index.tsx
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import BeginnerTips from "./BeginnerTips";
 
-ReactDOM.render(
-  <BeginnerTips />,
-  document.getElementById('root') as HTMLElement
-);
+const root = createRoot(document.getElementById('root')!);
+root.render(<BeginnerTips />);

--- a/src/beginner-tips/assets/style.scss
+++ b/src/beginner-tips/assets/style.scss
@@ -44,4 +44,17 @@ code {
     font-family: var(--vscode-editor-font-family);
 }
 
+.text-danger {
+    color: var(--vscode-editorError-foreground, #f44747);
+}
+
+.row {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.mt-5 { margin-top: 3rem; }
+.mb-0 { margin-bottom: 0; }
+.mb-5 { margin-bottom: 3rem; }
+
 @import "../../../node_modules/@vscode/codicons/dist/codicon.css";

--- a/src/beginner-tips/assets/tabs/CodeEditingPanel.tsx
+++ b/src/beginner-tips/assets/tabs/CodeEditingPanel.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { GenerateHeaderOptions } from "@microsoft/fast-foundation";
-import { VSCodeDataGrid, VSCodeDataGridRow, VSCodeDataGridCell } from "@vscode/webview-ui-toolkit/react";
-import React from 'react';
+import "@vscode-elements/elements/dist/vscode-table/index.js";
+import "@vscode-elements/elements/dist/vscode-table-row/index.js";
+import "@vscode-elements/elements/dist/vscode-table-cell/index.js";
+import "@vscode-elements/elements/dist/vscode-table-body/index.js";
 const isMac: boolean = navigator.platform.toLowerCase().indexOf("darwin") === 0;
 
 export default function CodeEditingPanel() {
@@ -33,48 +34,54 @@ export default function CodeEditingPanel() {
         <p>
           Code Navigation makes it easy to understand existing codebase. Here to mention a few features that can help you navigate your code repositories.
         </p>
-        <VSCodeDataGrid generateHeader={GenerateHeaderOptions.none} gridTemplateColumns="1fr 3fr">
-          <VSCodeDataGridRow key={1}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Go to Definition</VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2"><kbd>F12</kbd><br />You can also hover on the symbol to preview its declaration and javadoc. To jump to the definition, hold the {controlKey} key, and click on the symbol.</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-          <VSCodeDataGridRow key={2}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Go to Implementation</VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2">{f12Key}<br />For an interface, this shows all the implementors of that interface and for abstract methods, this shows all concrete implementations of that method.</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-          <VSCodeDataGridRow key={3}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Go to Type Definition</VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2">This one allows you to go to the definition of the type of the symbol. For example, you have a class member <code>someString</code>, "Go to Definition" will take you to the definition of <code>someString</code> while "Go to <strong>Type</strong> Definition" will take you to the definition of <code>String</code>.</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-          <VSCodeDataGridRow key={4}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Find All References</VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2">{shiftAltF12}<br />This allows you to quickly analyze the impact of your edit or the popularity of your specific method or property throughout your repository.</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-        </VSCodeDataGrid>
+        <vscode-table>
+          <vscode-table-body slot="body">
+          <vscode-table-row key={1}>
+            <vscode-table-cell className="font-weight-bold" >Go to Definition</vscode-table-cell>
+            <vscode-table-cell ><kbd>F12</kbd><br />You can also hover on the symbol to preview its declaration and javadoc. To jump to the definition, hold the {controlKey} key, and click on the symbol.</vscode-table-cell>
+          </vscode-table-row>
+          <vscode-table-row key={2}>
+            <vscode-table-cell className="font-weight-bold" >Go to Implementation</vscode-table-cell>
+            <vscode-table-cell >{f12Key}<br />For an interface, this shows all the implementors of that interface and for abstract methods, this shows all concrete implementations of that method.</vscode-table-cell>
+          </vscode-table-row>
+          <vscode-table-row key={3}>
+            <vscode-table-cell className="font-weight-bold" >Go to Type Definition</vscode-table-cell>
+            <vscode-table-cell >This one allows you to go to the definition of the type of the symbol. For example, you have a class member <code>someString</code>, "Go to Definition" will take you to the definition of <code>someString</code> while "Go to <strong>Type</strong> Definition" will take you to the definition of <code>String</code>.</vscode-table-cell>
+          </vscode-table-row>
+          <vscode-table-row key={4}>
+            <vscode-table-cell className="font-weight-bold" >Find All References</vscode-table-cell>
+            <vscode-table-cell >{shiftAltF12}<br />This allows you to quickly analyze the impact of your edit or the popularity of your specific method or property throughout your repository.</vscode-table-cell>
+          </vscode-table-row>
+          </vscode-table-body>
+        </vscode-table>
       </div>
       <div>
         <p>
           The commands above will possibly take you to another file. But you can choose to stay using the peeking features below:
         </p>
-        <VSCodeDataGrid generateHeader={GenerateHeaderOptions.none} gridTemplateColumns="1fr 3fr">
-          <VSCodeDataGridRow key={1}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Peek Definition</VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2">{altF12Key}</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-          <VSCodeDataGridRow key={2}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Peek References</VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2">{shiftF12}</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-        </VSCodeDataGrid>
+        <vscode-table>
+          <vscode-table-body slot="body">
+          <vscode-table-row key={1}>
+            <vscode-table-cell className="font-weight-bold" >Peek Definition</vscode-table-cell>
+            <vscode-table-cell >{altF12Key}</vscode-table-cell>
+          </vscode-table-row>
+          <vscode-table-row key={2}>
+            <vscode-table-cell className="font-weight-bold" >Peek References</vscode-table-cell>
+            <vscode-table-cell >{shiftF12}</vscode-table-cell>
+          </vscode-table-row>
+          </vscode-table-body>
+        </vscode-table>
       </div>
       <div>
         <p> Last but not least, you can jump between the matching brackets back and forth: </p>
-        <VSCodeDataGrid generateHeader={GenerateHeaderOptions.none} gridTemplateColumns="1fr 3fr">
-          <VSCodeDataGridRow key={1}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Go to Bracket</VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2">{ctrlShiftSlash}</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-        </VSCodeDataGrid>
+        <vscode-table>
+          <vscode-table-body slot="body">
+          <vscode-table-row key={1}>
+            <vscode-table-cell className="font-weight-bold" >Go to Bracket</vscode-table-cell>
+            <vscode-table-cell >{ctrlShiftSlash}</vscode-table-cell>
+          </vscode-table-row>
+          </vscode-table-body>
+        </vscode-table>
       </div>
       <h2 className="font-weight-light">IntelliSense</h2>
       <p>

--- a/src/beginner-tips/assets/tabs/DebuggingPanel.tsx
+++ b/src/beginner-tips/assets/tabs/DebuggingPanel.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { GenerateHeaderOptions } from "@microsoft/fast-foundation";
-import { VSCodeDataGrid, VSCodeDataGridRow, VSCodeDataGridCell } from "@vscode/webview-ui-toolkit/react";
-import React from 'react';
+import "@vscode-elements/elements/dist/vscode-table/index.js";
+import "@vscode-elements/elements/dist/vscode-table-row/index.js";
+import "@vscode-elements/elements/dist/vscode-table-cell/index.js";
+import "@vscode-elements/elements/dist/vscode-table-body/index.js";
 const isMac: boolean = navigator.platform.toLowerCase().indexOf("darwin") === 0;
 
 export default function DebuggingPanel() {
@@ -38,16 +39,18 @@ export default function DebuggingPanel() {
             <p>
                 You can also set <strong>Conditional Breakpoints</strong> based on expressions, hit counts, or a combination of both.
             </p>
-            <VSCodeDataGrid generateHeader={GenerateHeaderOptions.none} gridTemplateColumns="1fr 3fr">
-                <VSCodeDataGridRow key={1}>
-                    <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Expression condition</VSCodeDataGridCell>
-                    <VSCodeDataGridCell gridColumn="2">The breakpoint will be hit whenever the expression evaluates to <code>true</code></VSCodeDataGridCell>
-                </VSCodeDataGridRow>
-                <VSCodeDataGridRow key={2}>
-                    <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Hit count</VSCodeDataGridCell>
-                    <VSCodeDataGridCell gridColumn="2">The 'hit count' controls how many times a breakpoint needs to be hit before it will 'break' execution</VSCodeDataGridCell>
-                </VSCodeDataGridRow>
-            </VSCodeDataGrid>
+            <vscode-table>
+                <vscode-table-body slot="body">
+                <vscode-table-row key={1}>
+                    <vscode-table-cell className="font-weight-bold" >Expression condition</vscode-table-cell>
+                    <vscode-table-cell >The breakpoint will be hit whenever the expression evaluates to <code>true</code></vscode-table-cell>
+                </vscode-table-row>
+                <vscode-table-row key={2}>
+                    <vscode-table-cell className="font-weight-bold" >Hit count</vscode-table-cell>
+                    <vscode-table-cell >The 'hit count' controls how many times a breakpoint needs to be hit before it will 'break' execution</vscode-table-cell>
+                </vscode-table-row>
+                </vscode-table-body>
+            </vscode-table>
             <p>
                 You can add a condition and/or hit count when creating the breakpoint (with the <a href="command:editor.debug.action.conditionalBreakpoint">Add Conditional Breakpoint</a> action) or when modifying an existing one (with the Edit Breakpoint action). In both cases, an inline text box with a drop-down menu opens where you can enter expressions.
             </p>
@@ -64,32 +67,34 @@ export default function DebuggingPanel() {
             <p>
                 Once a debug session starts, the Debug toolbar will appear on the top of the editor. You can control the execution flow using the actions below.
             </p>
-            <VSCodeDataGrid generateHeader={GenerateHeaderOptions.none} gridTemplateColumns="1fr 3fr">
-                <VSCodeDataGridRow key={1}>
-                    <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Continue/Pause</VSCodeDataGridCell>
-                    <VSCodeDataGridCell gridColumn="2"><kbd>F5</kbd></VSCodeDataGridCell>
-                </VSCodeDataGridRow>
-                <VSCodeDataGridRow key={2}>
-                    <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Step Over</VSCodeDataGridCell>
-                    <VSCodeDataGridCell gridColumn="2"><kbd>F10</kbd></VSCodeDataGridCell>
-                </VSCodeDataGridRow>
-                <VSCodeDataGridRow key={3}>
-                    <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Step Into</VSCodeDataGridCell>
-                    <VSCodeDataGridCell gridColumn="2"><kbd>F11</kbd></VSCodeDataGridCell>
-                </VSCodeDataGridRow>
-                <VSCodeDataGridRow key={4}>
-                    <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Step Out</VSCodeDataGridCell>
-                    <VSCodeDataGridCell gridColumn="2">{sF11}</VSCodeDataGridCell>
-                </VSCodeDataGridRow>
-                <VSCodeDataGridRow key={5}>
-                    <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Restart</VSCodeDataGridCell>
-                    <VSCodeDataGridCell gridColumn="2">{csF5}</VSCodeDataGridCell>
-                </VSCodeDataGridRow>
-                <VSCodeDataGridRow key={6}>
-                    <VSCodeDataGridCell className="font-weight-bold" gridColumn="1">Stop</VSCodeDataGridCell>
-                    <VSCodeDataGridCell gridColumn="2">{sF5}</VSCodeDataGridCell>
-                </VSCodeDataGridRow>
-            </VSCodeDataGrid>
+            <vscode-table>
+                <vscode-table-body slot="body">
+                <vscode-table-row key={1}>
+                    <vscode-table-cell className="font-weight-bold" >Continue/Pause</vscode-table-cell>
+                    <vscode-table-cell ><kbd>F5</kbd></vscode-table-cell>
+                </vscode-table-row>
+                <vscode-table-row key={2}>
+                    <vscode-table-cell className="font-weight-bold" >Step Over</vscode-table-cell>
+                    <vscode-table-cell ><kbd>F10</kbd></vscode-table-cell>
+                </vscode-table-row>
+                <vscode-table-row key={3}>
+                    <vscode-table-cell className="font-weight-bold" >Step Into</vscode-table-cell>
+                    <vscode-table-cell ><kbd>F11</kbd></vscode-table-cell>
+                </vscode-table-row>
+                <vscode-table-row key={4}>
+                    <vscode-table-cell className="font-weight-bold" >Step Out</vscode-table-cell>
+                    <vscode-table-cell >{sF11}</vscode-table-cell>
+                </vscode-table-row>
+                <vscode-table-row key={5}>
+                    <vscode-table-cell className="font-weight-bold" >Restart</vscode-table-cell>
+                    <vscode-table-cell >{csF5}</vscode-table-cell>
+                </vscode-table-row>
+                <vscode-table-row key={6}>
+                    <vscode-table-cell className="font-weight-bold" >Stop</vscode-table-cell>
+                    <vscode-table-cell >{sF5}</vscode-table-cell>
+                </vscode-table-row>
+                </vscode-table-body>
+            </vscode-table>
             <h2 className="font-weight-light">Inspect Variables</h2>
             <p>
                 Variables can be inspected in the <strong>VARIABLES</strong> section of the Debug view or by hovering over their source in the editor. Variable values and expression evaluation are relative to the selected stack frame in the <strong>CALL STACK</strong> section.

--- a/src/beginner-tips/assets/tabs/FaqPanel.tsx
+++ b/src/beginner-tips/assets/tabs/FaqPanel.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { GenerateHeaderOptions } from "@microsoft/fast-foundation";
-import { VSCodeDataGrid, VSCodeDataGridRow, VSCodeDataGridCell } from "@vscode/webview-ui-toolkit/react";
-import React from 'react';
+import "@vscode-elements/elements/dist/vscode-table/index.js";
+import "@vscode-elements/elements/dist/vscode-table-row/index.js";
+import "@vscode-elements/elements/dist/vscode-table-cell/index.js";
+import "@vscode-elements/elements/dist/vscode-table-body/index.js";
 const REQUIRED_JDK_VERSION = 17;
 
 export default function FaqPanel() {
@@ -29,20 +30,22 @@ export default function FaqPanel() {
         <p>
           VS Code Java is new, and we are here to help.
         </p>
-        <VSCodeDataGrid generateHeader={GenerateHeaderOptions.none} gridTemplateColumns="1fr 3fr">
-          <VSCodeDataGridRow key={1}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1"><a href="https://gitter.im/redhat-developer/vscode-java">Ask Questions</a></VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2"><a href="https://gitter.im/redhat-developer/vscode-java">vscode-java</a> Gitter channel is recommended to ask for help</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-          <VSCodeDataGridRow key={2}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1"><a href="https://github.com/microsoft/vscode-java-pack/issues">Open Issues</a></VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2"><a href="https://github.com/microsoft/vscode-java-pack/issues">vscode-java-pack</a> GitHub repo is recommended for opening bugs</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-          <VSCodeDataGridRow key={3}>
-            <VSCodeDataGridCell className="font-weight-bold" gridColumn="1"><a href="https://twitter.com/search?q=vscodejava">Other Feedback</a></VSCodeDataGridCell>
-            <VSCodeDataGridCell gridColumn="2"><a href="https://twitter.com/VSCodeJava">@VSCodeJava</a> is the handle to mention on twitter</VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-        </VSCodeDataGrid>
+        <vscode-table>
+          <vscode-table-body slot="body">
+          <vscode-table-row key={1}>
+            <vscode-table-cell className="font-weight-bold" ><a href="https://gitter.im/redhat-developer/vscode-java">Ask Questions</a></vscode-table-cell>
+            <vscode-table-cell ><a href="https://gitter.im/redhat-developer/vscode-java">vscode-java</a> Gitter channel is recommended to ask for help</vscode-table-cell>
+          </vscode-table-row>
+          <vscode-table-row key={2}>
+            <vscode-table-cell className="font-weight-bold" ><a href="https://github.com/microsoft/vscode-java-pack/issues">Open Issues</a></vscode-table-cell>
+            <vscode-table-cell ><a href="https://github.com/microsoft/vscode-java-pack/issues">vscode-java-pack</a> GitHub repo is recommended for opening bugs</vscode-table-cell>
+          </vscode-table-row>
+          <vscode-table-row key={3}>
+            <vscode-table-cell className="font-weight-bold" ><a href="https://twitter.com/search?q=vscodejava">Other Feedback</a></vscode-table-cell>
+            <vscode-table-cell ><a href="https://twitter.com/VSCodeJava">@VSCodeJava</a> is the handle to mention on twitter</vscode-table-cell>
+          </vscode-table-row>
+          </vscode-table-body>
+        </vscode-table>
       </blockquote>
 
       <h2 className="font-weight-light">Why do I see the JDK errors?</h2>

--- a/src/beginner-tips/assets/tabs/QuickStartPanel.tsx
+++ b/src/beginner-tips/assets/tabs/QuickStartPanel.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React from 'react';
 
 const isMac: boolean = navigator.platform.toLowerCase().indexOf("darwin") === 0;
 

--- a/src/formatter-settings/assets/App.tsx
+++ b/src/formatter-settings/assets/App.tsx
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React from "react";
 import FormatterSettingsView from "./features/formatterSettings/FormatterSettingView";
 
-export class App extends React.Component {
-
-  render() {
-    return (
-      <FormatterSettingsView />
-    );
-  }
+export function App() {
+  return <FormatterSettingsView />;
 }

--- a/src/formatter-settings/assets/features/formatterSettings/FormatterSettingView.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/FormatterSettingView.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React, { useEffect } from "react";
-import { Col, Container, Nav, Row } from "react-bootstrap";
+import { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Dispatch } from "@reduxjs/toolkit";
 import { applyFormatResult, changeActiveCategory, changeReadOnlyState, loadProfileSetting, loadVSCodeSetting } from "./formatterSettingViewSlice";
@@ -12,6 +11,15 @@ import Setting from "./components/Setting";
 import { renderWhitespace } from "../../whitespace";
 import { onWillChangeExampleKind, onWillDownloadAndUse, onWillInitialize } from "../../utils";
 
+const categories = [
+  { key: Category.Indentation, label: "Indentation", example: ExampleKind.INDENTATION_EXAMPLE },
+  { key: Category.BlankLine, label: "Blank Lines", example: ExampleKind.BLANKLINE_EXAMPLE },
+  { key: Category.Comment, label: "Comment", example: ExampleKind.COMMENT_EXAMPLE },
+  { key: Category.InsertLine, label: "Insert Line", example: ExampleKind.INSERTLINE_EXAMPLE },
+  { key: Category.Whitespace, label: "Whitespace", example: ExampleKind.WHITESPACE_EXAMPLE },
+  { key: Category.Wrapping, label: "Wrapping", example: ExampleKind.WRAPPING_EXAMPLE },
+];
+
 const FormatterSettingsView = (): JSX.Element => {
   const activeCategory: Category = useSelector((state: any) => state.formatterSettings.activeCategory);
   const contentText: string = useSelector((state: any) => state.formatterSettings.formattedContent);
@@ -19,56 +27,24 @@ const FormatterSettingsView = (): JSX.Element => {
   const title: string = "Java Formatter Settings" + (readOnly ? " (Read Only)" : "");
 
   const dispatch: Dispatch<any> = useDispatch();
-  const onClickNaviBar = (element: any) => {
-    const activeCategory: Category = Number(element);
-    dispatch(changeActiveCategory(activeCategory));
-    let exampleKind: ExampleKind = ExampleKind.INDENTATION_EXAMPLE;
-    switch (activeCategory) {
-      case Category.BlankLine:
-        exampleKind = ExampleKind.BLANKLINE_EXAMPLE;
-        break;
-      case Category.Comment:
-        exampleKind = ExampleKind.COMMENT_EXAMPLE;
-        break;
-      case Category.Indentation:
-        exampleKind = ExampleKind.INDENTATION_EXAMPLE;
-        break;
-      case Category.InsertLine:
-        exampleKind = ExampleKind.INSERTLINE_EXAMPLE;
-        break;
-      case Category.Whitespace:
-        exampleKind = ExampleKind.WHITESPACE_EXAMPLE;
-        break;
-      case Category.Wrapping:
-        exampleKind = ExampleKind.WRAPPING_EXAMPLE;
-        break;
-      default:
-        exampleKind = ExampleKind.INDENTATION_EXAMPLE;
-    }
+  const onClickNaviBar = (cat: Category, exampleKind: ExampleKind) => {
+    dispatch(changeActiveCategory(cat));
     onWillChangeExampleKind(exampleKind);
   };
 
-  const naviBar: JSX.Element = (
-    <Nav activeKey={activeCategory} className="setting-nav flex-column" onSelect={onClickNaviBar}>
-      <Nav.Item>
-        <Nav.Link className="p-0" eventKey={Category.Indentation}>Indentation</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link className="p-0" eventKey={Category.BlankLine}>Blank Lines</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link className="p-0" eventKey={Category.Comment}>Comment</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link className="p-0" eventKey={Category.InsertLine}>Insert Line</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link className="p-0" eventKey={Category.Whitespace}>Whitespace</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link className="p-0" eventKey={Category.Wrapping}>Wrapping</Nav.Link>
-      </Nav.Item>
-    </Nav>
+  const naviBar = (
+    <nav className="setting-nav flex-column">
+      {categories.map(cat => (
+        <a
+          key={cat.key}
+          className={`nav-link p-0${activeCategory === cat.key ? " active" : ""}`}
+          onClick={() => onClickNaviBar(cat.key, cat.example)}
+          role="button"
+        >
+          {cat.label}
+        </a>
+      ))}
+    </nav>
   );
 
   const onDidReceiveMessage = (event: any) => {
@@ -94,21 +70,21 @@ const FormatterSettingsView = (): JSX.Element => {
   }, [contentText]);
 
   return (
-    <Container className="root d-flex flex-column">
-      <Row className="setting-header">
-        <Col><h2 className="mb-0">{title}</h2></Col>
-        <Col className="flex-grow-0">{readOnly && (<div><a className="btn btn-primary float-right edit-button" role="button" title="Download and edit profile" onClick={() => onWillDownloadAndUse()}>Download and Edit</a></div>)}</Col>
-      </Row>
-      <Row className="flex-grow-1 d-flex flex-nowrap view-body">
-        <Col className="flex-grow-0">{naviBar}</Col>
-        <Col className="d-flex view-content">
-          <Row className="flex-grow-1 flex-nowrap flex-column flex-lg-row d-flex w-100 h-100">
-            <Col className="flex-grow-0 setting-container d-flex flex-row flex-lg-column flex-lg-nowrap">{<Setting />}</Col>
-            <Col className="preview-container d-flex">{highlight(contentText)}</Col>
-          </Row>
-        </Col>
-      </Row>
-    </Container>
+    <div className="container root d-flex flex-column">
+      <div className="row setting-header">
+        <div className="col"><h2 className="mb-0">{title}</h2></div>
+        <div className="col flex-grow-0">{readOnly && (<div><a className="btn btn-primary float-right edit-button" role="button" title="Download and edit profile" onClick={() => onWillDownloadAndUse()}>Download and Edit</a></div>)}</div>
+      </div>
+      <div className="row flex-grow-1 d-flex flex-nowrap view-body">
+        <div className="col flex-grow-0">{naviBar}</div>
+        <div className="col d-flex view-content">
+          <div className="row flex-grow-1 flex-nowrap flex-column flex-lg-row d-flex w-100 h-100">
+            <div className="col flex-grow-0 setting-container d-flex flex-row flex-lg-column flex-lg-nowrap"><Setting /></div>
+            <div className="col preview-container d-flex">{highlight(contentText)}</div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/formatter-settings/assets/features/formatterSettings/components/Highlight.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/components/Highlight.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
 import hljs from "highlight.js";
 import "../../../../../../webview-resources/highlight.css";
 

--- a/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
+++ b/src/formatter-settings/assets/features/formatterSettings/components/Setting.tsx
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import checkIcon from "@iconify-icons/codicon/check";
-import chevronDownIcon from "@iconify-icons/codicon/chevron-down";
-import { Icon } from "@iconify/react";
-import React from "react";
-import { Dropdown, Form } from "react-bootstrap";
+import "@vscode-elements/elements/dist/vscode-single-select/index.js";
+import "@vscode-elements/elements/dist/vscode-option/index.js";
+
 import { useSelector } from "react-redux";
 import { VSCodeSettings } from "../../../../FormatterConstants";
 import { Category, ExampleKind, JavaFormatterSetting, ValueKind } from "../../../../types";
@@ -29,8 +27,8 @@ const Setting = (): JSX.Element => {
     onWillChangeSetting(e.target.id, e.target.value);
   };
 
-  const handleSelect = (setting: JavaFormatterSetting, entry: string) => {
-    onWillChangeSetting(setting.id, entry);
+  const handleSelect = (setting: JavaFormatterSetting, value: string) => {
+    onWillChangeSetting(setting.id, value);
   };
 
   const handleClick = (exampleKind: ExampleKind) => {
@@ -41,55 +39,50 @@ const Setting = (): JSX.Element => {
     if (!setting.name || !setting.id) {
       return null;
     }
-    const candidates = [];
     switch (setting.valueKind as ValueKind) {
       case ValueKind.Boolean:
         const willBeOverriden = detectIndentation && setting.id === VSCodeSettings.DETECT_INDENTATION;
         return (
           <div className="setting-section" key={`${setting.id}`} onClick={() => handleClick(setting.exampleKind)}>
-            <Form.Check type="checkbox" className="pl-0" id={`${setting.id}`} >
-              <Form.Check.Input type="checkbox" checked={setting.value === "true"} onChange={handleChangeCheckbox} disabled={readOnly} />
-              <Form.Check.Label className="setting-section-description">
-                <Icon className="codicon" icon={checkIcon} />
-                <div className="setting-section-description-checkbox">{setting.name}.</div>
-              </Form.Check.Label>
-              <br></br>
+            <div className="pl-0">
+              <label className="setting-section-description">
+                <input type="checkbox" id={`${setting.id}`} checked={setting.value === "true"} onChange={handleChangeCheckbox} disabled={readOnly} />
+                <i className="codicon codicon-check"></i>
+                <span className="setting-section-description-checkbox">{setting.name}.</span>
+              </label>
+              <br />
               <span className="warning">
                 {willBeOverriden ? "When enabled, the indentation settings will be overriden based on the file contents." : ""}
               </span>
-            </Form.Check>
+            </div>
           </div>
         );
       case ValueKind.Enum:
         if (!setting.candidates) {
           return null;
         }
-        for (const candidate of setting.candidates) {
-          candidates.push(
-            <Dropdown.Item key={`${setting.id}.${candidate}`} className="dropdown-item py-0 pl-1" onSelect={() => handleSelect(setting, candidate)}>
-              {candidate}
-            </Dropdown.Item>
-          );
-        }
         return (
           <div className="setting-section" key={`${setting.id}`} onClick={() => handleClick(setting.exampleKind)}>
             <span className="setting-section-description">{setting.name}.</span>
-            <Dropdown className="mt-1">
-              <Dropdown.Toggle className="dropdown-button flex-vertical-center text-left" disabled={readOnly}>
-                <span>{setting.value}</span>
-                <Icon className="codicon" icon={chevronDownIcon} />
-              </Dropdown.Toggle>
-              <Dropdown.Menu className="dropdown-menu mt-0 p-0">
-                {candidates}
-              </Dropdown.Menu>
-            </Dropdown>
-          </div >
+            <vscode-single-select
+              className="mt-1"
+              value={setting.value}
+              disabled={readOnly}
+              onChange={(e: any) => handleSelect(setting, e.target.value)}
+            >
+              {setting.candidates.map(candidate => (
+                <vscode-option key={`${setting.id}.${candidate}`} value={candidate} selected={candidate === setting.value}>
+                  {candidate}
+                </vscode-option>
+              ))}
+            </vscode-single-select>
+          </div>
         );
       case ValueKind.Number:
         return (
           <div className="setting-section" key={`${setting.id}`} onClick={() => handleClick(setting.exampleKind)}>
-            <Form.Label className="setting-section-description my-0">{setting.name}.</Form.Label>
-            <Form.Control className="pl-1 mt-1" type="number" id={setting.id} value={setting.value} onChange={handleChangeInput} disabled={readOnly}></Form.Control>
+            <label className="setting-section-description my-0">{setting.name}.</label>
+            <input className="form-control pl-1 mt-1" type="number" id={setting.id} value={setting.value} onChange={handleChangeInput} disabled={readOnly} />
           </div>
         );
       default:

--- a/src/formatter-settings/assets/index.tsx
+++ b/src/formatter-settings/assets/index.tsx
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import "./style.scss";
 import { App } from "./App";
 import store from "./app/store";
 
-ReactDOM.render(
-  <React.StrictMode>
-    <Provider store={store} >
+const root = createRoot(document.getElementById("formatterPanel")!);
+root.render(
+  <StrictMode>
+    <Provider store={store}>
       <App />
     </Provider>
-  </React.StrictMode>,
-  document.getElementById("formatterPanel")
+  </StrictMode>
 );

--- a/src/install-jdk/assets/App.tsx
+++ b/src/install-jdk/assets/App.tsx
@@ -1,16 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React from "react";
 import InstallJDKView from "./features/InstallJDKView";
 import './App.scss';
 
-class App extends React.Component {
-  render() {
-    return (
-      <InstallJDKView />
-    );
-  }
+export default function App() {
+  return <InstallJDKView />;
 }
-
-export default App;

--- a/src/install-jdk/assets/features/InstallJDKView.tsx
+++ b/src/install-jdk/assets/features/InstallJDKView.tsx
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeLink, VSCodeButton, VSCodePanelView, VSCodePanels, VSCodePanelTab } from "@vscode/webview-ui-toolkit/react";
-import React from 'react';
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+import "@vscode-elements/elements/dist/vscode-tabs/index.js";
+import "@vscode-elements/elements/dist/vscode-tab-header/index.js";
+import "@vscode-elements/elements/dist/vscode-tab-panel/index.js";
+
+
 import { WEBVIEW_ID } from '../../constants';
 import { encodeExternalLinkWithTelemetry } from '../../../utils/webview';
 import { onWillReloadWindow } from '../vscode.api';
@@ -17,21 +21,21 @@ export default function InstallJDKView() {
                 <h1 className="title">Install New JDK</h1>
             </header>
             <p className="intro">{/*reserved for introduction*/}</p>
-            <VSCodePanels activeid="tab-1">
-                <VSCodePanelTab id="tab-1">Adoptium's Temurin</VSCodePanelTab>
-                <VSCodePanelTab id="tab-2">Others</VSCodePanelTab>
-                <VSCodePanelView id="view-1">
+            <vscode-tabs selected-index={0} >
+                <vscode-tab-header slot="header" id="tab-1">Adoptium's Temurin</vscode-tab-header>
+                <vscode-tab-header slot="header" id="tab-2">Others</vscode-tab-header>
+                <vscode-tab-panel id="view-1">
                     <AdoptiumJDKPanel />
-                </VSCodePanelView>
-                <VSCodePanelView id="view-2">
+                </vscode-tab-panel>
+                <vscode-tab-panel id="view-2">
                     <OtherJDKsPanel />
-                </VSCodePanelView>
-            </VSCodePanels>
+                </vscode-tab-panel>
+            </vscode-tabs>
             <div className="footer">
                 <p>After you finish JDK installation, please reload Visual Studio Code to make it effective.</p>
                 <div>
-                    <VSCodeButton appearance='secondary' onClick={onWillReloadWindow}>Reload Window</VSCodeButton>
-                    <VSCodeLink className='troubleshoot-link' href={encodeExternalLinkWithTelemetry(WEBVIEW_ID, "Having trouble?", helpLink)}>Having trouble?</VSCodeLink>
+                    <vscode-button secondary onClick={onWillReloadWindow}>Reload Window</vscode-button>
+                    <a className='troubleshoot-link' href={encodeExternalLinkWithTelemetry(WEBVIEW_ID, "Having trouble?", helpLink)}>Having trouble?</a>
                 </div>
 
             </div>

--- a/src/install-jdk/assets/features/components/AdoptiumJDKPanel.tsx
+++ b/src/install-jdk/assets/features/components/AdoptiumJDKPanel.tsx
@@ -1,13 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { Orientation } from '@microsoft/fast-web-utilities';
-import { VSCodeRadioGroup, VSCodeRadio, VSCodeButton, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+import "@vscode-elements/elements/dist/vscode-progress-ring/index.js";
+import "@vscode-elements/elements/dist/vscode-radio-group/index.js";
+import "@vscode-elements/elements/dist/vscode-radio/index.js";
+
+
 import { AdoptiumAsset, AdoptiumReleaseInfo } from '../../../../utils/adoptiumApi';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { listReleases, selectVersion, showAsset } from '../installJDKViewSlice';
 import { onWillDownloadTemurinJDK, onWillFetchAsset, onWillFetchAvailableReleases } from '../../vscode.api';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import bytes from "bytes";
 
 const AdoptiumJDKPanel = () => {
@@ -49,7 +53,7 @@ const AdoptiumJDKPanel = () => {
 
   // rendering
   if (releases === undefined) {
-    return <VSCodeProgressRing />;
+    return <vscode-progress-ring />;
   }
 
   const versionElements = releases?.available_lts_releases.map((v: number) => {
@@ -57,16 +61,16 @@ const AdoptiumJDKPanel = () => {
       version: v,
       isLts: true,
     };
-  }).map((obj: any) => <VSCodeRadio
+  }).map((obj: any) => <vscode-radio
     key={obj.version}
     defaultChecked={obj.version === releases.most_recent_lts}
     checked={obj.version === currentVersion}
     onClick={() => handleVersionChange(obj.version)}
-  >{obj.version}{obj.isLts && " (LTS)"}</VSCodeRadio>);
+  >{obj.version}{obj.isLts && " (LTS)"}</vscode-radio>);
 
   const downloadPanel = asset ?
     <div>
-      <VSCodeButton onClick={() => downloadJDK(asset)}>
+      <vscode-button onClick={() => downloadJDK(asset)}>
         <div className='btn-download'>
           <div> 
             Download
@@ -88,21 +92,21 @@ const AdoptiumJDKPanel = () => {
             </div>
           </div>
         </div>
-      </VSCodeButton>
+      </vscode-button>
     </div>
     : 
-    <VSCodeProgressRing />;
+    <vscode-progress-ring />;
 
   return (
     <div>
-      <VSCodeRadioGroup orientation={Orientation.vertical} readOnly={asset===undefined}>
+      <vscode-radio-group orientation="vertical" readOnly={asset===undefined}>
         <label slot="label">Version</label>
         {versionElements}
-      </VSCodeRadioGroup>
-      <VSCodeRadioGroup orientation={Orientation.vertical} readOnly={asset===undefined}>
+      </vscode-radio-group>
+      <vscode-radio-group orientation="vertical" readOnly={asset===undefined}>
         <label slot="label">JVM</label>
-        <VSCodeRadio defaultChecked checked>hotspot</VSCodeRadio>
-      </VSCodeRadioGroup>
+        <vscode-radio defaultChecked checked>hotspot</vscode-radio>
+      </vscode-radio-group>
       {downloadPanel}
     </div>
   );

--- a/src/install-jdk/assets/features/components/OtherJDKsPanel.tsx
+++ b/src/install-jdk/assets/features/components/OtherJDKsPanel.tsx
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
-import * as React from 'react';
 import { encodeExternalLinkWithTelemetry } from '../../../../utils/webview';
 import { WEBVIEW_ID } from '../../../constants';
 
-class OtherJDKsPanel extends React.Component {
-  public render() {
+export default function OtherJDKsPanel() {
     const jdkList = [
       { name: "Amazon Corretto", url: "https://aws.amazon.com/corretto" },
       { name: "Azul Zulu", url: "https://www.azul.com/downloads/?package=jdk" },
@@ -23,13 +20,9 @@ class OtherJDKsPanel extends React.Component {
       <div>
         <ul className='jdk-distros'>
           {
-            jdkList.map((jdk, idx) => <li key={idx}><VSCodeLink href={encodeExternalLinkWithTelemetry(WEBVIEW_ID, jdk.name, jdk.url)} title={jdk.name}>{jdk.name}</VSCodeLink></li>)
+            jdkList.map((jdk, idx) => <li key={idx}><a href={encodeExternalLinkWithTelemetry(WEBVIEW_ID, jdk.name, jdk.url)} title={jdk.name}>{jdk.name}</a></li>)
           }
         </ul>
-
       </div>
     );
-  }
 }
-
-export default OtherJDKsPanel;

--- a/src/install-jdk/assets/index.tsx
+++ b/src/install-jdk/assets/index.tsx
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
-import { Provider } from 'react-redux'
+import { Provider } from 'react-redux';
 import store from './app/store';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root')!);
+root.render(
   <Provider store={store}>
     <App />
-  </Provider>,
-  document.getElementById('root') as HTMLElement
+  </Provider>
 );

--- a/src/java-runtime/assets/ProjectJDKPanel.tsx
+++ b/src/java-runtime/assets/ProjectJDKPanel.tsx
@@ -1,9 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { DataGridRowTypes, GenerateHeaderOptions } from "@microsoft/fast-foundation";
-import { VSCodeDataGrid, VSCodeDataGridRow, VSCodeDataGridCell, VSCodeButton } from "@vscode/webview-ui-toolkit/react";
-import * as React from "react";
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+import "@vscode-elements/elements/dist/vscode-table/index.js";
+import "@vscode-elements/elements/dist/vscode-table-body/index.js";
+import "@vscode-elements/elements/dist/vscode-table-row/index.js";
+import "@vscode-elements/elements/dist/vscode-table-cell/index.js";
+import "@vscode-elements/elements/dist/vscode-table-header/index.js";
+import "@vscode-elements/elements/dist/vscode-table-header-cell/index.js";
+
+import { useState } from "react";
 import { encodeCommandUriWithTelemetry, ProjectType } from "../../utils/webview";
 import { JavaRuntimeEntry, ProjectRuntimeEntry } from "../types";
 import { DefaultJDKSelector } from "./components/DefaultJDKSelector";
@@ -13,101 +19,81 @@ import { onWillListRuntimes, openBuildScript } from "./vscode.api";
 interface Props {
   jdkEntries: JavaRuntimeEntry[];
   projectRuntimes: ProjectRuntimeEntry[];
-};
-interface State {
-  showHintFor?: "Maven" | "Gradle" | "Others";
 }
 
-export class ProjectJDKPanel extends React.Component<Props, State> {
-  constructor(props: any) {
-    super(props);
-    this.state = {
-    };
-  }
-  render = () => {
-    const { jdkEntries, projectRuntimes } = this.props;
-    const { showHintFor } = this.state;
-    
+export function ProjectJDKPanel({ jdkEntries, projectRuntimes }: Props) {
+  const [showHintFor, setShowHintFor] = useState<"Maven" | "Gradle" | "Others" | undefined>();
 
-    const projectTypeHint = (projectType: ProjectType) => {
-      switch (projectType) {
-        case "Maven":
-          return <VSCodeButton onClick={() => this.showHint("Maven")} appearance="icon" title="For projects managed by build tools, Java version is specified in build scripts(e.g. pom.xml)."><span className="codicon codicon-info"></span></VSCodeButton>
-        case "Gradle":
-          return <VSCodeButton onClick={() => this.showHint("Gradle")} appearance="icon" title="For projects managed by build tools, Java version is specified in build scripts(e.g. build.gradle)."><span className="codicon codicon-info"></span></VSCodeButton>
-        default:
-          return <VSCodeButton onClick={() => this.showHint("Others")} appearance="icon" title="For folders containing .java files, but not managed by build tools like Maven/Gradle, a default JDK is used."><span className="codicon codicon-info"></span></VSCodeButton>
-      }
+  const projectTypeHint = (projectType: ProjectType) => {
+    switch (projectType) {
+      case "Maven":
+        return <vscode-button onClick={() => setShowHintFor("Maven")} icon-only title="For projects managed by build tools, Java version is specified in build scripts(e.g. pom.xml)."><span className="codicon codicon-info"></span></vscode-button>;
+      case "Gradle":
+        return <vscode-button onClick={() => setShowHintFor("Gradle")} icon-only title="For projects managed by build tools, Java version is specified in build scripts(e.g. build.gradle)."><span className="codicon codicon-info"></span></vscode-button>;
+      default:
+        return <vscode-button onClick={() => setShowHintFor("Others")} icon-only title="For folders containing .java files, but not managed by build tools like Maven/Gradle, a default JDK is used."><span className="codicon codicon-info"></span></vscode-button>;
     }
+  };
 
-    const projectEntries = projectRuntimes
-      .filter(p => p.projectType !== ProjectType.Default)
-      .map((p, index) => (
-        <VSCodeDataGridRow key={index}>
-          <VSCodeDataGridCell gridColumn="1">{p.name}</VSCodeDataGridCell>
-          <VSCodeDataGridCell gridColumn="2"><div className="inline-flex">{p.projectType}{projectTypeHint(p.projectType)}</div></VSCodeDataGridCell>
-          <VSCodeDataGridCell gridColumn="3">
-            {
-              hasBuildTool(p) ?
-                <div className="inline-flex">
-                  <span>{p.sourceLevel}</span>
-                  <VSCodeButton appearance="icon" onClick={() => this.onClickEdit(p)} title="Edit"><span className="codicon codicon-edit"></span></VSCodeButton>
-                </div>
-                :
-                <DefaultJDKSelector projectRuntime={p} jdkEntries={jdkEntries} />
-            }
-          </VSCodeDataGridCell>
-        </VSCodeDataGridRow>
-      ));
-    const downloadJDKCommand = encodeCommandUriWithTelemetry("java.runtime", "download", "java.installJdk");
-    return (
-      <div className="container">
-        <h1>Configure Runtime for Projects</h1>
-        {projectEntries.length > 0 && <p>Manage Java runtime for your projects. If you don't have a valid Java runtime, you can <a href={downloadJDKCommand}>download</a> one.</p>}
-        {
-          projectEntries.length > 0 ?
-            <VSCodeDataGrid generateHeader={GenerateHeaderOptions.none} gridTemplateColumns="1fr 1fr 1fr">
-              <VSCodeDataGridRow rowType={DataGridRowTypes.stickyHeader}>
-                <VSCodeDataGridCell gridColumn="1">Project Name</VSCodeDataGridCell>
-                <VSCodeDataGridCell gridColumn="2">Type</VSCodeDataGridCell>
-                <VSCodeDataGridCell gridColumn="3">Java Version</VSCodeDataGridCell>
-              </VSCodeDataGridRow>
-              {projectEntries}
-            </VSCodeDataGrid>
-            :
-            <div>
-              <p>No project detected yet. Please refresh later if Java extension is importing your projects.</p>
-              <VSCodeButton onClick={this.refresh}>Refresh<span slot="start" className="codicon codicon-refresh"></span></VSCodeButton>
-            </div>
-        }
-        <ProjectTypeHint projectType={showHintFor} />
-      </div>
-    );
-  }
-
-  onClickEdit = (p: ProjectRuntimeEntry) => {
+  const onClickEdit = (p: ProjectRuntimeEntry) => {
     let scriptFile;
     if (p.projectType === ProjectType.Maven) {
       scriptFile = "pom.xml";
     } else if (p.projectType === ProjectType.Gradle) {
       scriptFile = "build.gradle";
     }
-
     if (scriptFile) {
       openBuildScript(p.rootPath, scriptFile);
     }
-  }
+  };
 
-  showHint = (projectType: any) => {
-    this.setState({
-      showHintFor: projectType
-    });
-  }
+  const projectEntries = projectRuntimes
+    .filter(p => p.projectType !== ProjectType.Default)
+    .map((p, index) => (
+      <vscode-table-row key={index}>
+        <vscode-table-cell>{p.name}</vscode-table-cell>
+        <vscode-table-cell><div className="inline-flex">{p.projectType}{projectTypeHint(p.projectType)}</div></vscode-table-cell>
+        <vscode-table-cell>
+          {
+            hasBuildTool(p) ?
+              <div className="inline-flex">
+                <span>{p.sourceLevel}</span>
+                <vscode-button icon-only onClick={() => onClickEdit(p)} title="Edit"><span className="codicon codicon-edit"></span></vscode-button>
+              </div>
+              :
+              <DefaultJDKSelector projectRuntime={p} jdkEntries={jdkEntries} />
+          }
+        </vscode-table-cell>
+      </vscode-table-row>
+    ));
 
-  refresh = () => {
-    onWillListRuntimes();
-  }
-  
+  const downloadJDKCommand = encodeCommandUriWithTelemetry("java.runtime", "download", "java.installJdk");
+
+  return (
+    <div className="container">
+      <h1>Configure Runtime for Projects</h1>
+      {projectEntries.length > 0 && <p>Manage Java runtime for your projects. If you don't have a valid Java runtime, you can <a href={downloadJDKCommand}>download</a> one.</p>}
+      {
+        projectEntries.length > 0 ?
+          <vscode-table>
+            <vscode-table-header slot="header">
+              <vscode-table-header-cell>Project Name</vscode-table-header-cell>
+              <vscode-table-header-cell>Type</vscode-table-header-cell>
+              <vscode-table-header-cell>Java Version</vscode-table-header-cell>
+            </vscode-table-header>
+            <vscode-table-body slot="body">
+              {projectEntries}
+            </vscode-table-body>
+          </vscode-table>
+          :
+          <div>
+            <p>No project detected yet. Please refresh later if Java extension is importing your projects.</p>
+            <vscode-button onClick={onWillListRuntimes}>Refresh<span slot="start" className="codicon codicon-refresh"></span></vscode-button>
+          </div>
+      }
+      <ProjectTypeHint projectType={showHintFor} />
+    </div>
+  );
 }
 
 function hasBuildTool(p: ProjectRuntimeEntry) {

--- a/src/java-runtime/assets/ToolingJDKPanel.tsx
+++ b/src/java-runtime/assets/ToolingJDKPanel.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
-import * as React from "react";
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+
+import { useState } from "react";
 import { JavaRuntimeEntry } from "../types";
 import { onWillBrowseForJDK, onWillRunCommandFromWebview } from './vscode.api';
 
@@ -14,38 +15,32 @@ interface Props {
   javaHomeError?: any;
 }
 
-interface State {
-  isDirty?: boolean;
-}
+export function ToolingJDKPanel({ javaHomeError }: Props) {
+  const [isDirty, setIsDirty] = useState(false);
 
-export class ToolingJDKPanel extends React.Component<Props, State> {
-  render = () => {
-    const { javaHomeError } = this.props;
-    
-    return (
-      <div className="container">
-        <h1>Configure Runtime for Language Server</h1>
-        <div className="warning-box"><i className="codicon codicon-warning"></i>Java Language Server requires a JDK {REQUIRED_JDK_VERSION}+ to launch itself.</div>
-
-        {javaHomeError && (<p className="java-home-error">{javaHomeError}</p>)}
-
-        <div className="jdk-action">
-          <VSCodeButton appearance="secondary" onClick={this.onClickBrowseJDKButton}><a href="#">Locate an <b>Existing JDK</b></a></VSCodeButton>
-          {this?.state?.isDirty && <VSCodeButton><a href="command:workbench.action.reloadWindow">Reload</a></VSCodeButton> }
-        </div>
-        <div className="jdk-action">
-          <VSCodeButton appearance="secondary" onClick={this.onClickInstallButton}><a href="#">Install a <b>New JDK</b></a></VSCodeButton>
-        </div>
-      </div>
-    );
-  }
-
-  onClickBrowseJDKButton = () => {
+  const onClickBrowseJDKButton = () => {
     onWillBrowseForJDK();
-    this.setState({ isDirty: true });
-  }
+    setIsDirty(true);
+  };
 
-  onClickInstallButton = () => {
+  const onClickInstallButton = () => {
     onWillRunCommandFromWebview("java.runtime", "download", "java.installJdk");
-  }
+  };
+
+  return (
+    <div className="container">
+      <h1>Configure Runtime for Language Server</h1>
+      <div className="warning-box"><i className="codicon codicon-warning"></i>Java Language Server requires a JDK {REQUIRED_JDK_VERSION}+ to launch itself.</div>
+
+      {javaHomeError && (<p className="java-home-error">{javaHomeError}</p>)}
+
+      <div className="jdk-action">
+        <vscode-button secondary onClick={onClickBrowseJDKButton}><a href="#">Locate an <b>Existing JDK</b></a></vscode-button>
+        {isDirty && <vscode-button><a href="command:workbench.action.reloadWindow">Reload</a></vscode-button>}
+      </div>
+      <div className="jdk-action">
+        <vscode-button secondary onClick={onClickInstallButton}><a href="#">Install a <b>New JDK</b></a></vscode-button>
+      </div>
+    </div>
+  );
 }

--- a/src/java-runtime/assets/components/DefaultJDKSelector.tsx
+++ b/src/java-runtime/assets/components/DefaultJDKSelector.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
-import * as React from "react";
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+
+import { useState } from "react";
 import { JavaRuntimeEntry, ProjectRuntimeEntry } from "../../types";
 import { setDefaultRuntime } from "../vscode.api";
 
@@ -11,53 +12,30 @@ interface Props {
   projectRuntime: ProjectRuntimeEntry;
 }
 
-interface State {
-  isEditing: boolean;
-}
+export function DefaultJDKSelector({ jdkEntries, projectRuntime: p }: Props) {
+  const [isEditing, setIsEditing] = useState(false);
 
-export class DefaultJDKSelector extends React.Component<Props, State> {
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      isEditing: false
-    };
-  }
-
-  render = () => {
-    const { jdkEntries, projectRuntime: p } = this.props;
-    const { isEditing } = this.state;
-    return (
-      <div className="inline-flex">
-        { isEditing ? 
-          <select className="jdkDropdown" id="jdkDropdown" defaultValue={p.runtimePath} onChange={this.onSelectionChange}>
-            {jdkEntries.map(jdk => (
-              <option key={jdk.name} value={jdk.fspath}>{jdk.majorVersion} - {jdk.name}</option>
-            ))}
-          </select>
-          : 
-          <span>{p.sourceLevel}</span>
-        }
-        <VSCodeButton appearance="icon" onClick={() => this.onClickEdit()} title="Edit"><span className="codicon codicon-edit"></span></VSCodeButton>
-      </div>
-    );
-  }
-
-  onSelectionChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    this.setIsEditing(false);
+  const onSelectionChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setIsEditing(false);
     const { value } = event.target;
-    const targetJdk = this.props.jdkEntries.find(jdk => jdk.fspath === value);
+    const targetJdk = jdkEntries.find(jdk => jdk.fspath === value);
     if (targetJdk) {
       setDefaultRuntime(targetJdk.fspath, targetJdk.majorVersion);
     }
-  }
+  };
 
-  onClickEdit = () => {
-    this.setIsEditing(true);
-  }
-
-  setIsEditing = (isEditing: boolean) => {
-    this.setState({
-      isEditing
-    })
-  }
+  return (
+    <div className="inline-flex">
+      {isEditing ?
+        <select className="jdkDropdown" id="jdkDropdown" defaultValue={p.runtimePath} onChange={onSelectionChange}>
+          {jdkEntries.map(jdk => (
+            <option key={jdk.name} value={jdk.fspath}>{jdk.majorVersion} - {jdk.name}</option>
+          ))}
+        </select>
+        :
+        <span>{p.sourceLevel}</span>
+      }
+      <vscode-button icon-only onClick={() => setIsEditing(true)} title="Edit"><span className="codicon codicon-edit"></span></vscode-button>
+    </div>
+  );
 }

--- a/src/java-runtime/assets/components/ProjectTypeHint.tsx
+++ b/src/java-runtime/assets/components/ProjectTypeHint.tsx
@@ -1,24 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
-
 interface Props {
   projectType: "Maven" | "Gradle" | "Others" | undefined;
 }
 
-export class ProjectTypeHint extends React.Component<Props, {}> {
-
-  render = () => {
-    return (
-      <div className="hintPanel">
-        {this.hintContent()}
-      </div>
-    );
-  }
-
-  hintContent = () => {
-    const { projectType } = this.props;
+export function ProjectTypeHint({ projectType }: Props) {
+  const hintContent = () => {
     switch (projectType) {
       case "Maven":
         return (
@@ -46,7 +34,6 @@ export class ProjectTypeHint extends React.Component<Props, {}> {
             </div>
           </div>
         );
-
       case "Others":
         return (
           <div>
@@ -56,5 +43,11 @@ export class ProjectTypeHint extends React.Component<Props, {}> {
       default:
         return undefined;
     }
-  }
+  };
+
+  return (
+    <div className="hintPanel">
+      {hintContent()}
+    </div>
+  );
 }

--- a/src/java-runtime/assets/index.ts
+++ b/src/java-runtime/assets/index.ts
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
 import "./style.scss";
 import { ProjectJDKPanel } from "./ProjectJDKPanel";
 import { onWillListRuntimes } from "./vscode.api";
 import { ToolingJDKPanel } from "./ToolingJDKPanel";
+
+const container = document.getElementById("content")!;
+const root = createRoot(container);
 
 const onInitialize = (event: any) => {
   const { data } = event;
@@ -26,12 +29,12 @@ function showJavaRuntimeEntries(args: any) {
       javaHomeError: args.javaHomeError,
       javaDotHome: args.javaDotHome
     };
-    ReactDOM.render(React.createElement(ToolingJDKPanel, props), document.getElementById("content"));
+    root.render(createElement(ToolingJDKPanel, props));
   } else {
     const props = {
       jdkEntries: args.javaRuntimes,
       projectRuntimes: args.projectRuntimes,
     }
-    ReactDOM.render(React.createElement(ProjectJDKPanel, props), document.getElementById("content"));
+    root.render(createElement(ProjectJDKPanel, props));
   }
 }

--- a/src/project-settings/assets/classpath/features/ClasspathConfigurationView.tsx
+++ b/src/project-settings/assets/classpath/features/ClasspathConfigurationView.tsx
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React, { useEffect } from "react";
+import "@vscode-elements/elements/dist/vscode-tabs/index.js";
+import "@vscode-elements/elements/dist/vscode-tab-header/index.js";
+import "@vscode-elements/elements/dist/vscode-tab-panel/index.js";
+
+import { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Dispatch } from "@reduxjs/toolkit";
 import Output from "./components/Output";
@@ -9,7 +13,7 @@ import Sources from "./components/Sources";
 import Libraries from "./components/Libraries";
 import { listVmInstalls, updateActiveTab } from "./classpathConfigurationViewSlice";
 import JdkRuntime from "./components/JdkRuntime";
-import { VSCodePanelTab, VSCodePanelView, VSCodePanels } from "@vscode/webview-ui-toolkit/react";
+
 import { ProjectType } from "../../../../utils/webview";
 import UnmanagedFolderSources from "./components/UnmanagedFolderSources";
 import Hint from "./components/Hint";
@@ -20,6 +24,9 @@ const ClasspathConfigurationView = (): JSX.Element => {
   const activeProjectIndex: number = useSelector((state: any) => state.commonConfig.ui.activeProjectIndex);
   const projectType: ProjectType = useSelector((state: any) => state.commonConfig.data.projectType[activeProjectIndex]);
   const dispatch: Dispatch<any> = useDispatch();
+
+  const tabIds = ["source", "jdk", "libraries"];
+  const selectedIndex = Math.max(0, tabIds.indexOf(activeTab));
 
   const onClickTab = (tabId: string) => {
     dispatch(updateActiveTab(tabId));
@@ -41,22 +48,22 @@ const ClasspathConfigurationView = (): JSX.Element => {
 
   return (
     <div className="root">
-      <VSCodePanels activeid={activeTab} className="setting-panels">
-        <VSCodePanelTab id="source" onClick={() => onClickTab("source")}>Sources</VSCodePanelTab>
-        <VSCodePanelTab id="jdk" onClick={() => onClickTab("jdk")}>JDK Runtime</VSCodePanelTab>
-        <VSCodePanelTab id="libraries" onClick={() => onClickTab("libraries")}>Libraries</VSCodePanelTab>
-        <VSCodePanelView className="setting-panels-view">
+      <vscode-tabs selected-index={selectedIndex} className="setting-panels">
+        <vscode-tab-header slot="header" onClick={() => onClickTab("source")}>Sources</vscode-tab-header>
+        <vscode-tab-header slot="header" onClick={() => onClickTab("jdk")}>JDK Runtime</vscode-tab-header>
+        <vscode-tab-header slot="header" onClick={() => onClickTab("libraries")}>Libraries</vscode-tab-header>
+        <vscode-tab-panel className="setting-panels-view">
           {[ProjectType.Gradle, ProjectType.Maven].includes(projectType) && (<Sources />)}
           {projectType !== ProjectType.Gradle && projectType !== ProjectType.Maven && (<UnmanagedFolderSources />)}
           {projectType === ProjectType.UnmanagedFolder && (<Output />)}
-        </VSCodePanelView>
-        <VSCodePanelView className="setting-panels-view">
+        </vscode-tab-panel>
+        <vscode-tab-panel className="setting-panels-view">
           <JdkRuntime />
-        </VSCodePanelView>
-        <VSCodePanelView className="setting-panels-view">
+        </vscode-tab-panel>
+        <vscode-tab-panel className="setting-panels-view">
           <Libraries />
-        </VSCodePanelView>
-      </VSCodePanels>
+        </vscode-tab-panel>
+      </vscode-tabs>
       <Hint />
     </div>
   );

--- a/src/project-settings/assets/classpath/features/components/Hint.tsx
+++ b/src/project-settings/assets/classpath/features/components/Hint.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeLink} from "@vscode/webview-ui-toolkit/react";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { ClasspathEntry, ProjectInfo } from "../../../../types";
 import { useSelector } from "react-redux";
 import { ProjectType } from "../../../../../utils/webview";
@@ -59,7 +58,7 @@ const Hint = (): JSX.Element | null => {
         {(projectType[activeProjectIndex] === ProjectType.Gradle || projectType[activeProjectIndex] === ProjectType.Maven) &&
           <span className="setting-section-warning">
             '{projects[activeProjectIndex].name}' is imported by {projectType[activeProjectIndex]}, changes made to the classpath might be lost after reloading.
-            To make permanent changes, please edit the <VSCodeLink href="" onClick={() => handleOpenBuildFile()}>{buildFile}</VSCodeLink> file.
+            To make permanent changes, please edit the <a href="" onClick={() => handleOpenBuildFile()}>{buildFile}</a> file.
           </span>
         }
     </div>

--- a/src/project-settings/assets/classpath/features/components/JdkRuntime.tsx
+++ b/src/project-settings/assets/classpath/features/components/JdkRuntime.tsx
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React, { Dispatch, useEffect, useRef, useState } from "react";
+import "@vscode-elements/elements/dist/vscode-divider/index.js";
+import "@vscode-elements/elements/dist/vscode-single-select/index.js";
+import "@vscode-elements/elements/dist/vscode-option/index.js";
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+
+import { useCallback, useEffect, useRef } from "react";
 import { ClasspathRequest, CommonRequest } from "../../../vscode/utils";
-import { VSCodeDivider, VSCodeDropdown, VSCodeOption, } from "@vscode/webview-ui-toolkit/react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { VmInstall } from "../../../../types";
 import { setJdks } from "../classpathConfigurationViewSlice";
@@ -19,29 +24,45 @@ const JdkRuntime = (): JSX.Element => {
   const vmInstalls: VmInstall[] = useSelector((state: any) => state.classpathConfig.data.vmInstalls);
   const activeVmInstallPath: string = useSelector((state: any) => state.classpathConfig.data.activeVmInstallPath[activeProjectIndex]);
 
-  const [optionDescription, setOptionDescription] = useState<string | null>(null);
+  const dispatch = useDispatch();
+  const selectRef = useRef<HTMLElement>(null);
 
-  const dispatch: Dispatch<any> = useDispatch();
-
-  const handleSelectJdk = (path: string) => {
+  const handleSelectJdk = useCallback((path: string) => {
     if (path === "add-new-jdk") {
       ClasspathRequest.onWillAddNewJdk();
     } else if (path === "download-jdk") {
       CommonRequest.onWillExecuteCommand("java.installJdk")
     } else {
       dispatch(setJdks({
-        activeProjectIndex,
+        activeProjectIndex: activeProjectIndexRef.current,
         activeVmInstallPath: path
       }));
     }
-  }
+  }, [dispatch]);
 
-  const handleDropdownChange = (event: any) => {
-    const selectedValue = event.target.value;
-    handleSelectJdk(selectedValue);
-  }
+  // Use native change event on the select element
+  useEffect(() => {
+    const el = selectRef.current;
+    if (!el) return;
+    const handleChange = (e: Event) => {
+      const selectedValue = (e.target as any).value;
+      if (selectedValue) {
+        handleSelectJdk(selectedValue);
+      }
+    };
+    el.addEventListener("change", handleChange);
+    return () => el.removeEventListener("change", handleChange);
+  }, [handleSelectJdk]);
 
-  const onDidChangeJdk = (event: OnDidChangeJdkEvent) => {
+  // Sync the value property on the select element when activeVmInstallPath changes
+  useEffect(() => {
+    const el = selectRef.current;
+    if (el && activeVmInstallPath) {
+      (el as any).value = activeVmInstallPath;
+    }
+  }, [activeVmInstallPath, vmInstalls]);
+
+  const onDidChangeJdk = useCallback((event: OnDidChangeJdkEvent) => {
     const {data} = event;
     if (data.command === "classpath.onDidChangeJdk") {
       dispatch(setJdks({
@@ -49,90 +70,49 @@ const JdkRuntime = (): JSX.Element => {
         ...data
       }));
     }
-  }
+  }, [dispatch]);
 
   useEffect(() => {
     window.addEventListener("message", onDidChangeJdk);
-    // the dropdown list has a fixed height by default, which makes the list jitter
-    // when the jdk path changes. We set the max-height to initial to fix this issue.
-    // Note that the list box is rendered inside a shadow dom so this is the only way
-    // to change its style.
-    document.querySelector("#jdk-dropdown")?.shadowRoot
-        ?.querySelector(".listbox")?.setAttribute("style", "max-height: initial;");
     if (vmInstalls.length === 0) {
       ClasspathRequest.onWillListVmInstalls();
     }
     return () => window.removeEventListener("message", onDidChangeJdk);
-  }, []);
-
-  const jdkSelections = vmInstalls.map((vmInstall) => {
-    return (
-      <VSCodeOption
-        className="setting-section-option"
-        key={vmInstall.path}
-        value={vmInstall.path}
-        onMouseEnter={() => setOptionDescription(vmInstall.path)}
-        onMouseLeave={() => setOptionDescription(activeVmInstallPath)}
-      >
-        <span>{vmInstall.name}</span>
-      </VSCodeOption>
-    );
-  });
-
-  const addNewJdk = (
-    <VSCodeOption
-      className="setting-section-option"
-      key="add-new-jdk"
-      value="add-new-jdk"
-      id="add-new-jdk"
-      onMouseEnter={() => setOptionDescription("Select a JDK from the local file system.")}
-      onMouseLeave={() => setOptionDescription(activeVmInstallPath)}
-    >
-      <div className="setting-section-option-action">
-        <span className="codicon codicon-folder-opened"/>Find a local JDK...
-      </div>
-    </VSCodeOption>
-  );
-
-  const downloadJdk = (
-      <VSCodeOption
-        className="setting-section-option"
-        key="download-jdk"
-        value="download-jdk"
-        id="download-jdk"
-        onMouseEnter={() => setOptionDescription("Download a new JDK.")}
-        onMouseLeave={() => setOptionDescription(activeVmInstallPath)}
-      >
-        <div className="setting-section-option-action">
-          <span className="codicon codicon-desktop-download"/>Download a new JDK...
-        </div>
-      </VSCodeOption>
-    );
+  }, [onDidChangeJdk]);
 
   return (
     <div className="setting-section">
-      <div className="flex-center mt-2">
-        <span className="setting-section-description mr-1">JDK:</span>
-        <VSCodeDropdown 
-          id="jdk-dropdown" 
-          value={activeVmInstallPath} 
-          className="setting-section-dropdown" 
-          position="below"
-          onChange={handleDropdownChange}
+      <div className="jdk-runtime-row">
+        <span className="setting-section-description">JDK:</span>
+        <vscode-single-select
+          ref={selectRef}
+          id="jdk-dropdown"
+          className="setting-section-dropdown"
         >
-          <div className="dropdown-description dropdown-above-description">
-            <p>{optionDescription ?? activeVmInstallPath}</p>
-            <VSCodeDivider></VSCodeDivider>
-          </div>
-          {jdkSelections}
-          <VSCodeDivider></VSCodeDivider>
-          {addNewJdk}
-          {downloadJdk}
-          <div className="dropdown-description dropdown-below-description">
-            <VSCodeDivider></VSCodeDivider>
-            <p>{optionDescription ?? activeVmInstallPath}</p>
-          </div>
-        </VSCodeDropdown>
+          {vmInstalls.map((vmInstall) => (
+            <vscode-option
+              key={vmInstall.path}
+              value={vmInstall.path}
+              selected={vmInstall.path === activeVmInstallPath ? true : undefined}
+              description={vmInstall.path}
+            >
+              {vmInstall.name}
+            </vscode-option>
+          ))}
+        </vscode-single-select>
+      </div>
+      <div className="jdk-runtime-path">
+        {activeVmInstallPath}
+      </div>
+      <div className="jdk-runtime-actions">
+        <vscode-button secondary onClick={() => ClasspathRequest.onWillAddNewJdk()}>
+          <span className="codicon codicon-folder-opened mr-1"></span>
+          Find a local JDK...
+        </vscode-button>
+        <vscode-button secondary onClick={() => CommonRequest.onWillExecuteCommand("java.installJdk")}>
+          <span className="codicon codicon-desktop-download mr-1"></span>
+          Download a new JDK...
+        </vscode-button>
       </div>
     </div>
   );

--- a/src/project-settings/assets/classpath/features/components/Libraries.tsx
+++ b/src/project-settings/assets/classpath/features/components/Libraries.tsx
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+import "@vscode-elements/elements/dist/vscode-divider/index.js";
+
 import { Dispatch } from "@reduxjs/toolkit";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { removeReferencedLibrary, addLibraries } from "../classpathConfigurationViewSlice";
 import { ClasspathRequest } from "../../../vscode/utils";
-import { VSCodeButton, VSCodeDataGrid, VSCodeDataGridCell, VSCodeDataGridRow, VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
+
 import { ClasspathEntry, ClasspathEntryKind } from "../../../../types";
 
 const Libraries = (): JSX.Element => {
@@ -83,25 +86,23 @@ const Libraries = (): JSX.Element => {
   let librariesSections: JSX.Element | JSX.Element[];
   if (libraries.length === 0) {
     librariesSections = (
-      <VSCodeDataGridRow className="setting-section-grid-row">
+      <div className="source-row">
         <span><em>No libraries are configured.</em></span>
-      </VSCodeDataGridRow>
+      </div>
     );
   } else {
     librariesSections = libraries.map((library, index) => (
-      <VSCodeDataGridRow className="setting-section-grid-row" id={`library-${index}`} onMouseEnter={() => setHoveredRow(`library-${index}`)} onMouseLeave={() => setHoveredRow(null)}  key={library.path}>
-        <VSCodeDataGridCell className="setting-section-grid-cell setting-section-grid-cell-readonly" gridColumn="1">
-          <div title={library.path} className="setting-section-grid-cell">
-            <span className={`codicon ${library.kind === 2 ? "codicon-project" : "codicon-library"} mr-1`}></span>
-            <span>{resolveLibPath(library)}</span>
-          </div>
-          {hoveredRow === `library-${index}` && (
-            <VSCodeButton appearance='icon' onClick={() => handleRemove(index)}>
-              <span className="codicon codicon-close"></span>
-            </VSCodeButton>
-          )}
-        </VSCodeDataGridCell>
-      </VSCodeDataGridRow>
+      <div className="source-row" id={`library-${index}`} onMouseEnter={() => setHoveredRow(`library-${index}`)} onMouseLeave={() => setHoveredRow(null)}  key={library.path}>
+        <div title={library.path} className="setting-section-grid-cell" style={{flex: 1}}>
+          <span className={`codicon ${library.kind === 2 ? "codicon-project" : "codicon-library"} mr-1`}></span>
+          <span>{resolveLibPath(library)}</span>
+        </div>
+        <div className={`source-row-actions ${hoveredRow === `library-${index}` ? "" : "hidden"}`}>
+          <vscode-button class="ghost-button" icon-only onClick={() => handleRemove(index)} title="Remove">
+            <span className="codicon codicon-close"></span>
+          </vscode-button>
+        </div>
+      </div>
     ));
   }
 
@@ -109,16 +110,14 @@ const Libraries = (): JSX.Element => {
     <div className="setting-section">
       <div>
         <div id="list-actions" className="flex-center setting-list-actions">
-          <VSCodeButton className="pl-1 pr-1 pt-1 pb-1" slot="end" appearance="icon" onClick={() => handleAdd()}>
+          <vscode-button class="ghost-button" onClick={() => handleAdd()}>
             <span className="codicon codicon-add mr-1"></span>
             Add Library...
-          </VSCodeButton>
+          </vscode-button>
         </div>
-        <VSCodeDivider className="mb-0"/>
+        <vscode-divider className="mb-0"/>
         <div className="setting-overflow-area">
-          <VSCodeDataGrid>
-            {librariesSections}
-          </VSCodeDataGrid>
+          {librariesSections}
         </div>
       </div>
     </div>

--- a/src/project-settings/assets/classpath/features/components/Output.tsx
+++ b/src/project-settings/assets/classpath/features/components/Output.tsx
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+import "@vscode-elements/elements/dist/vscode-textfield/index.js";
+
 import { Dispatch } from "@reduxjs/toolkit";
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { ProjectType } from "../../../../../utils/webview";
 import { ClasspathRequest } from "../../../vscode/utils";
 import { setOutputPath } from "../classpathConfigurationViewSlice";
-import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
+
 
 const Output = (): JSX.Element | null => {
   const activeProjectIndex: number = useSelector((state: any) => state.commonConfig.ui.activeProjectIndex);
@@ -45,14 +48,14 @@ const Output = (): JSX.Element | null => {
   return (
     <div className="setting-section mt-2">
       <h4 className="mb-2 pl-1">Output Path</h4>
-      <VSCodeTextField className="inactive setting-section-text pl-1"
+      <vscode-textfield className="inactive setting-section-text pl-1"
         readOnly
         value={output}
         placeholder="Output Path">
-        <VSCodeButton slot="end" appearance="icon" title="Browse..." aria-label="Browse..." onClick={() => handleClick()}>
+        <vscode-button slot="end" icon-only title="Browse..." aria-label="Browse..." onClick={() => handleClick()}>
           <span className="codicon codicon-folder-opened"></span>
-        </VSCodeButton>
-      </VSCodeTextField>
+        </vscode-button>
+      </vscode-textfield>
     </div>
   );
 };

--- a/src/project-settings/assets/classpath/features/components/Sources.tsx
+++ b/src/project-settings/assets/classpath/features/components/Sources.tsx
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React, { useEffect, useRef, useState } from "react";
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+import "@vscode-elements/elements/dist/vscode-textfield/index.js";
+import "@vscode-elements/elements/dist/vscode-divider/index.js";
+
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Dispatch } from "@reduxjs/toolkit";
 import { updateSource } from "../classpathConfigurationViewSlice";
 import { ClasspathRequest } from "../../../vscode/utils";
-import { VSCodeButton, VSCodeDataGrid, VSCodeDataGridCell, VSCodeDataGridRow, VSCodeDivider, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
+
 import { ClasspathEntry, ClasspathEntryKind } from "../../../../types";
 
 const Sources = (): JSX.Element => {
@@ -25,7 +29,36 @@ const Sources = (): JSX.Element => {
   const [editingSourcePath, setEditingSourcePath] = useState<string | null>(null);
   const [editingOutputPath, setEditingOutputPath] = useState<string | null>(defaultOutput);
 
+  const sourceInputRef = useRef<HTMLElement>(null);
+  const outputInputRef = useRef<HTMLElement>(null);
+
   const dispatch: Dispatch<any> = useDispatch();
+
+  // Use refs to hold latest editing values so native event listeners can access them
+  const editingSourcePathRef = useRef(editingSourcePath);
+  const editingOutputPathRef = useRef(editingOutputPath);
+  const editRowRef = useRef(editRow);
+  useEffect(() => { editingSourcePathRef.current = editingSourcePath; }, [editingSourcePath]);
+  useEffect(() => { editingOutputPathRef.current = editingOutputPath; }, [editingOutputPath]);
+  useEffect(() => { editRowRef.current = editRow; }, [editRow]);
+
+  // Attach native input events to textfield refs
+  useEffect(() => {
+    const srcEl = sourceInputRef.current;
+    const outEl = outputInputRef.current;
+    const onSrcInput = (e: Event) => {
+      setEditingSourcePath((e.target as any).value);
+    };
+    const onOutInput = (e: Event) => {
+      setEditingOutputPath((e.target as any).value);
+    };
+    if (srcEl) srcEl.addEventListener("input", onSrcInput);
+    if (outEl) outEl.addEventListener("input", onOutInput);
+    return () => {
+      if (srcEl) srcEl.removeEventListener("input", onSrcInput);
+      if (outEl) outEl.removeEventListener("input", onOutInput);
+    };
+  }, [editRow]);
 
   const handleRemove = (path: string) => {
     const updatedSources: ClasspathEntry[] = [];
@@ -54,23 +87,27 @@ const Sources = (): JSX.Element => {
   }
 
   const handleOK = () => {
+    const currentSourcePath = editingSourcePathRef.current;
+    const currentOutputPath = editingOutputPathRef.current;
+    const currentEditRow = editRowRef.current;
+
     const updatedSources: ClasspathEntry[] = sources.map((source, index) => {
-      if (index === editRow && editingSourcePath) {
+      if (index === currentEditRow && currentSourcePath) {
         return {
           kind: ClasspathEntryKind.Source,
-          path: editingSourcePath,
-          output: editingOutputPath ?? undefined,
+          path: currentSourcePath,
+          output: currentOutputPath ?? undefined,
           attributes: source.attributes,
         };
       }
       return source;
     });
 
-    if (editRow === sources.length) {
+    if (currentEditRow === sources.length) {
       updatedSources.push({
         kind: ClasspathEntryKind.Source,
-        path: editingSourcePath!,
-        output: editingOutputPath ?? undefined,
+        path: currentSourcePath!,
+        output: currentOutputPath ?? undefined,
       });
     }
     dispatch(updateSource({
@@ -92,146 +129,115 @@ const Sources = (): JSX.Element => {
     ClasspathRequest.onWillSelectFolder(type);
   }
 
-  const messageHandler = (event: any) => {
+  const messageHandler = useCallback((event: any) => {
     const {data} = event;
     if (data.command === "classpath.onDidSelectFolder") {
-      /**
-       * data: {
-       *  command: string;
-       *  path: string;
-       *  type: string;
-       * }
-       */
       if (data.type === "source") {
         setEditingSourcePath(data.path);
       } else if (data.type === "output") {
         setEditingOutputPath(data.path);
       }
     } else if (data.command === "classpath.onDidUpdateSourceFolder") {
-      /**
-       * data: {
-       *  command: string;
-       *  sourcePaths: string[];
-       * }
-       */
       dispatch(updateSource({
         activeProjectIndex: activeProjectIndexRef.current,
         sources: data.sourcePaths
       }));
     }
-  }
+  }, [dispatch]);
 
   useEffect(() => {
     window.addEventListener("message", messageHandler);
     return () => window.removeEventListener("message", messageHandler);
-  }, []);
+  }, [messageHandler]);
 
-  const getSourceSections = () => {
-    if (sources.length === 0) {
-      return (
-        <VSCodeDataGridRow className="setting-section-grid-row">
-          <span><em>No source paths are configured.</em></span>
-        </VSCodeDataGridRow>
-      );
-    } else {
-      return sources.map((source, index) => {
-        return getSourceRowComponents(source, index);
-      });
-    }
-  };
-
-  const getEditRow = (id: string) => {
+  const renderEditRow = (id: string) => {
     return (
-      <VSCodeDataGridRow className="setting-section-grid-row" id={id}  key={id}>
-        <VSCodeDataGridCell className="setting-section-grid-cell setting-section-grid-cell-editable" gridColumn="1">
-          <VSCodeTextField
-              className="setting-section-grid-text"
-              value={editingSourcePath!}
-              placeholder="Source Root Path"
-              onInput={(e: any) => setEditingSourcePath(e.target.value)}>
-            <VSCodeButton slot="end" appearance="icon" title="Browse..." aria-label="Browse..." onClick={() => handleBrowse("source")}>
+      <div className="source-edit-row" key={id}>
+        <div className="source-edit-field">
+          <label>Source Path:</label>
+          <div className="source-edit-input-group">
+            <vscode-textfield
+                ref={sourceInputRef}
+                className="source-edit-input"
+                value={editingSourcePath ?? ""}
+                placeholder="Source Root Path">
+            </vscode-textfield>
+            <vscode-button icon-only title="Browse..." aria-label="Browse..." onClick={() => handleBrowse("source")}>
               <span className="codicon codicon-folder-opened"></span>
-            </VSCodeButton>
-          </VSCodeTextField>
-        </VSCodeDataGridCell>
-        <VSCodeDataGridCell className="setting-section-grid-cell setting-section-grid-cell-editable" gridColumn="2">
-          <VSCodeTextField style={{width: "55%"}}
-              className="setting-section-grid-text"
-              value={editingOutputPath!}
-              placeholder="Output Path"
-              onInput={(e: any) => setEditingOutputPath(e.target.value)}>
-            <VSCodeButton slot="end" appearance="icon" title="Browse..." aria-label="Browse..." onClick={() => handleBrowse("output")}>
+            </vscode-button>
+          </div>
+        </div>
+        <div className="source-edit-field">
+          <label>Output Path:</label>
+          <div className="source-edit-input-group">
+            <vscode-textfield
+                ref={outputInputRef}
+                className="source-edit-input"
+                value={editingOutputPath ?? ""}
+                placeholder="Output Path">
+            </vscode-textfield>
+            <vscode-button icon-only title="Browse..." aria-label="Browse..." onClick={() => handleBrowse("output")}>
               <span className="codicon codicon-folder-opened"></span>
-            </VSCodeButton>
-          </VSCodeTextField>
-          <VSCodeButton className="ml-1" appearance="primary" onClick={() => handleOK()}>OK</VSCodeButton>
-          <VSCodeButton className="ml-1" appearance="secondary" onClick={() => handleCancel()}>
-            Cancel
-          </VSCodeButton>
-        </VSCodeDataGridCell>
-      </VSCodeDataGridRow>
-    )
+            </vscode-button>
+          </div>
+        </div>
+        <div className="source-edit-actions">
+          <vscode-button onClick={() => handleOK()}>OK</vscode-button>
+          <vscode-button secondary onClick={() => handleCancel()}>Cancel</vscode-button>
+        </div>
+      </div>
+    );
   };
 
-  const getSourceRowComponents = (source: ClasspathEntry, index: number) => {
+  const renderSourceRow = (source: ClasspathEntry, index: number) => {
     if (editRow === index) {
-      return getEditRow(`sources-${index}`);
-    } else {
-      return (
-        <VSCodeDataGridRow className="setting-section-grid-row" id={`sources-${index}`} onMouseEnter={() => setHoveredRow(`sources-${index}`)} onMouseLeave={() => setHoveredRow(null)} key={source.path}>
-          <VSCodeDataGridCell className="setting-section-grid-cell setting-section-grid-cell-left setting-section-grid-cell-readonly" gridColumn="1">
-            {source.path}
-          </VSCodeDataGridCell>
-          <VSCodeDataGridCell className="setting-section-grid-cell setting-section-grid-cell-readonly" gridColumn="2">
-            <span>{source.output || defaultOutput}</span>
-            <div className={hoveredRow === `sources-${index}` ? "" : "hidden"}>
-              <VSCodeButton appearance='icon' onClick={() => handleEdit(source.path, source.output || defaultOutput, index)}>
-                <span className="codicon codicon-edit"></span>
-              </VSCodeButton>
-              <VSCodeButton appearance='icon' onClick={() => handleRemove(source.path)}>
-                <span className="codicon codicon-close"></span>
-              </VSCodeButton>
-            </div>
-          </VSCodeDataGridCell>
-        </VSCodeDataGridRow>
-      );
+      return renderEditRow(`sources-${index}`);
     }
-  };
-
-  const getAdditionalEditRow = () => {
-    if (editRow === null) {
-      return null;
-    }
-    if (editRow < sources.length) {
-      return null;
-    }
-    return getEditRow("sources-additional-editing");
+    const rowId = `sources-${index}`;
+    return (
+      <div
+        className="source-row"
+        key={source.path}
+        onMouseEnter={() => setHoveredRow(rowId)}
+        onMouseLeave={() => setHoveredRow(null)}
+      >
+        <div className="source-row-path">{source.path}</div>
+        <div className="source-row-output">
+          <span className="source-row-output-text">{source.output || defaultOutput}</span>
+          <div className={`source-row-actions ${hoveredRow === rowId ? "" : "hidden"}`}>
+            <vscode-button class="ghost-button" icon-only onClick={() => handleEdit(source.path, source.output || defaultOutput, index)} title="Edit">
+              <span className="codicon codicon-edit"></span>
+            </vscode-button>
+            <vscode-button class="ghost-button" icon-only onClick={() => handleRemove(source.path)} title="Remove">
+              <span className="codicon codicon-close"></span>
+            </vscode-button>
+          </div>
+        </div>
+      </div>
+    );
   };
 
   return (
     <div className="setting-section">
       <div id="list-actions" className="flex-center setting-list-actions">
-        <VSCodeButton className="pl-1 pr-1 pt-1 pb-1" slot="end" appearance="icon" onClick={() => handleAdd()}>
+        <vscode-button class="ghost-button" onClick={() => handleAdd()}>
           <span className="codicon codicon-add mr-1"></span>
           Add Source Root...
-        </VSCodeButton>
+        </vscode-button>
       </div>
-      <VSCodeDivider className="mb-0"/>
+      <vscode-divider></vscode-divider>
       <div className="setting-overflow-area">
-        <VSCodeDataGrid gridTemplateColumns="40% 60%" generateHeader="sticky">
-          <VSCodeDataGridRow className="setting-section-grid-row" rowType="header">
-            <VSCodeDataGridCell className="setting-section-grid-cell" cellType="columnheader" gridColumn="1">
-              <span className="setting-section-grid-row-header">Path</span>
-            </VSCodeDataGridCell>
-            <VSCodeDataGridCell className="setting-section-grid-cell" cellType="columnheader" gridColumn="2">
-              <span className="setting-section-grid-row-header">Output</span>
-            </VSCodeDataGridCell>
-          </VSCodeDataGridRow>
-          {getSourceSections()}
-          {getAdditionalEditRow()}
-        </VSCodeDataGrid>
+        <div className="source-list-header">
+          <div className="source-list-header-cell">Path</div>
+          <div className="source-list-header-cell">Output</div>
+        </div>
+        {sources.length === 0 ? (
+          <div className="source-row"><em>No source paths are configured.</em></div>
+        ) : (
+          sources.map((source, index) => renderSourceRow(source, index))
+        )}
+        {editRow !== null && editRow >= sources.length && renderEditRow("sources-additional-editing")}
       </div>
-      
     </div>
   );
 };

--- a/src/project-settings/assets/classpath/features/components/UnmanagedFolderSources.tsx
+++ b/src/project-settings/assets/classpath/features/components/UnmanagedFolderSources.tsx
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React, { useEffect, useRef, useState } from "react";
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+import "@vscode-elements/elements/dist/vscode-divider/index.js";
+
+import { useEffect, useRef, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Dispatch } from "@reduxjs/toolkit";
 import { updateSource } from "../classpathConfigurationViewSlice";
 import { ClasspathRequest } from "../../../vscode/utils";
 import { ProjectType } from "../../../../../utils/webview";
-import { VSCodeButton, VSCodeDataGrid, VSCodeDataGridCell, VSCodeDataGridRow, VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
+
 import { ClasspathEntry } from "../../../../types";
 
 const UnmanagedFolderSources = (): JSX.Element => {
@@ -64,25 +67,23 @@ const UnmanagedFolderSources = (): JSX.Element => {
   let sourceSections: JSX.Element | JSX.Element[];
   if (sources.length === 0) {
     sourceSections = (
-      <VSCodeDataGridRow className={`${projectType !== ProjectType.UnmanagedFolder ? "inactive" : ""} setting-section-grid-row`}>
+      <div className={`source-row ${projectType !== ProjectType.UnmanagedFolder ? "inactive" : ""}`}>
         <span><em>No source paths are configured.</em></span>
-      </VSCodeDataGridRow>
+      </div>
     );
   } else {
     sourceSections = sources.map((source, index) => (
-      <VSCodeDataGridRow className={`${projectType !== ProjectType.UnmanagedFolder ? "inactive" : ""} setting-section-grid-row`} id={`sources-${index}`} onMouseEnter={() => setHoveredRow(`sources-${index}`)} onMouseLeave={() => setHoveredRow(null)}  key={source.path}>
-        <VSCodeDataGridCell className="setting-section-grid-cell setting-section-grid-cell-readonly" gridColumn="1">
-          <div className="setting-section-grid-cell">
-             <span className="codicon codicon-folder mr-1"></span>
-             <span>{source.path}</span>
-           </div>
-          {hoveredRow === `sources-${index}` && projectType === ProjectType.UnmanagedFolder && (
-            <VSCodeButton appearance='icon' onClick={() => handleRemove(source.path)}>
-                <span className="codicon codicon-close"></span>
-            </VSCodeButton>
-          )}
-        </VSCodeDataGridCell>
-      </VSCodeDataGridRow>
+      <div className={`source-row ${projectType !== ProjectType.UnmanagedFolder ? "inactive" : ""}`} id={`sources-${index}`} onMouseEnter={() => setHoveredRow(`sources-${index}`)} onMouseLeave={() => setHoveredRow(null)}  key={source.path}>
+        <div className="setting-section-grid-cell" style={{flex: 1}}>
+           <span className="codicon codicon-folder mr-1"></span>
+           <span>{source.path}</span>
+        </div>
+        <div className={`source-row-actions ${hoveredRow === `sources-${index}` && projectType === ProjectType.UnmanagedFolder ? "" : "hidden"}`}>
+          <vscode-button class="ghost-button" icon-only onClick={() => handleRemove(source.path)} title="Remove">
+              <span className="codicon codicon-close"></span>
+          </vscode-button>
+        </div>
+      </div>
     ));
   }
 
@@ -90,15 +91,15 @@ const UnmanagedFolderSources = (): JSX.Element => {
     <div className="setting-section">
       <h4 className="mt-1 mb-1 pl-1">Source Paths</h4>
       <div id="list-actions" className="flex-center setting-list-actions">
-        <VSCodeButton className="pl-1 pr-1 pt-1 pb-1" slot="end" appearance="icon" onClick={() => handleAdd()}>
+        <vscode-button class="ghost-button" onClick={() => handleAdd()}>
           <span className="codicon codicon-add mr-1"></span>
           Add Source Root...
-        </VSCodeButton>
+        </vscode-button>
       </div>
-      <VSCodeDivider className="mb-0"/>
-      <VSCodeDataGrid>
+      <vscode-divider className="mb-0"/>
+      <div className="setting-overflow-area">
         {sourceSections}
-      </VSCodeDataGrid>
+      </div>
     </div>
   );
 };

--- a/src/project-settings/assets/classpath/style.scss
+++ b/src/project-settings/assets/classpath/style.scss
@@ -91,6 +91,7 @@
   }
   .setting-section-grid-cell-readonly {
     justify-content: space-between;
+    width: 100%;
   }
   .setting-section-grid-cell-editable {
     justify-content: end;
@@ -121,6 +122,14 @@
   height: calc(var(--design-unit) * 8px);
 }
 
+// Ghost/icon button style (transparent background, like old appearance="icon")
+.ghost-button {
+  --vscode-button-background: transparent;
+  --vscode-button-foreground: var(--vscode-foreground);
+  --vscode-button-hoverBackground: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+  --vscode-button-border: transparent;
+}
+
 .setting-overflow-area {
   overflow: auto;
   max-height: 50vh;
@@ -128,4 +137,94 @@
 
 .inactive {
   opacity: 0.67;
+}
+
+// Sources tab layout
+.source-list-header {
+  display: flex;
+  padding: 4px 8px;
+  font-weight: 700;
+  border-bottom: 1px solid var(--vscode-settings-headerBorder, rgba(128,128,128,0.35));
+  .source-list-header-cell {
+    flex: 1;
+    font-size: 12.8px;
+  }
+}
+
+.source-row {
+  display: flex;
+  padding: 4px 8px;
+  align-items: center;
+  &:hover {
+    background: var(--vscode-list-hoverBackground);
+  }
+  .source-row-path {
+    flex: 1;
+    font-size: 12.8px;
+    word-break: break-all;
+  }
+  .source-row-output {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 12.8px;
+    .source-row-output-text {
+      word-break: break-all;
+    }
+    .source-row-actions {
+      display: flex;
+      gap: 2px;
+      flex-shrink: 0;
+    }
+  }
+}
+
+.source-edit-row {
+  padding: 8px;
+  border: 1px solid var(--vscode-settings-headerBorder, rgba(128,128,128,0.35));
+  margin: 4px 0;
+  .source-edit-field {
+    margin-bottom: 8px;
+    label {
+      display: block;
+      margin-bottom: 4px;
+      color: var(--vscode-descriptionForeground);
+      font-size: 12px;
+    }
+    .source-edit-input-group {
+      display: flex;
+      gap: 4px;
+      align-items: center;
+      .source-edit-input {
+        flex: 1;
+      }
+    }
+  }
+  .source-edit-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+  }
+}
+
+// JDK Runtime tab layout
+.jdk-runtime-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.jdk-runtime-path {
+  margin-top: 8px;
+  color: var(--vscode-descriptionForeground);
+  word-break: break-all;
+  font-size: 12.8px;
+}
+
+.jdk-runtime-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
 }

--- a/src/project-settings/assets/classpath/style.scss
+++ b/src/project-settings/assets/classpath/style.scss
@@ -51,7 +51,7 @@
   }
 
   &[open][position='above'] #add-new-jdk {
-    margin: calc(var(--design-unit) * 1px) 0;
+    margin: calc(var(--design-unit, 4) * 1px) 0;
   }
  
   p {
@@ -66,7 +66,7 @@
       display: flex;
       align-items: flex-end;
       .codicon {
-        margin-right: calc(var(--design-unit) * 1px);
+        margin-right: calc(var(--design-unit, 4) * 1px);
       }
     }
   }
@@ -87,7 +87,7 @@
     align-items: center;
   }
   .setting-section-grid-cell-left {
-    padding-right: calc(var(--design-unit) * 4px);
+    padding-right: calc(var(--design-unit, 4) * 4px);
   }
   .setting-section-grid-cell-readonly {
     justify-content: space-between;
@@ -119,7 +119,7 @@
 }
 
 .setting-list-actions {
-  height: calc(var(--design-unit) * 8px);
+  height: calc(var(--design-unit, 4) * 8px);
 }
 
 // Ghost/icon button style (transparent background, like old appearance="icon")

--- a/src/project-settings/assets/compiler/features/CompilerConfigurationView.tsx
+++ b/src/project-settings/assets/compiler/features/CompilerConfigurationView.tsx
@@ -1,8 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeCheckbox, VSCodeDataGrid, VSCodeDataGridCell, VSCodeDataGridRow, VSCodeDivider, VSCodeDropdown, VSCodeLink, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
-import React, { Dispatch, useEffect } from "react";
+import "@vscode-elements/elements/dist/vscode-divider/index.js";
+import "@vscode-elements/elements/dist/vscode-single-select/index.js";
+import "@vscode-elements/elements/dist/vscode-option/index.js";
+import "@vscode-elements/elements/dist/vscode-checkbox/index.js";
+import "@vscode-elements/elements/dist/vscode-table/index.js";
+import "@vscode-elements/elements/dist/vscode-table-body/index.js";
+import "@vscode-elements/elements/dist/vscode-table-row/index.js";
+import "@vscode-elements/elements/dist/vscode-table-cell/index.js";
+
+
+import { Dispatch, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { updateCompilerSettings, updateAvailableComplianceLevels } from "./compilerConfigurationViewSlice";
 import { CompilerRequest } from "../../vscode/utils";
@@ -68,7 +77,7 @@ const CompilerConfigurationView = (): JSX.Element | null => {
     return availableComplianceLevels.map((level) => {
 
       return (
-        <VSCodeOption
+        <vscode-option
           className="setting-section-option"
           key={`${label}-${level}`}
           value={level}
@@ -76,7 +85,7 @@ const CompilerConfigurationView = (): JSX.Element | null => {
           onClick={() => onClick(level)}
         >
           <span>{level}</span>
-        </VSCodeOption>
+        </vscode-option>
       );
     });
   };
@@ -139,41 +148,43 @@ const CompilerConfigurationView = (): JSX.Element | null => {
     <div className="root">
       <div className="setting-section">
         <div>
-          <VSCodeCheckbox checked={useRelease} onClick={onClickUseRelease}>Use '--release' option for cross-compilation (Java 9 and later)</VSCodeCheckbox>
+          <vscode-checkbox checked={useRelease} onClick={onClickUseRelease}>Use '--release' option for cross-compilation (Java 9 and later)</vscode-checkbox>
         </div>
         <div>
-          <VSCodeDataGrid gridTemplateColumns="40% 60%">
-            <VSCodeDataGridRow className={useRelease ? "" : "invisible"}>
-              <VSCodeDataGridCell className="flex-center pl-0 pr-0" gridColumn="1">
+          <vscode-table >
+            <vscode-table-body slot="body">
+            <vscode-table-row className={useRelease ? "" : "invisible"}>
+              <vscode-table-cell className="flex-center pl-0 pr-0" >
                 <span>Bytecode version:</span>
-              </VSCodeDataGridCell>
-              <VSCodeDataGridCell className="flex-center pl-0 pr-0" gridColumn="2">
-                <VSCodeDropdown value={complianceLevel}>
+              </vscode-table-cell>
+              <vscode-table-cell className="flex-center pl-0 pr-0" >
+                <vscode-single-select value={complianceLevel}>
                   {jdkLevels(complianceLevel, "compliance", onClickComplianceLevel)}
-                </VSCodeDropdown>
-              </VSCodeDataGridCell>
-            </VSCodeDataGridRow>
-            <VSCodeDataGridRow className={useRelease ? "invisible" : ""}>
-              <VSCodeDataGridCell className="flex-center pl-0 pr-0" gridColumn="1">
+                </vscode-single-select>
+              </vscode-table-cell>
+            </vscode-table-row>
+            <vscode-table-row className={useRelease ? "invisible" : ""}>
+              <vscode-table-cell className="flex-center pl-0 pr-0" >
                 <span>Source compatibility:</span>
-              </VSCodeDataGridCell>
-              <VSCodeDataGridCell className="flex-center pl-0 pr-0" gridColumn="2">
-                <VSCodeDropdown value={sourceLevel}>
+              </vscode-table-cell>
+              <vscode-table-cell className="flex-center pl-0 pr-0" >
+                <vscode-single-select value={sourceLevel}>
                   {jdkLevels(sourceLevel, "source", onClickSourceLevel)}
-                </VSCodeDropdown>
-              </VSCodeDataGridCell>
-            </VSCodeDataGridRow>
-            <VSCodeDataGridRow className={useRelease ? "invisible" : ""}>
-              <VSCodeDataGridCell className="flex-center pl-0 pr-0" gridColumn="1">
+                </vscode-single-select>
+              </vscode-table-cell>
+            </vscode-table-row>
+            <vscode-table-row className={useRelease ? "invisible" : ""}>
+              <vscode-table-cell className="flex-center pl-0 pr-0" >
                 <span>Target compatibility:</span>
-              </VSCodeDataGridCell>
-              <VSCodeDataGridCell className="flex-center pl-0 pr-0" gridColumn="2">
-                <VSCodeDropdown value={targetLevel}>
+              </vscode-table-cell>
+              <vscode-table-cell className="flex-center pl-0 pr-0" >
+                <vscode-single-select value={targetLevel}>
                   {jdkLevels(targetLevel, "target", onClickTargetLevel)}
-                </VSCodeDropdown>
-              </VSCodeDataGridCell>
-            </VSCodeDataGridRow>
-          </VSCodeDataGrid>
+                </vscode-single-select>
+              </vscode-table-cell>
+            </vscode-table-row>
+            </vscode-table-body>
+          </vscode-table>
         </div>
         <div className={`mt-2 mb-2 ${showSourceTargetWarning ? "" : "invisible"}`}>
           <span className="setting-section-warning">
@@ -182,19 +193,19 @@ const CompilerConfigurationView = (): JSX.Element | null => {
         </div>
         <div className={`mt-2 mb-2 ${showJdkLevelWarning ? "" : "invisible"}`}>
           <span className="setting-section-warning">
-            Please make sure to have a compatible JDK configured (currently {currentJdkComplianceLevel}). You can change the JDK under the <VSCodeLink href="" onClick={() => onClickChangeJdk()}>JDK Runtime</VSCodeLink> tab.
+            Please make sure to have a compatible JDK configured (currently {currentJdkComplianceLevel}). You can change the JDK under the <a href="" onClick={() => onClickChangeJdk()}>JDK Runtime</a> tab.
           </span>
         </div>
         <div className={showPreviewFlag ? "" : "invisible"}>
-          <VSCodeCheckbox checked={enablePreview} onClick={onClickEnablePreview}>Enable preview features</VSCodeCheckbox>
+          <vscode-checkbox checked={enablePreview} onClick={onClickEnablePreview}>Enable preview features</vscode-checkbox>
         </div>
-        <VSCodeDivider className="mt-3" />
+        <vscode-divider className="mt-3" />
         <h4 className="mt-3 mb-3">Class File Generation</h4>
         <div>
-          <VSCodeCheckbox checked={generateDebugInfo} onClick={onClickGenerateDebugInfo}>Generate debugging information</VSCodeCheckbox>
+          <vscode-checkbox checked={generateDebugInfo} onClick={onClickGenerateDebugInfo}>Generate debugging information</vscode-checkbox>
         </div>
         <div>
-          <VSCodeCheckbox checked={storeMethodParamNames} onClick={onClickStoreMethodParamNames}>Store information about method parameters</VSCodeCheckbox>
+          <vscode-checkbox checked={storeMethodParamNames} onClick={onClickStoreMethodParamNames}>Store information about method parameters</vscode-checkbox>
         </div>
       </div>
       <Hint />

--- a/src/project-settings/assets/compiler/features/components/Hint.tsx
+++ b/src/project-settings/assets/compiler/features/components/Hint.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeLink} from "@vscode/webview-ui-toolkit/react";
-import React from "react";
 import { useSelector } from "react-redux";
 import { ProjectType } from "../../../../../utils/webview";
 import { ClasspathRequest } from "../../../vscode/utils";
@@ -45,7 +43,7 @@ const Hint = (): JSX.Element | null => {
           <div className="mt-1">
             <span className="setting-section-warning">
               '{projects[activeProjectIndex].name}' is imported by {projectType[activeProjectIndex]}, some changes made to the compiler settings might be lost after reloading.
-              To make permanent changes, please edit the <VSCodeLink href="" onClick={() => handleOpenBuildFile()}>{buildFile}</VSCodeLink> file.
+              To make permanent changes, please edit the <a href="" onClick={() => handleOpenBuildFile()}>{buildFile}</a> file.
             </span>
           </div>
         }

--- a/src/project-settings/assets/index.tsx
+++ b/src/project-settings/assets/index.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 import App from "./mainpage/features/App";
 
-ReactDOM.render(
-    <React.StrictMode>
+const root = createRoot(document.getElementById("content")!);
+root.render(
+    <StrictMode>
         <App />
-    </React.StrictMode>,
-    document.getElementById("content")
+    </StrictMode>
 );

--- a/src/project-settings/assets/mainpage/features/App.tsx
+++ b/src/project-settings/assets/mainpage/features/App.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React from "react";
 import { Provider } from "react-redux";
 import store from "../../store";
 import ProjectSettingView from "./ProjectSettingView";

--- a/src/project-settings/assets/mainpage/features/ProjectSettingView.tsx
+++ b/src/project-settings/assets/mainpage/features/ProjectSettingView.tsx
@@ -1,14 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React, { Dispatch, useEffect, useRef } from "react";
+import "@vscode-elements/elements/dist/vscode-divider/index.js";
+import "@vscode-elements/elements/dist/vscode-progress-ring/index.js";
+
+import { Dispatch, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import ClasspathConfigurationView from "../../classpath/features/ClasspathConfigurationView";
 import { initializeClasspathData, loadClasspath, updateActiveTab } from "../../classpath/features/classpathConfigurationViewSlice";
 import "../style.scss";
 import { catchException, listProjects, setProjectType, updateActiveSection } from "./commonSlice";
 import ProjectSelector from "./component/ProjectSelector";
-import { VSCodeDivider, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+
 import Footer from "./component/Footer";
 import SideBar from "./component/SideBar";
 import MavenConfigurationView from "../../maven/features/MavenConfigurationView";
@@ -88,7 +91,7 @@ const ProjectSettingView = (): JSX.Element => {
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener("message", onMessage);
     if (projects.length == 0) {
       // this makes sure the initialization only happens when the
@@ -116,19 +119,19 @@ const ProjectSettingView = (): JSX.Element => {
   if (exception) {
     return <Exception />;
   } else if (projects.length === 0) {
-    return <VSCodeProgressRing/>;
+    return <vscode-progress-ring/>;
   } else {
     return (
       <div className="root">
         <ProjectSelector />
-        <VSCodeDivider />
+        <vscode-divider />
         <div className="app-container">
           <SideBar />
           <div className="app-frame">
             {getSectionContent()}
           </div>
         </div>
-        <VSCodeDivider />
+        <vscode-divider />
         <Footer />
       </div>
     );

--- a/src/project-settings/assets/mainpage/features/component/Exception.tsx
+++ b/src/project-settings/assets/mainpage/features/component/Exception.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React from "react";
 import { useSelector } from "react-redux";
 import { encodeCommandUriWithTelemetry, supportedByNavigator } from "../../../../../utils/webview";
 import { ProjectSettingsException } from "../../../../types";

--- a/src/project-settings/assets/mainpage/features/component/Footer.tsx
+++ b/src/project-settings/assets/mainpage/features/component/Footer.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import "@vscode-elements/elements/dist/vscode-button/index.js";
+
 import { Dispatch } from "@reduxjs/toolkit";
-import React, { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { ClasspathEntry, ProjectInfo } from "../../../../types";
 import { useDispatch, useSelector } from "react-redux";
 import { ProjectType } from "../../../../../utils/webview";
@@ -127,18 +128,31 @@ const Footer = (): JSX.Element => {
       }
     }, []);
 
+  const isModified = classpathModified || mavenModified || compilerModified;
+  const applyBtnRef = useRef<HTMLElement>(null);
+
+  // Sync disabled attribute via ref for reliable web component behavior
+  useEffect(() => {
+    const el = applyBtnRef.current;
+    if (!el) return;
+    if (!isModified) {
+      el.setAttribute("disabled", "");
+    } else {
+      el.removeAttribute("disabled");
+    }
+  }, [isModified]);
+
   return (
     <div id="footer" className="pt-1">
-        {loadingState && <VSCodeButton className="ml-1" disabled>Applying...</VSCodeButton>}
+        {loadingState && <vscode-button className="ml-1" disabled>Applying...</vscode-button>}
         {!loadingState &&
-          <VSCodeButton
+          <vscode-button
+            ref={applyBtnRef}
             className="ml-1"
-            appearance="primary"
-            disabled={!classpathModified && !mavenModified && !compilerModified}
             onClick={() => handleApply()}
           >
             Apply Settings
-          </VSCodeButton>
+          </vscode-button>
         }
     </div>
   );

--- a/src/project-settings/assets/mainpage/features/component/ProjectSelector.tsx
+++ b/src/project-settings/assets/mainpage/features/component/ProjectSelector.tsx
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React, { useEffect } from "react";
+import "@vscode-elements/elements/dist/vscode-single-select/index.js";
+import "@vscode-elements/elements/dist/vscode-option/index.js";
+
+import { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { ProjectInfo } from "../../../../types";
 import { Dispatch } from "@reduxjs/toolkit";
-import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+
 import { activeProjectChange } from "../../../mainpage/features/commonSlice";
 import { ClasspathRequest, CompilerRequest, MavenRequest } from "../../../vscode/utils";
 
@@ -35,9 +38,9 @@ const ProjectSelector = (): JSX.Element | null => {
     }
 
     return (
-      <VSCodeOption className="setting-section-option" key={project.rootPath} onClick={() => handleActiveProjectChange(index)}>
+      <vscode-option className="setting-section-option" key={project.rootPath} onClick={() => handleActiveProjectChange(index)}>
         {project.name}
-      </VSCodeOption>
+      </vscode-option>
     );
   });
 
@@ -45,9 +48,9 @@ const ProjectSelector = (): JSX.Element | null => {
     <div id="project-selector" className="setting-section">
       <div className="flex-center mt-2 mb-2">
         <span className="setting-section-description ml-1 mr-1">Project:</span>
-        <VSCodeDropdown className="setting-section-dropdown">
+        <vscode-single-select className="setting-section-dropdown">
             {projectSelections}
-        </VSCodeDropdown>
+        </vscode-single-select>
       </div>
     </div>
   );

--- a/src/project-settings/assets/mainpage/features/component/SideBar.tsx
+++ b/src/project-settings/assets/mainpage/features/component/SideBar.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Dispatch } from "@reduxjs/toolkit";
 import { updateActiveSection } from "../commonSlice";

--- a/src/project-settings/assets/maven/features/MavenConfigurationView.tsx
+++ b/src/project-settings/assets/maven/features/MavenConfigurationView.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React from "react";
 import { useSelector } from "react-redux";
 import { ProjectType } from "../../../../utils/webview";
 import Profile from "./components/Profile";

--- a/src/project-settings/assets/maven/features/components/Profile.tsx
+++ b/src/project-settings/assets/maven/features/components/Profile.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
-import React, { Dispatch } from "react";
+import "@vscode-elements/elements/dist/vscode-textfield/index.js";
+
+
+import { Dispatch } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { updateActiveProfiles } from "../mavenConfigurationViewSlice";
 
@@ -26,10 +28,10 @@ const Profile = (): JSX.Element => {
         <span>(comma separated)</span>
       </div>
 
-      <VSCodeTextField className="setting-section-text"
+      <vscode-textfield className="setting-section-text"
         value={activeProfiles ?? ""}
         onInput={handleInput}>
-      </VSCodeTextField>
+      </vscode-textfield>
     </div>
   );
 };

--- a/src/project-settings/assets/utils.scss
+++ b/src/project-settings/assets/utils.scss
@@ -1,36 +1,36 @@
 @for $i from 0 through 12 {
     .pl-#{$i} {
-        padding-left: calc(var(--design-unit) * #{$i}px);
+        padding-left: calc(var(--design-unit, 4) * #{$i}px);
     }
 
     .pr-#{$i} {
-        padding-right: calc(var(--design-unit) * #{$i}px);
+        padding-right: calc(var(--design-unit, 4) * #{$i}px);
     }
 
     .pt-#{$i} {
-        padding-top: calc(var(--design-unit) * #{$i}px);
+        padding-top: calc(var(--design-unit, 4) * #{$i}px);
     }
 
     .pb-#{$i} {
-        padding-bottom: calc(var(--design-unit) * #{$i}px);
+        padding-bottom: calc(var(--design-unit, 4) * #{$i}px);
     }
 }
 
 @for $i from 0 through 12 {
     .ml-#{$i} {
-        margin-left: calc(var(--design-unit) * #{$i}px);
+        margin-left: calc(var(--design-unit, 4) * #{$i}px);
     }
 
     .mr-#{$i} {
-        margin-right: calc(var(--design-unit) * #{$i}px);
+        margin-right: calc(var(--design-unit, 4) * #{$i}px);
     }
 
     .mt-#{$i} {
-        margin-top: calc(var(--design-unit) * #{$i}px);
+        margin-top: calc(var(--design-unit, 4) * #{$i}px);
     }
 
     .mb-#{$i} {
-        margin-bottom: calc(var(--design-unit) * #{$i}px);
+        margin-bottom: calc(var(--design-unit, 4) * #{$i}px);
     }
 }
 

--- a/src/vscode-elements.d.ts
+++ b/src/vscode-elements.d.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import "react";
+
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "vscode-button": any;
+      "vscode-badge": any;
+      "vscode-checkbox": any;
+      "vscode-collapsible": any;
+      "vscode-divider": any;
+      "vscode-icon": any;
+      "vscode-label": any;
+      "vscode-option": any;
+      "vscode-progress-ring": any;
+      "vscode-radio": any;
+      "vscode-radio-group": any;
+      "vscode-single-select": any;
+      "vscode-tab-header": any;
+      "vscode-tab-panel": any;
+      "vscode-tabs": any;
+      "vscode-table": any;
+      "vscode-table-body": any;
+      "vscode-table-cell": any;
+      "vscode-table-header": any;
+      "vscode-table-header-cell": any;
+      "vscode-table-row": any;
+      "vscode-textfield": any;
+      "vscode-textarea": any;
+    }
+  }
+}
+
+// Re-export JSX globally for files using JSX.Element without import
+declare global {
+  namespace JSX {
+    type Element = React.JSX.Element;
+  }
+}

--- a/src/welcome/assets/components/ControllerPanel.tsx
+++ b/src/welcome/assets/components/ControllerPanel.tsx
@@ -1,23 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React from "react";
-import { Form } from "react-bootstrap";
 import { setWelcomeVisibility } from "../utils";
 
-export default class ControllerPanel extends React.Component<{
+interface ControllerPanelProps {
     showWhenUsingJava?: boolean;
-}> {
-  render() {
-    let {showWhenUsingJava} = this.props;
+}
 
-    return <Form>
-        <Form.Check defaultChecked={showWhenUsingJava} label="Show Help Center when using Java" onChange={toggleVisibility}/>
-    </Form>;
-  }
-
+export default function ControllerPanel({ showWhenUsingJava }: ControllerPanelProps) {
+    return (
+        <div>
+            <label>
+                <input
+                    type="checkbox"
+                    defaultChecked={showWhenUsingJava}
+                    onChange={toggleVisibility}
+                />
+                {" "}Show Help Center when using Java
+            </label>
+        </div>
+    );
 }
 
 function toggleVisibility(event: React.ChangeEvent<HTMLInputElement>) {
-  setWelcomeVisibility(event.target.checked);
+    setWelcomeVisibility(event.target.checked);
 }

--- a/src/welcome/assets/components/GetStartedPage.tsx
+++ b/src/welcome/assets/components/GetStartedPage.tsx
@@ -1,66 +1,50 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
-import { Col, Container, Row } from "react-bootstrap";
 import ControllerPanel from "./ControllerPanel";
 import Header from "./Header";
 import NavigationPanel from "./NavigationPanel";
 import QuickActionPanel from "./QuickActionPanel";
 import SocialMediaPanel from "./SocialMediaPanel";
-import TourPage from "./TourPage";
 
-export class GetStartedPage extends React.Component<{
-    showWhenUsingJava: boolean,
-    firstTimeRun: boolean,
-    isAwtDisabled: boolean,
-}> {
+interface GetStartedPageProps {
+    showWhenUsingJava: boolean;
+    firstTimeRun: boolean;
+    isAwtDisabled: boolean;
+}
 
-    render() {
-        return this.renderWelcomePage();
-    }
-
-    renderWelcomePage() {
-        const {showWhenUsingJava, isAwtDisabled} = this.props;
-        return (
-            <Container fluid className="root">
-                <Row className="mb-4">
-                    <Col>
-                        <Header />
-                    </Col>
-                </Row>
-                <Row className="mb-4">
-                    <Col>
-                        <QuickActionPanel/>
-                    </Col>
-                </Row>
-                <Row className="mb-4">
-                    <Col>
-                        <NavigationPanel isAwtDisabled={isAwtDisabled}/>
-                    </Col>
-                </Row>
-                <Row className="mb-4 footer">
-                    <Col>
-                        <Row className="mb-2">
-                            <Col>
-                                <SocialMediaPanel />
-                            </Col>
-                        </Row>
-                        <Row>
-                            <Col>
-                                <ControllerPanel showWhenUsingJava={showWhenUsingJava}/>
-                            </Col>
-                        </Row>
-                    </Col>
-                </Row>
-            </Container>
-        );
-    }
-
-    /**
-     * @deprecated 
-     */
-    renderTourPage() {
-        return <TourPage></TourPage>;
-    }
+export function GetStartedPage({ showWhenUsingJava, isAwtDisabled }: GetStartedPageProps) {
+    return (
+        <div className="container-fluid root">
+            <div className="row mb-4">
+                <div className="col">
+                    <Header />
+                </div>
+            </div>
+            <div className="row mb-4">
+                <div className="col">
+                    <QuickActionPanel />
+                </div>
+            </div>
+            <div className="row mb-4">
+                <div className="col">
+                    <NavigationPanel isAwtDisabled={isAwtDisabled} />
+                </div>
+            </div>
+            <div className="row mb-4 footer">
+                <div className="col">
+                    <div className="row mb-2">
+                        <div className="col">
+                            <SocialMediaPanel />
+                        </div>
+                    </div>
+                    <div className="row">
+                        <div className="col">
+                            <ControllerPanel showWhenUsingJava={showWhenUsingJava} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/src/welcome/assets/components/Header.tsx
+++ b/src/welcome/assets/components/Header.tsx
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
 import { encodeCommandUriWithTelemetry } from "../../../utils/webview";
 import { WEBVIEW_ID } from "../utils";
 
 const DEV_BLOG_LINK = "https://devblogs.microsoft.com/?s=Java+on+Visual+Studio+Code";
-export default class Header extends React.Component {
-  render() {
+
+export default function Header() {
     const openBlogCommand = encodeCommandUriWithTelemetry(WEBVIEW_ID, "blogs", "java.helper.openUrl", [DEV_BLOG_LINK]);
     const title = <h2>Java Help Center</h2>;
     const blogsLink = <a href={openBlogCommand}>blogs</a>;
@@ -20,5 +19,4 @@ export default class Header extends React.Component {
         </div>
       </div>
     );
-  }
 }

--- a/src/welcome/assets/components/NavigationPanel.tsx
+++ b/src/welcome/assets/components/NavigationPanel.tsx
@@ -2,99 +2,100 @@
 // Licensed under the MIT license.
 
 import * as _ from "lodash";
-import Tabs from "react-bootstrap/Tabs";
-import Tab from "react-bootstrap/Tab";
-import React from "react";
-import Icon from "@iconify/react";
-import gearIcon from "@iconify-icons/codicon/gear";
-import globeIcon from "@iconify-icons/codicon/globe";
-import mortarBoardIcon from "@iconify-icons/codicon/mortar-board";
-import rocketIcon from "@iconify-icons/codicon/rocket";
-import { ListGroup } from "react-bootstrap";
+import { useState, useRef } from "react";
 import { reportTabSwitch, WEBVIEW_ID } from "../utils";
 import { encodeCommandUriWithTelemetry } from "../../../utils/webview";
 
-export default class NavigationPanel extends React.Component<{
+interface NavigationPanelProps {
   isAwtDisabled: boolean;
-}> {
-  private groups = [
-    {
-      name: "General",
-      icon: <Icon className="codicon" icon={gearIcon} />,
-      actions: [
-        { name: "Configure Java Runtime", command: "java.runtime" },
-        { name: "Open Java Settings", command: "workbench.action.openSettings", args: ["java."] },
-        { name: "Install Extensions...", command: "java.extGuide" },
-        { name: "Configure Formatter Settings", command: "java.formatterSettings" }
-      ]
-    },
-    {
-      name: "Spring",
-      icon: <Icon className="codicon" icon={globeIcon} />,
-      actions: [
-        { name: "Spring Boot with VS Code", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-spring-boot"] },
-        { name: "Spring PetClinic Sample Application", command: "java.helper.openUrl", args: ["https://github.com/spring-projects/spring-petclinic"] },
-        { name: "Install Spring Boot Extension Pack ...", command: "java.helper.installExtension", args: ["vmware.vscode-boot-dev-pack", "Spring Boot Extension Pack"] }
-      ]
-    },
-    {
-      name: "Student",
-      icon: <Icon className="codicon" icon={mortarBoardIcon} />,
-      actions: [
-        { name: "Coding and Debugging Tips", command: "java.gettingStarted" },
-        { name: "Tutorial: Running and Debugging", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-debugging"] },
-        { name: "Tutorial: Testing", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-testing"] },
-        { name: "Configure Sources, Dependencies, Output Folder...", command: "java.classpathConfiguration" },
-        { name: "Quick Start: Jupyter Notebook for Java", command: "java.helper.openUrl", args: ["https://github.com/microsoft/vscode-java-pack/wiki/Quick-Start:-Jupyter-Notebook-for-Java"] },
-        { name: "Enable AWT Development", command: "java.toggleAwtDevelopment", args: [true] },
-      ]
-    },
-  ];
+}
 
-  private currentTab: string = this.groups[0].name;
+const groups = [
+  {
+    name: "General",
+    iconClass: "codicon codicon-gear",
+    actions: [
+      { name: "Configure Java Runtime", command: "java.runtime" },
+      { name: "Open Java Settings", command: "workbench.action.openSettings", args: ["java."] as string[] },
+      { name: "Install Extensions...", command: "java.extGuide" },
+      { name: "Configure Formatter Settings", command: "java.formatterSettings" }
+    ]
+  },
+  {
+    name: "Spring",
+    iconClass: "codicon codicon-globe",
+    actions: [
+      { name: "Spring Boot with VS Code", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-spring-boot"] },
+      { name: "Spring PetClinic Sample Application", command: "java.helper.openUrl", args: ["https://github.com/spring-projects/spring-petclinic"] },
+      { name: "Install Spring Boot Extension Pack ...", command: "java.helper.installExtension", args: ["vmware.vscode-boot-dev-pack", "Spring Boot Extension Pack"] }
+    ]
+  },
+  {
+    name: "Student",
+    iconClass: "codicon codicon-mortar-board",
+    actions: [
+      { name: "Coding and Debugging Tips", command: "java.gettingStarted" },
+      { name: "Tutorial: Running and Debugging", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-debugging"] },
+      { name: "Tutorial: Testing", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-testing"] },
+      { name: "Configure Sources, Dependencies, Output Folder...", command: "java.classpathConfiguration" },
+      { name: "Quick Start: Jupyter Notebook for Java", command: "java.helper.openUrl", args: ["https://github.com/microsoft/vscode-java-pack/wiki/Quick-Start:-Jupyter-Notebook-for-Java"] },
+      { name: "Enable AWT Development", command: "java.toggleAwtDevelopment", args: [true] as any[] },
+    ]
+  },
+];
 
-  render() {
-    const {isAwtDisabled} = this.props;
-    const studentSection = _.find(this.groups, {name: "Student"});
-    if (studentSection) {
-      for (const action of studentSection.actions) {
-        if (action.command === "java.toggleAwtDevelopment") {
-          action.name = `${isAwtDisabled ? "Enable" : "Disable"} AWT Development`;
-          action.args = [isAwtDisabled];
-        }
+export default function NavigationPanel({ isAwtDisabled }: NavigationPanelProps) {
+  const [activeTab, setActiveTab] = useState(groups[0].name);
+  const prevTabRef = useRef(groups[0].name);
+
+  const studentSection = _.find(groups, { name: "Student" });
+  if (studentSection) {
+    for (const action of studentSection.actions) {
+      if (action.command === "java.toggleAwtDevelopment") {
+        action.name = `${isAwtDisabled ? "Enable" : "Disable"} AWT Development`;
+        action.args = [isAwtDisabled];
       }
     }
-
-    const itemIcon = <Icon className="codicon" icon={rocketIcon} />;
-    const tabItems = this.groups.map(group => {
-      const actionItems = group.actions.map(action => (
-        <a
-          href={encodeCommandUriWithTelemetry(WEBVIEW_ID, action.name, action.command, action.args)}
-          key={action.name}
-        >{itemIcon} {action.name}</a>
-      ));
-      const titleNode = <div className="navigation-title">{group.icon} {group.name}</div>;
-      return (
-        <Tab eventKey={group.name} title={titleNode} key={group.name} className="navigation-tabcontent" tabClassName="navigation-tab">
-          <ListGroup>
-            {actionItems}
-          </ListGroup>
-        </Tab>
-      );
-    });
-
-    return (
-      <Tabs defaultActiveKey={this.currentTab} id="navigationPanel" onSelect={this.onSwitchTab}>
-        {tabItems}
-      </Tabs>
-    );
   }
 
-  onSwitchTab = (eventKey: string | null, _e: React.SyntheticEvent<unknown>) => {
-    if (eventKey) {
-      reportTabSwitch(this.currentTab, eventKey);
-      this.currentTab = eventKey;
-    }
-  }
+  const onSwitchTab = (newTab: string) => {
+    reportTabSwitch(prevTabRef.current, newTab);
+    prevTabRef.current = newTab;
+    setActiveTab(newTab);
+  };
 
+  return (
+    <div id="navigationPanel">
+      <ul className="nav-tabs" role="tablist">
+        {groups.map(group => (
+          <li key={group.name} className="navigation-tab">
+            <button
+              role="tab"
+              className={`nav-link${activeTab === group.name ? " active" : ""}`}
+              onClick={() => onSwitchTab(group.name)}
+              aria-selected={activeTab === group.name}
+            >
+              <div className="navigation-title">
+                <i className={group.iconClass}></i> {group.name}
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {groups.map(group => (
+        activeTab === group.name && (
+          <div key={group.name} className="navigation-tabcontent" role="tabpanel">
+            <div className="list-group">
+              {group.actions.map(action => (
+                <a
+                  href={encodeCommandUriWithTelemetry(WEBVIEW_ID, action.name, action.command, action.args)}
+                  key={action.name}
+                ><i className="codicon codicon-rocket"></i> {action.name}</a>
+              ))}
+            </div>
+          </div>
+        )
+      ))}
+    </div>
+  );
 }

--- a/src/welcome/assets/components/NavigationPanel.tsx
+++ b/src/welcome/assets/components/NavigationPanel.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as _ from "lodash";
 import { useState, useRef } from "react";
 import { reportTabSwitch, WEBVIEW_ID } from "../utils";
 import { encodeCommandUriWithTelemetry } from "../../../utils/webview";
@@ -48,15 +47,20 @@ export default function NavigationPanel({ isAwtDisabled }: NavigationPanelProps)
   const [activeTab, setActiveTab] = useState(groups[0].name);
   const prevTabRef = useRef(groups[0].name);
 
-  const studentSection = _.find(groups, { name: "Student" });
-  if (studentSection) {
-    for (const action of studentSection.actions) {
-      if (action.command === "java.toggleAwtDevelopment") {
-        action.name = `${isAwtDisabled ? "Enable" : "Disable"} AWT Development`;
-        action.args = [isAwtDisabled];
-      }
-    }
-  }
+  const resolvedGroups = groups.map(group => {
+    if (group.name !== "Student") return group;
+    return {
+      ...group,
+      actions: group.actions.map(action => {
+        if (action.command !== "java.toggleAwtDevelopment") return action;
+        return {
+          ...action,
+          name: `${isAwtDisabled ? "Enable" : "Disable"} AWT Development`,
+          args: [isAwtDisabled],
+        };
+      }),
+    };
+  });
 
   const onSwitchTab = (newTab: string) => {
     reportTabSwitch(prevTabRef.current, newTab);
@@ -67,7 +71,7 @@ export default function NavigationPanel({ isAwtDisabled }: NavigationPanelProps)
   return (
     <div id="navigationPanel">
       <ul className="nav-tabs" role="tablist">
-        {groups.map(group => (
+        {resolvedGroups.map(group => (
           <li key={group.name} className="navigation-tab">
             <button
               role="tab"
@@ -82,7 +86,7 @@ export default function NavigationPanel({ isAwtDisabled }: NavigationPanelProps)
           </li>
         ))}
       </ul>
-      {groups.map(group => (
+      {resolvedGroups.map(group => (
         activeTab === group.name && (
           <div key={group.name} className="navigation-tabcontent" role="tabpanel">
             <div className="list-group">

--- a/src/welcome/assets/components/QuickActionPanel.tsx
+++ b/src/welcome/assets/components/QuickActionPanel.tsx
@@ -1,46 +1,42 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
-import { ListGroup } from "react-bootstrap";
 import { encodeCommandUriWithTelemetry, supportedByNavigator } from "../../../utils/webview";
 import { WEBVIEW_ID } from "../utils";
 
-export default class QuickActionPanel extends React.Component<{}, {}> {
-    render() {
-        const newProjectElement = <span>
-            {"Create a "}
-            <span className="highlight">{"New Project"}</span>
-        </span>;
-        const existingProjectElement = <span>
-            {"Open an "}
-            <span className="highlight">{"Existing Project"}</span>
-        </span>;
-        const tourElement = <span>
-            {"Take a "}
-            <span className="highlight">{"Tour"}</span>
-        </span>;
-        const actions: any[] = [
-            { name: "Create a New Project", command: "java.project.create", element: newProjectElement },
-            { name: "Open an Existing Project", command: "workbench.action.files.openFolder", os: "win", element: existingProjectElement },
-            { name: "Open an Existing Project", command: "workbench.action.files.openFolder", os: "linux", element: existingProjectElement },
-            { name: "Open an Existing Project", command: "workbench.action.files.openFileFolder", os: "mac", element: existingProjectElement },
-            { name: "Take a Tour", command: "workbench.action.openWalkthrough", args: ["vscjava.vscode-java-pack#javaWelcome"], element: tourElement }
-        ];
-        const actionItems = actions.filter(action => !action.os || supportedByNavigator(action.os)).map(action => (
-            <ListGroup.Item
-                action
-                href={encodeCommandUriWithTelemetry(WEBVIEW_ID, action.name, action.command, action.args)}
-                key={action.name}
-            >{action.element}</ListGroup.Item>
-        ));
-        return (
-            <div className="quick-actions">
-                <h5>Get Started</h5>
-                <ListGroup>
-                    {actionItems}
-                </ListGroup>
+export default function QuickActionPanel() {
+    const newProjectElement = <span>
+        {"Create a "}
+        <span className="highlight">{"New Project"}</span>
+    </span>;
+    const existingProjectElement = <span>
+        {"Open an "}
+        <span className="highlight">{"Existing Project"}</span>
+    </span>;
+    const tourElement = <span>
+        {"Take a "}
+        <span className="highlight">{"Tour"}</span>
+    </span>;
+    const actions: any[] = [
+        { name: "Create a New Project", command: "java.project.create", element: newProjectElement },
+        { name: "Open an Existing Project", command: "workbench.action.files.openFolder", os: "win", element: existingProjectElement },
+        { name: "Open an Existing Project", command: "workbench.action.files.openFolder", os: "linux", element: existingProjectElement },
+        { name: "Open an Existing Project", command: "workbench.action.files.openFileFolder", os: "mac", element: existingProjectElement },
+        { name: "Take a Tour", command: "workbench.action.openWalkthrough", args: ["vscjava.vscode-java-pack#javaWelcome"], element: tourElement }
+    ];
+    const actionItems = actions.filter(action => !action.os || supportedByNavigator(action.os)).map(action => (
+        <a
+            className="list-group-item list-group-item-action"
+            href={encodeCommandUriWithTelemetry(WEBVIEW_ID, action.name, action.command, action.args)}
+            key={action.name}
+        >{action.element}</a>
+    ));
+    return (
+        <div className="quick-actions">
+            <h5>Get Started</h5>
+            <div className="list-group">
+                {actionItems}
             </div>
-        );
-    }
+        </div>
+    );
 }

--- a/src/welcome/assets/components/SocialMediaPanel.tsx
+++ b/src/welcome/assets/components/SocialMediaPanel.tsx
@@ -1,31 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
-import { Icon } from "@iconify/react";
-import bookIcon from "@iconify-icons/codicon/book";
-import githubIcon from "@iconify-icons/codicon/github-inverted";
-import { ListGroup } from "react-bootstrap";
 import { encodeCommandUriWithTelemetry } from "../../../utils/webview";
 import { WEBVIEW_ID } from "../utils";
 
-export default class SocialMediaPanel extends React.Component {
-    render() {
-        const links = [
-            { name: "Documentation", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-tutorial"], icon: bookIcon },
-            { name: "Questions & Issues", command: "java.helper.openUrl", args: ["https://github.com/microsoft/vscode-java-pack/issues"], icon: githubIcon },
-        ];
-        const elements = links.map(link => (
-            <a
-              href={encodeCommandUriWithTelemetry(WEBVIEW_ID, link.name, link.command, link.args)}
-              key={link.name}
-            ><Icon className="codicon" icon={link.icon} width="1.2em" height="1.2em"/> {link.name}</a>
-
-        ));
-        return (
-            <ListGroup>
-                {elements}
-            </ListGroup>
-        );
-    }
+export default function SocialMediaPanel() {
+    const links = [
+        { name: "Documentation", command: "java.helper.openUrl", args: ["https://code.visualstudio.com/docs/java/java-tutorial"], iconClass: "codicon codicon-book" },
+        { name: "Questions & Issues", command: "java.helper.openUrl", args: ["https://github.com/microsoft/vscode-java-pack/issues"], iconClass: "codicon codicon-github-inverted" },
+    ];
+    const elements = links.map(link => (
+        <a
+          href={encodeCommandUriWithTelemetry(WEBVIEW_ID, link.name, link.command, link.args)}
+          key={link.name}
+        ><i className={link.iconClass} style={{width: "1.2em", height: "1.2em"}}></i> {link.name}</a>
+    ));
+    return (
+        <div className="list-group">
+            {elements}
+        </div>
+    );
 }

--- a/src/welcome/assets/components/TourPage.tsx
+++ b/src/welcome/assets/components/TourPage.tsx
@@ -1,155 +1,116 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import React, { Component } from "react";
-import { Button, Col, Container, Row } from "react-bootstrap";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { encodeCommandUriWithTelemetry, supportedByNavigator } from "../../../utils/webview";
 import { onWillFetchInitProps, reportSkipTour, WEBVIEW_ID } from "../utils";
 
 const logoIcon = require("../../../../logo.svg");
 const doneIcon = require("../resources/done.svg");
 
-declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
+export default function TourPage() {
+    const [step, setStep] = useState(0);
+    const timerRef = useRef<number | undefined>(undefined);
 
-export default class TourPage extends Component<{
-}, {
-    step: number
-}> {
-    constructor(props: any) {
-        super(props);
-        this.state = {
-            step: 0
-        };
+    const contentPages = useMemo(() => {
+        const openFolderCommand = encodeCommandUriWithTelemetry(WEBVIEW_ID, "open folder", supportedByNavigator("mac") ? "workbench.action.files.openFileFolder" : "workbench.action.files.openFolder");
+        const showProjectExplorerCommand = encodeCommandUriWithTelemetry(WEBVIEW_ID, "show project explorer", "javaProjectExplorer.focus");
+        const showRunAndDebugViewCommand = encodeCommandUriWithTelemetry(WEBVIEW_ID, "show run and debug view", "workbench.view.debug");
+        const showTestExplorerViewCommand = encodeCommandUriWithTelemetry(WEBVIEW_ID, "show test explorer", "testExplorer.focus");
 
-        this.steps = [
-            this.getStartingPage(),
-            ...this.getContentPages(),
-            this.getEndingPage()
-        ];
-
-        this.timer = undefined;
-    }
-
-    private steps: JSX.Element[];
-    // auto navigate to welcome page in last step
-    private timer: number | undefined;
-
-    render() {
-        const { step } = this.state;
-
-        if (this.timer !== undefined) {
-            clearTimeout(this.timer);
-        }
-
-        if (step >= this.steps.length) {
-            onWillFetchInitProps();
-            return <div>Loading...</div>;
-        } else if (step === this.steps.length - 1) {
-            this.timer = setTimeout(() => {
-                onWillFetchInitProps();
-            }, 5000);
-        }
-
-        return (
-            <Container fluid className="root">
-                <Row className="mb-4 mt-5">
-                    <Col className="text-center page-content">
-                        {this.steps[step]}
-
-                    </Col>
-                </Row>
-                <Row className="mb-4 footer">
-                    <Col>
-                        <div className="page-indicator text-center">
-                            {this.steps.map((_elem, index) =>
-                                <span key={index} className={index === step ? "active dot" : "dot"} onClick={() => this.showStep(index)}></span>
-                            )}
-                        </div>
-                    </Col>
-                </Row>
-            </Container>
-        );
-    }
-
-    showStep = (newStep: number) => {
-        this.setState({
-            step: newStep
-        });
-    }
-
-    nextStep = () => {
-        const newStep = this.state.step + 1;
-        this.setState({
-            step: newStep
-        });
-    }
-
-    getContentPages = () => {
-        /**
-         * Provide 4 pages:
-         * 1. open folder: for full features
-         * 2. project view
-         * 3. run/debug: point out the entry we want to promote
-         * 4. testing
-         */
-
-        const openFolderCommand: string = encodeCommandUriWithTelemetry(WEBVIEW_ID, "open folder", supportedByNavigator("mac") ? "workbench.action.files.openFileFolder" : "workbench.action.files.openFolder");
-        const showProjectExplorerCommand: string = encodeCommandUriWithTelemetry(WEBVIEW_ID, "show project explorer", "javaProjectExplorer.focus");
-        const showRunAndDebugViewCommand: string = encodeCommandUriWithTelemetry(WEBVIEW_ID, "show run and debug view", "workbench.view.debug");
-        const showTestExplorerViewCommand: string = encodeCommandUriWithTelemetry(WEBVIEW_ID, "show test explorer", "testExplorer.focus");
-
-        const content = [{
+        return [{
             title: "Open Project Folder",
             description: <div><a href={openFolderCommand}>Open a folder</a> containing your Java project for full features.</div>,
             imageUri: require("../resources/open-project.png")
-        },
-        {
+        }, {
             title: "Project Explorer",
             description: <div>Expand <a href={showProjectExplorerCommand}>Java Project Explorer</a> to view your project structure.</div>,
             imageUri: require("../resources/project-manager.png")
-        },
-        {
+        }, {
             title: "Running and Debugging",
             description: <div>Open <a href={showRunAndDebugViewCommand}>Run and Debug View</a> to start your project.</div>,
             imageUri: require("../resources/debugger.png")
-        },
-        {
+        }, {
             title: "Testing",
             description: <div>Use <a href={showTestExplorerViewCommand}>Testing View</a> to run unit tests.</div>,
             imageUri: require("../resources/testing.png")
         }];
+    }, []);
 
-        return content.map((elem) => <div className="text-center">
+    const nextStep = () => setStep(s => s + 1);
+
+    const steps = useMemo(() => {
+        const startingPage = <div key="start">
+            <img src={logoIcon} alt="logo" className="logo" />
+            <h2>Welcome to use Java Tools</h2>
+            <div>lightweight, performant, powerful.</div>
+            <div><button className="btn" onClick={nextStep}>Get Started</button></div>
+            <div><a href="#" onClick={() => skipTourFrom("Starting Page")}>skip</a></div>
+        </div>;
+
+        const pages = contentPages.map(elem => <div className="text-center" key={elem.title}>
             <h2>{elem.title}</h2>
             <div>{elem.description}</div>
             <img src={elem.imageUri} alt={elem.title} className="screenshot" />
-            <Button onClick={this.nextStep}>Next Step</Button>
+            <button className="btn" onClick={nextStep}>Next Step</button>
             <div><a href="#" onClick={() => skipTourFrom(elem.title)}>skip</a></div>
-        </div>, this);
-    }
+        </div>);
 
-    getStartingPage = () => {
-        return <div>
-            <img src={logoIcon} alt="logo" className="logo"/>
-            <h2>Welcome to use Java Tools</h2>
-            <div>lightweight, performant, powerful.</div>
-            <div><Button onClick={this.nextStep}>Get Started</Button></div>
-            <div><a href="#" onClick={() => skipTourFrom("Starting Page")}>skip</a></div>
-        </div>;
-    }
-
-    getEndingPage = () => {
-        return <div>
-            <img src={doneIcon} alt="logo" className="logo"/>
-            <h2>You’re good to go!</h2>
+        const endingPage = <div key="end">
+            <img src={doneIcon} alt="logo" className="logo" />
+            <h2>You're good to go!</h2>
             <div>Next, start using Java!</div>
-            <div><Button onClick={this.nextStep}>What's next?</Button></div>
+            <div><button className="btn" onClick={nextStep}>What's next?</button></div>
         </div>;
+
+        return [startingPage, ...pages, endingPage];
+    }, [contentPages]);
+
+    useEffect(() => {
+        if (timerRef.current !== undefined) {
+            clearTimeout(timerRef.current);
+        }
+
+        if (step >= steps.length) {
+            onWillFetchInitProps();
+        } else if (step === steps.length - 1) {
+            timerRef.current = window.setTimeout(() => {
+                onWillFetchInitProps();
+            }, 5000);
+        }
+
+        return () => {
+            if (timerRef.current !== undefined) {
+                clearTimeout(timerRef.current);
+            }
+        };
+    }, [step, steps.length]);
+
+    if (step >= steps.length) {
+        return <div>Loading...</div>;
     }
+
+    return (
+        <div className="container-fluid root">
+            <div className="row mb-4 mt-5">
+                <div className="col text-center page-content">
+                    {steps[step]}
+                </div>
+            </div>
+            <div className="row mb-4 footer">
+                <div className="col">
+                    <div className="page-indicator text-center">
+                        {steps.map((_elem, index) =>
+                            <span key={index} className={index === step ? "active dot" : "dot"} onClick={() => setStep(index)}></span>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
 }
 
 function skipTourFrom(page: string) {
     reportSkipTour(page);
     onWillFetchInitProps();
 }
-

--- a/src/welcome/assets/index.ts
+++ b/src/welcome/assets/index.ts
@@ -1,17 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { GetStartedPage } from "./components/GetStartedPage";
 import "./style.scss";
 import { onWillFetchInitProps } from "./utils";
 
+const container = document.getElementById("content")!;
+const root = createRoot(container);
 
 const onInitialize =  (event: any) => {
     const { data } = event;
     if (data.command === "onDidFetchInitProps") {
-        ReactDOM.render(React.createElement(GetStartedPage, data.props), document.getElementById("content"));
+        root.render(createElement(GetStartedPage, data.props));
     }
 };
 

--- a/src/welcome/assets/style.scss
+++ b/src/welcome/assets/style.scss
@@ -1,31 +1,41 @@
 @import "../../assets/vscode.scss";
 
 // Custom styles dedicated to this webview:
-$nav-tabs-link-active-color: var(--vscode-panelTitle-activeForeground);
-$nav-tabs-link-active-bg: transparent;
-$nav-tabs-link-active-border-color: transparent;
-$nav-tabs-link-hover-border-color: transparent;
-$nav-tabs-border-color: transparent;
 
-$list-group-bg: var(--vscode-peekViewTitle-background);
-$list-group-border-color: var(--vscode-peekViewTitle-background);
-$list-group-action-active-bg: $list-group-bg;
-
-@import "~bootstrap/scss/bootstrap";
-
-.nav-link,
-.nav-link:hover {
-  color: var(--vscode-panelTitle-inactiveForeground);
-  text-transform: uppercase;
+// Tab styles (replacing react-bootstrap Tabs)
+.nav-tabs {
+  display: flex;
+  border-bottom: 1px solid transparent;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
 }
 
-.nav-tabs a:hover div,
-.nav-tabs a.active div {
+.nav-link {
+  display: block;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: var(--vscode-panelTitle-inactiveForeground);
+  text-transform: uppercase;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--vscode-panelTitle-inactiveForeground);
+  }
+  &.active {
+    color: var(--vscode-panelTitle-activeForeground);
+  }
+}
+
+.nav-tabs .nav-link:hover .navigation-title,
+.nav-tabs .nav-link.active .navigation-title {
   border-color: transparent transparent var(--vscode-panelTitle-activeBorder)
     transparent;
 }
 
-.nav-tabs a div {
+.nav-tabs .nav-link .navigation-title {
   border: solid 1px;
   padding-bottom: 8px;
   border-color: transparent;
@@ -40,14 +50,17 @@ $list-group-action-active-bg: $list-group-bg;
   padding: 24px 0px 0px 0px;
 }
 
-.tab-content a {
+// Style for links inside tab/navigation content and list-groups
+.tab-content a,
+.navigation-tabcontent a {
   &:hover {
     color: var(--vscode-panelTitle-activeForeground);
   }
   color: var(--vscode-foreground);
   width: fit-content;
 
-  svg.codicon {
+  svg.codicon,
+  i.codicon {
     margin-right: 0.5em;
   }
 }
@@ -107,18 +120,47 @@ div.header {
   }
 }
 
-.list-group a {
-  margin-bottom: 12px;
-}
-
+// Override list-group colors for quick-actions section only
 div.quick-actions {
+  .list-group {
+    gap: 6px;
+  }
+
+  .list-group-item {
+    background-color: var(--vscode-sideBar-background);
+    border: none;
+    border-radius: 4px;
+    padding: 0.65rem 1rem;
+    // Override list-group-item-action color with higher specificity
+    &.list-group-item-action {
+      color: var(--vscode-descriptionForeground);
+      &:hover {
+        background-color: var(--vscode-list-hoverBackground);
+      }
+    }
+  }
+
   a {
     color: var(--vscode-descriptionForeground);
 
     span.highlight {
       color: var(--vscode-foreground);
+      font-weight: 600;
     }
   }
+}
+
+// Navigation and footer list-groups: transparent background
+.navigation-tabcontent .list-group,
+.footer .list-group {
+  background-color: transparent;
+  border-color: transparent;
+}
+
+// Spacing for plain links inside list-groups (navigation & footer only)
+.navigation-tabcontent .list-group a,
+.footer .list-group a {
+  margin-bottom: 12px;
 }
 
 div.page-content {

--- a/test-fixtures/maven-resolve-type/README.md
+++ b/test-fixtures/maven-resolve-type/README.md
@@ -1,0 +1,16 @@
+# Maven Resolve Unknown Type — Test Fixture
+
+This fixture is consumed by `test-plans/java-maven-resolve-type.yaml`.
+
+It is a minimal self-contained Maven project intentionally configured with
+JDK 11 compliance (`<release>11</release>`), so JDT runs full semantic
+analysis under the JDK 21 toolchain that the E2E workflow installs. This
+avoids the historical problem of using fixtures with `<source>1.7</source>`,
+which causes JDT to emit only syntactic warnings (e.g. "compiler
+compliance 1.7 but JRE 11 is used") and silently skip semantic
+diagnostics — making the `Gson cannot be resolved to a type` error never
+surface and breaking the `Resolve unknown type` Code Action assertion.
+
+The plan inserts `Gson gson;` into `App.java`, expects JDT to publish the
+unresolved-type diagnostic, and then exercises `vscode-maven`'s
+`Resolve unknown type` Code Action.

--- a/test-fixtures/maven-resolve-type/pom.xml
+++ b/test-fixtures/maven-resolve-type/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.example</groupId>
+	<artifactId>maven-resolve-type</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<release>11</release>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/test-fixtures/maven-resolve-type/src/main/java/com/example/App.java
+++ b/test-fixtures/maven-resolve-type/src/main/java/com/example/App.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public class App {
+    public static void main(String[] args) {
+    }
+}

--- a/test-plans/java-maven-resolve-type.yaml
+++ b/test-plans/java-maven-resolve-type.yaml
@@ -4,11 +4,14 @@
 # Verify: Type unknown type → hover shows "Resolve unknown type" → add dependency and import
 #
 # Prerequisites:
-#   - vscode-java repo cloned locally
-#   - JDK installed and available
-#   - Maven installed
+#   - JDK 11+ installed and available on PATH (the workflow installs JDK 21)
+#   - Maven installed (or the redhat.java embedded one)
 #
 # Usage: autotest run test-plans/java-maven-resolve-type.yaml
+#
+# Fixture: test-fixtures/maven-resolve-type — self-contained, owned by this
+# repo. Uses JDK 11 compliance to ensure JDT runs full semantic analysis
+# and publishes the unresolved-type diagnostic (see fixture README).
 
 name: "Maven for Java — Resolve Unknown Type"
 description: |
@@ -21,7 +24,7 @@ setup:
   extensions:
     - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
-  workspace: "../../vscode-java/test/resources/projects/maven/salut"
+  workspace: "../test-fixtures/maven-resolve-type"
   timeout: 90
 
 steps:
@@ -32,20 +35,22 @@ steps:
     timeout: 120
 
   # ── Open Java file ──────────────────────────────────────
-  - id: "open-foo"
-    action: "open file Foo.java"
-    verify: "Foo.java file is open in the editor"
+  - id: "open-app"
+    action: "open file App.java"
+    verify: "App.java file is open in the editor"
     timeout: 15
 
   # ── Type unknown type ─────────────────────────────────────────
-  # wiki: "type 'Gson gson;'" — use insertLineInFile so LS detects the change
+  # wiki: "type 'Gson gson;'" — use insertLineInFile so LS detects the change.
+  # Line 4 places the field directly inside the class body of App.java.
   - id: "insert-unknown-type"
-    action: "insertLineInFile src/main/java/java/Foo.java 10         Gson gson;"
+    action: "insertLineInFile src/main/java/com/example/App.java 4         Gson gson;"
     waitBefore: 3
 
   # ── Verify Code Action: Resolve unknown type ────────────
-  # wiki: hover shows "Resolve unknown type" → apply Code Action
-  # Wait for LS to detect the Gson error before navigating
+  # wiki: hover shows "Resolve unknown type" → apply Code Action.
+  # navigateToError polls for diagnostics up to 30s and fails clearly if
+  # the LS hasn't published the unresolved-type error yet.
   - id: "navigate-to-error"
     action: "navigateToError 1"
     waitBefore: 5

--- a/test-plans/java-pack-help-center-webview.yaml
+++ b/test-plans/java-pack-help-center-webview.yaml
@@ -1,0 +1,38 @@
+# Test Plan: Java Extension Pack - Help Center webview
+#
+# Covers the React/vscode-elements webview migration by opening the local
+# vscode-java-pack Help Center and verifying key content from inside the webview.
+#
+# Usage after packaging vscode-java-pack:
+#   npx autotest run test-plans\java-pack-help-center-webview.yaml --vsix extension.vsix --no-llm
+
+name: "Java Extension Pack - Help Center Webview"
+description: |
+  Opens the Java Help Center webview from the installed vscode-java-pack VSIX
+  and verifies that the migrated React webview renders its main sections.
+
+setup:
+  extension: "redhat.java"
+  vscodeVersion: "stable"
+  timeout: 60
+  settings:
+    java.help.showReleaseNotes: false
+    java.help.firstView: "none"
+
+steps:
+  - id: "open-help-center"
+    action: "executeVSCodeCommand java.welcome"
+    verifyEditorTab:
+      title: "Java Help Center"
+    timeout: 20
+
+  - id: "verify-help-center-content"
+    action: "wait 2 seconds"
+    verifyWebview:
+      contains:
+        - "Java Help Center"
+        - "Get Started"
+        - "Create a New Project"
+        - "Configure Java Runtime"
+        - "Open Java Settings"
+    timeout: 20

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,11 +24,12 @@
         // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
         "noUnusedParameters": true, /* Report errors on unused parameters. */
         "skipLibCheck": true,
-        "jsx": "react",
+        "jsx": "react-jsx",
+        "jsxImportSource": "react",
         /* Enabled for React */
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
-        "noImplicitThis": false /* disabled for jQuery */
+        "noImplicitThis": false
     },
     "exclude": [
         "node_modules",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = function (env, argv) {
     mode: 'none',
     entry: {
       overview: './src/overview/assets/index.ts',
+      'java-runtime': './src/java-runtime/assets/index.ts',
       'beginner-tips': './src/beginner-tips/assets/index.tsx',
       'ext-guide': './src/ext-guide/assets/index.ts',
       welcome: './src/welcome/assets/index.ts',


### PR DESCRIPTION
## Summary

Migrate all webview UIs from React 16 + react-bootstrap + deprecated `@vscode/webview-ui-toolkit` to React 19 + `@vscode-elements/elements`, with custom Bootstrap-equivalent SCSS.

## Changes

### Dependencies
- **React** 16.14.0 → 19.x with `react-jsx` transform
- **@vscode-elements/elements** v2.5.x replaces deprecated `@vscode/webview-ui-toolkit`
- **react-bootstrap** removed — replaced with native HTML + custom SCSS utilities
- **tas-client** override to `~0.2.33` for compatibility

### Build & Config
- `tsconfig.json`: `"jsx": "react-jsx"`, `"jsxImportSource": "react"`
- `webpack.config.js`: updated for React 19 compatibility
- Added `src/vscode-elements.d.ts` TypeScript declarations for web components

### Webview Migrations (all pages)
- **welcome** — class → functional components, react-bootstrap `Tabs`/`ListGroup` → native HTML
- **project-settings** — `vscode-table` web components → plain `div` layout with hover actions
- **formatter-settings**, **beginner-tips**, **install-jdk**, **java-runtime** — all migrated
- Entry points updated to React 19 `createRoot` API

### Styling
- `src/assets/vscode.scss` — comprehensive Bootstrap-equivalent utility classes (grid, list-group, card, nav, buttons, forms, tables, spacing, flex, text)
- Page-specific SCSS preserved and refined for visual parity
- Ghost button styling for icon-only action buttons (edit/delete)

## Testing
- All webview pages verified: Overview, Java Help Center, Tips for Beginners, Project Settings (Sources/JDK Runtime/Libraries/Compiler/Maven), Formatter Settings, Install JDK
- Visual parity confirmed against pre-migration rendering
- Build compiles successfully with no errors