### PR TITLE
ci(e2e-autotest): add Linux and macOS to the runner matrix

### DIFF
--- a/.github/workflows/e2e-autotest.yml
+++ b/.github/workflows/e2e-autotest.yml
@@ -88,11 +88,12 @@ jobs:
     needs: [discover, build-pack]
     # build-pack is skipped on schedule/workflow_dispatch — only require it on PRs
     if: ${{ always() && needs.discover.result == 'success' && (github.event_name != 'pull_request' || needs.build-pack.result == 'success') }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
+        os: [windows-latest, ubuntu-latest]
         plan: ${{ fromJson(needs.discover.outputs.matrix) }}
 
     steps:
@@ -117,11 +118,24 @@ jobs:
           distribution: temurin
           java-version: 25-ea
 
-      - name: Create JDK 25 path
+      - name: Configure JDK 25 path for runner OS
         if: contains(matrix.plan, 'java25')
         shell: pwsh
         run: |
-          New-Item -ItemType Junction -Path "C:\Program Files\Java\jdk-25" -Target $env:JAVA_HOME
+          $planFile = "test-plans/${{ matrix.plan }}.yaml"
+          if ($IsWindows) {
+            $target = "C:\Program Files\Java\jdk-25"
+            New-Item -ItemType Junction -Path $target -Target $env:JAVA_HOME -Force | Out-Null
+            Write-Host "Created junction: $target -> $env:JAVA_HOME"
+          } else {
+            $target = "/opt/jdk-25"
+            sudo ln -sfn $env:JAVA_HOME $target
+            Write-Host "Created symlink: $target -> $env:JAVA_HOME"
+            # Linux: rewrite the Windows-style java.home setting in the plan
+            # so the language server resolves JDK 25 on this runner.
+            (Get-Content $planFile -Raw) -replace 'C:\\\\Program Files\\\\Java\\\\jdk-25', $target | Set-Content $planFile
+            Write-Host "Patched $planFile java.jdt.ls.java.home -> $target"
+          }
 
       - name: Setup Java 21
         uses: actions/setup-java@v4
@@ -131,6 +145,17 @@ jobs:
 
       - name: Install autotest CLI
         run: npm install -g @vscjava/vscode-autotest
+
+      - name: Setup virtual display (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          Xvfb :99 -screen 0 1920x1080x24 &
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+          # Give Xvfb a moment to start before the autotest CLI launches VS Code.
+          sleep 2
 
       - name: Download PR VSIX (vscode-java-pack from branch)
         if: ${{ github.event_name == 'pull_request' }}
@@ -217,7 +242,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: results-${{ matrix.plan }}
+          name: results-${{ matrix.plan }}-${{ matrix.os }}
           path: test-results/
           retention-days: 30
 
@@ -246,10 +271,13 @@ jobs:
       - name: Organize results
         run: |
           mkdir -p test-results
+          # Each artifact is named results-<plan>-<os>; keep that suffix so
+          # Windows and Linux runs of the same plan don't collide.
           for dir in all-results/results-*/; do
+            artifact=$(basename "$dir")          # results-<plan>-<os>
+            suffix="${artifact#results-}"        # <plan>-<os>
             find "$dir" -name "results.json" -exec dirname {} \; | while read d; do
-              name=$(basename "$d")
-              cp -r "$d" "test-results/$name"
+              cp -r "$d" "test-results/$suffix"
             done
           done
           echo "Organized results:"

--- a/.github/workflows/e2e-autotest.yml
+++ b/.github/workflows/e2e-autotest.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         plan: ${{ fromJson(needs.discover.outputs.matrix) }}
 
     steps:
@@ -128,11 +128,13 @@ jobs:
             New-Item -ItemType Junction -Path $target -Target $env:JAVA_HOME -Force | Out-Null
             Write-Host "Created junction: $target -> $env:JAVA_HOME"
           } else {
+            # Linux and macOS: symlink JAVA_HOME to a known location and
+            # rewrite the Windows-style java.jdt.ls.java.home in the plan
+            # so the language server resolves JDK 25 on this runner.
             $target = "/opt/jdk-25"
+            sudo mkdir -p /opt
             sudo ln -sfn $env:JAVA_HOME $target
             Write-Host "Created symlink: $target -> $env:JAVA_HOME"
-            # Linux: rewrite the Windows-style java.home setting in the plan
-            # so the language server resolves JDK 25 on this runner.
             (Get-Content $planFile -Raw) -replace 'C:\\\\Program Files\\\\Java\\\\jdk-25', $target | Set-Content $planFile
             Write-Host "Patched $planFile java.jdt.ls.java.home -> $target"
           }


### PR DESCRIPTION
Add Linux and macOS to the e2e-autotest matrix so every PR / schedule run exercises every plan on Windows, Linux, and macOS. The autotest framework was already cross-platform; the workflow just hadn't wired the matrix axis through.

## Why

The job is currently pinned to `runs-on: windows-latest`, even though:
- the autotest CLI ([@vscjava/vscode-autotest](https://www.npmjs.com/package/@vscjava/vscode-autotest)) supports Windows / Linux / macOS,
- this workflow already maps `runner.os` to `win32 / linux / darwin` for VSIX resolution (see the `$platformMap` block).

Coverage on Linux and macOS catches a class of Java-extension regressions (file casing, classpath separator, terminal shell, JDK detection on non-Windows paths, AppKit / GTK keyboard focus differences) that Windows-only CI cannot see.

## Changes

| Area | Before | After |
| --- | --- | --- |
| `runs-on` | hard-coded `windows-latest` | `${{ matrix.os }}` |
| `matrix` | `plan` only | `os: [windows-latest, ubuntu-latest, macos-latest]` × `plan` |
| JDK 25 step | Windows `New-Item Junction` only | cross-platform pwsh: junction on Windows, `ln -sfn` to `/opt/jdk-25` on Linux / macOS, plus an in-place rewrite of the Windows-style `java.jdt.ls.java.home` in the java25 plan yaml |
| Linux display | n/a | new `Setup virtual display (Linux)` step (`xvfb` + `DISPLAY=:99`), gated on `runner.os == 'Linux'`; macOS has a real display so no step is needed |
| Artifact name | `results-<plan>` | `results-<plan>-<os>` so per-OS results of the same plan don't collide |
| `analyze` aggregator | flattened to plan name | preserves the `<plan>-<os>` suffix so cross-platform results stay distinct |

## Validation plan

1. Opening this PR triggers the `windows-latest`, `ubuntu-latest`, and `macos-latest` matrix legs for the 17 plans.
2. If a per-OS leg surfaces a plan-level issue (e.g. a hard-coded Windows path inside a plan yaml), it's fixed in the plan in a follow-up — the framework-level cross-platform support is already in place.
3. After the first green run, the existing daily schedule (`cron: '0 5 * * 1-5'`) starts producing cross-platform coverage automatically — no further workflow change needed.

## Notes

- Run count grows from 17 to 51 per trigger (17 plans × 3 OSes). Wall-clock impact is minimal because the matrix is fully parallel; matrix concurrency on the repo's runner pool is the only limit. macOS runners are billed at a 10× multiplier, but the existing trigger gating (PR + weekday schedule, not push) keeps the total within budget.
- `--no-sandbox` is already passed to the VS Code launch args by the autotest framework, which is required for Electron on GitHub-hosted Linux runners.
- `actions/setup-java@v4` already handles JDK install on all three OSes; only the JDK 25 path-fixup step needed platform branching.
- PowerShell Core is preinstalled on `macos-latest` and `ubuntu-latest`, so the `shell: pwsh` steps run identically across the matrix.
