### PR TITLE
fix(test-plans): use self-contained Maven fixture for resolve-unknown-type plan

### DIFF
--- a/test-fixtures/maven-resolve-type/README.md
+++ b/test-fixtures/maven-resolve-type/README.md
@@ -1,0 +1,16 @@
+# Maven Resolve Unknown Type — Test Fixture
+
+This fixture is consumed by `test-plans/java-maven-resolve-type.yaml`.
+
+It is a minimal self-contained Maven project intentionally configured with
+JDK 11 compliance (`<release>11</release>`), so JDT runs full semantic
+analysis under the JDK 21 toolchain that the E2E workflow installs. This
+avoids the historical problem of using fixtures with `<source>1.7</source>`,
+which causes JDT to emit only syntactic warnings (e.g. "compiler
+compliance 1.7 but JRE 11 is used") and silently skip semantic
+diagnostics — making the `Gson cannot be resolved to a type` error never
+surface and breaking the `Resolve unknown type` Code Action assertion.
+
+The plan inserts `Gson gson;` into `App.java`, expects JDT to publish the
+unresolved-type diagnostic, and then exercises `vscode-maven`'s
+`Resolve unknown type` Code Action.

--- a/test-fixtures/maven-resolve-type/pom.xml
+++ b/test-fixtures/maven-resolve-type/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.example</groupId>
+	<artifactId>maven-resolve-type</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<release>11</release>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/test-fixtures/maven-resolve-type/src/main/java/com/example/App.java
+++ b/test-fixtures/maven-resolve-type/src/main/java/com/example/App.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public class App {
+    public static void main(String[] args) {
+    }
+}

--- a/test-plans/java-maven-resolve-type.yaml
+++ b/test-plans/java-maven-resolve-type.yaml
@@ -4,11 +4,14 @@
 # Verify: Type unknown type → hover shows "Resolve unknown type" → add dependency and import
 #
 # Prerequisites:
-#   - vscode-java repo cloned locally
-#   - JDK installed and available
-#   - Maven installed
+#   - JDK 11+ installed and available on PATH (the workflow installs JDK 21)
+#   - Maven installed (or the redhat.java embedded one)
 #
 # Usage: autotest run test-plans/java-maven-resolve-type.yaml
+#
+# Fixture: test-fixtures/maven-resolve-type — self-contained, owned by this
+# repo. Uses JDK 11 compliance to ensure JDT runs full semantic analysis
+# and publishes the unresolved-type diagnostic (see fixture README).
 
 name: "Maven for Java — Resolve Unknown Type"
 description: |
@@ -21,7 +24,7 @@ setup:
   extensions:
     - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
-  workspace: "../../vscode-java/test/resources/projects/maven/salut"
+  workspace: "../test-fixtures/maven-resolve-type"
   timeout: 90
 
 steps:
@@ -32,20 +35,22 @@ steps:
     timeout: 120
 
   # ── Open Java file ──────────────────────────────────────
-  - id: "open-foo"
-    action: "open file Foo.java"
-    verify: "Foo.java file is open in the editor"
+  - id: "open-app"
+    action: "open file App.java"
+    verify: "App.java file is open in the editor"
     timeout: 15
 
   # ── Type unknown type ─────────────────────────────────────────
-  # wiki: "type 'Gson gson;'" — use insertLineInFile so LS detects the change
+  # wiki: "type 'Gson gson;'" — use insertLineInFile so LS detects the change.
+  # Line 4 places the field directly inside the class body of App.java.
   - id: "insert-unknown-type"
-    action: "insertLineInFile src/main/java/java/Foo.java 10         Gson gson;"
+    action: "insertLineInFile src/main/java/com/example/App.java 4         Gson gson;"
     waitBefore: 3
 
   # ── Verify Code Action: Resolve unknown type ────────────
-  # wiki: hover shows "Resolve unknown type" → apply Code Action
-  # Wait for LS to detect the Gson error before navigating
+  # wiki: hover shows "Resolve unknown type" → apply Code Action.
+  # navigateToError polls for diagnostics up to 30s and fails clearly if
+  # the LS hasn't published the unresolved-type error yet.
   - id: "navigate-to-error"
     action: "navigateToError 1"
     waitBefore: 5


### PR DESCRIPTION
## What & Why

The `java-maven-resolve-type` E2E plan has been failing in scheduled runs (e.g. [actions/runs/25419116469](https://github.com/microsoft/vscode-java-pack/actions/runs/25419136374)). Investigation showed:

- Old fixture: `redhat-developer/vscode-java`'s `salut` Maven project, which sets `<source>1.7</source>` / `<target>1.7</target>`.
- CI runners only install JDK 21.
- Under that mismatch JDT reports the pom compliance warnings ("compiler compliance 1.7 but JRE 11 is used") and shows `Java: Ready`, but **never publishes semantic diagnostics for `Foo.java`**. So `Gson gson;` does not produce a `Gson cannot be resolved to a type` error and `navigateToError` / `applyCodeAction "Resolve unknown type"` cannot proceed.
- Older `@vscjava/vscode-autotest` masked this with a silent-fallback in `applyCodeAction` (Enter on whatever the first action happened to be). Once that fallback was removed upstream, the plan started consistently failing on `[check-code-action] applyCodeAction "Resolve unknown type"` with `Available actions: Extract interface..., Source Actions...`.

Verified locally: bumping the pom to `<release>11</release>` makes JDT publish the unresolved-type diagnostic in ~8 s and the full plan goes from 4/6 → **6/6 passed**.

## Change

Add a small, self-contained Maven fixture under `test-fixtures/maven-resolve-type/` that targets JDK 11 explicitly, and re-point the test plan at it:

- `test-fixtures/maven-resolve-type/pom.xml` — `maven-compiler-plugin 3.8.0`, `<release>11</release>`, no extra deps.
- `test-fixtures/maven-resolve-type/src/main/java/com/example/App.java` — minimal class.
- `test-fixtures/maven-resolve-type/README.md` — explains why the fixture lives here and the JDK-compliance pitfall.
- `test-plans/java-maven-resolve-type.yaml` — `workspace` repointed; opens `App.java`; inserts `Gson gson;` at line 4 (inside the class body); rest of the steps unchanged.

## Why a local fixture rather than reusing `salut-java11`

Owning the fixture in this repo decouples this plan from upstream `vscode-java` test-resource changes and removes the implicit ordering dependency of `git clone vscode-java` finishing before this plan can run.

## Verification

Local run with `@vscjava/vscode-autotest` (with the upcoming `navigateToError` fix that fails fast instead of falling through to warnings):

```
✅ [ls-ready] waitForLanguageServer (55088ms)
✅ [open-app] open file App.java (1299ms)
✅ [insert-unknown-type] insertLineInFile ... (3974ms)
✅ [navigate-to-error] navigateToError 1 (8083ms)
✅ [check-code-action] applyCodeAction Resolve unknown type (2559ms)
✅ [save-after-resolve] saveFile (970ms)
📊 Results: 6/6 passed
```

Problems panel screenshot confirms `Gson cannot be resolved to a type Java(16777218)` is published on `App.java:4`, which is the diagnostic code the `vscode-maven` `Resolve unknown type` Code Action keys on.
