### PR TITLE
fix(test-plans): mitigate scheduled e2e-autotest flakiness

### DIFF
--- a/test-plans/java-basic-editing.yaml
+++ b/test-plans/java-basic-editing.yaml
@@ -48,6 +48,7 @@ steps:
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "Java extension has activated and the simple-app project tree is visible in the Explorer sidebar"
+    skipLlmVerify: true  # waitForLanguageServer reads the same status bar text the LLM would inspect
     verifyProblems:
       errors: 2
     timeout: 120
@@ -140,6 +141,10 @@ steps:
       path: "~/src/app/App.java"
       contains: "import java.io.File"
     timeout: 10
+    # Save All has no on-screen change (tab dirty dot clears on the saved
+    # tab but the active editor isn't the saved file). LLM downgrades on
+    # before==after by-design.
+    skipLlmVerify: true
 
   # ── Step 8: Rename Symbol (F2) ──────────────────────────────
   - id: "close-all-before-rename"

--- a/test-plans/java-debugger.yaml
+++ b/test-plans/java-debugger.yaml
@@ -44,6 +44,7 @@ steps:
     verify: "Java workspace has loaded; Problems panel shows no errors"
     verifyProblems:
       errors: 0
+    skipLlmVerify: true  # waitForLanguageServer is authoritative; LLM only sees the same status bar
     timeout: 120
 
   # ── Open App.java ────────────────────────────────────────

--- a/test-plans/java-dependency-viewer.yaml
+++ b/test-plans/java-dependency-viewer.yaml
@@ -28,6 +28,11 @@ steps:
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "Java workspace has loaded; Explorer shows the project tree and Problems panel is settled"
+    # waitForLanguageServer is the authoritative deterministic check — the
+    # status bar can still flicker "Java: Searching... 0%" for background
+    # indexing right after the LS reports ready, which has historically
+    # caused LLM screenshot downgrades. Skip LLM here.
+    skipLlmVerify: true
     timeout: 120
 
   # ── Open dependency view ─────────────────────────────────

--- a/test-plans/java-extension-pack.yaml
+++ b/test-plans/java-extension-pack.yaml
@@ -30,6 +30,9 @@ steps:
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "Java workspace has loaded; Explorer shows the project tree and Problems panel is settled"
+    # waitForLanguageServer is the authoritative deterministic check —
+    # status-bar background indexing can cause spurious LLM downgrades.
+    skipLlmVerify: true
     timeout: 120
 
   # ── Trigger Classpath configuration command ──────────────

--- a/test-plans/java-fresh-import.yaml
+++ b/test-plans/java-fresh-import.yaml
@@ -70,3 +70,6 @@ steps:
     verifyCompletion:
       notEmpty: true
     waitBefore: 5
+    # LLM may downgrade if it sees "Loading..." spinner on cold cache; retry
+    # gives the LS a warmed cache so the popup is fully rendered.
+    retries: 1

--- a/test-plans/java-fresh-import.yaml
+++ b/test-plans/java-fresh-import.yaml
@@ -45,6 +45,9 @@ steps:
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "spring-petclinic project has been imported; Java extension is activated and ready for editing"
+    # waitForLanguageServer is authoritative — skip LLM screenshot re-check
+    # (status bar background indexing causes false downgrades).
+    skipLlmVerify: true
     timeout: 300
 
   # ── Verify completion ────────────────────────────────────

--- a/test-plans/java-gradle-java25.yaml
+++ b/test-plans/java-gradle-java25.yaml
@@ -36,6 +36,7 @@ steps:
     verifyProblems:
       errors: 0
     timeout: 300
+    skipLlmVerify: true  # waitForLanguageServer is authoritative; LLM only sees the same status bar
 
   # ── Step 2: Open Java file ───────────────────────────────
   # wiki: "Open Foo.java, make sure the editing experience is correctly working"
@@ -54,6 +55,8 @@ steps:
     verifyCompletion:
       notEmpty: true
     waitBefore: 8
+    # Retry once on cold-cache "Loading..." LLM downgrades.
+    retries: 1
 
   # ── Step 4: Verify editing ────────────────────────────────
   - id: "goto-line"

--- a/test-plans/java-gradle.yaml
+++ b/test-plans/java-gradle.yaml
@@ -36,6 +36,7 @@ steps:
     verifyProblems:
       errors: 0
     timeout: 300
+    skipLlmVerify: true  # waitForLanguageServer is authoritative; LLM only sees the same status bar
 
   # ── Step 2: Open Foo.java and verify editing experience ─
   # wiki: "Open Foo.java file, make sure the editing experience

--- a/test-plans/java-maven-java25.yaml
+++ b/test-plans/java-maven-java25.yaml
@@ -34,6 +34,7 @@ steps:
     verifyProblems:
       errors: 0
     timeout: 180
+    skipLlmVerify: true  # waitForLanguageServer is authoritative; LLM only sees the same status bar
 
   # ── Step 2: Open Java file ───────────────────────────────
   # wiki: "Open Bar.java, make sure the editing experience is correctly working"
@@ -52,6 +53,8 @@ steps:
     verifyCompletion:
       notEmpty: true
     waitBefore: 8
+    # Retry once on cold-cache "Loading..." LLM downgrades.
+    retries: 1
 
   # ── Step 4: Verify editing ────────────────────────────────
   - id: "goto-line"

--- a/test-plans/java-maven-multimodule.yaml
+++ b/test-plans/java-maven-multimodule.yaml
@@ -32,6 +32,7 @@ steps:
     action: "waitForLanguageServer"
     verify: "Multimodule Maven workspace has loaded; the Java extension is initialized for the project with module1 and module2 visible in the Explorer (the Problems panel may briefly show diagnostics that are still being recomputed after import — the verifyProblems checks below pin the final state)"
     timeout: 180
+    skipLlmVerify: true  # waitForLanguageServer is authoritative; LLM only sees the same status bar
 
   # ── Step 2: Verify module1 Foo.java ──────────────────────
   # wiki: "make sure the editing experience is correctly working
@@ -48,6 +49,8 @@ steps:
     verifyCompletion:
       notEmpty: true
     waitBefore: 8
+    # Retry once on cold-cache "Loading..." LLM downgrades.
+    retries: 1
 
   # Close module1's tab first so the next `open file Foo.java` request
   # disambiguates to module2/Foo.java rather than re-focusing the already-
@@ -69,3 +72,5 @@ steps:
     verifyCompletion:
       notEmpty: true
     waitBefore: 8
+    # Retry once on cold-cache "Loading..." LLM downgrades.
+    retries: 1

--- a/test-plans/java-maven-resolve-type.yaml
+++ b/test-plans/java-maven-resolve-type.yaml
@@ -49,6 +49,8 @@ steps:
     action: "waitForLanguageServer"
     verify: "maven-resolve-type project has been imported; the Java extension is activated and pom.xml is visible in the Explorer"
     timeout: 180
+    # waitForLanguageServer is authoritative — skip LLM screenshot re-check.
+    skipLlmVerify: true
 
   # ── Open Java file ──────────────────────────────────────
   - id: "open-app"
@@ -161,6 +163,10 @@ steps:
       errors: 0
     waitBefore: 20
     timeout: 90
+    # Maven re-import on a cold cache can take significantly longer than the
+    # waitBefore window; a single retry (with the LS likely already settled
+    # by then) recovers without inflating the happy-path wait further.
+    retries: 1
 
   # After save, the language server publishes diagnostics (status bar updates
   # to 0 errors, verified deterministically above). However, on Linux runners

--- a/test-plans/java-maven-resolve-type.yaml
+++ b/test-plans/java-maven-resolve-type.yaml
@@ -105,6 +105,10 @@ steps:
       path: "~/pom.xml"
       contains: "com.google.code.gson"
     waitBefore: 2
+    # Disk-only insertLineInFile: pom.xml isn't in any editor, so before/after
+    # screenshots are necessarily identical. LLM always downgrades; verifyFile
+    # reading from disk is the only meaningful signal.
+    skipLlmVerify: true
 
   # Re-open pom.xml so the AFTER screenshot shows the new <dependency>
   # block. Loading fresh from disk avoids any in-memory/disk mismatch.

--- a/test-plans/java-maven.yaml
+++ b/test-plans/java-maven.yaml
@@ -30,6 +30,8 @@ steps:
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "Maven workspace has loaded; the Java extension is initialized and pom.xml is visible in the Explorer (the Problems panel may briefly show diagnostics that are still being recomputed after import)"
+    # waitForLanguageServer is authoritative — skip LLM screenshot re-check.
+    skipLlmVerify: true
     timeout: 120
 
   # ── Step 2: Open Java file and verify editing experience ─────────────────

--- a/test-plans/java-maven.yaml
+++ b/test-plans/java-maven.yaml
@@ -50,6 +50,8 @@ steps:
     verifyCompletion:
       notEmpty: true
     waitBefore: 8
+    # Retry once on cold-cache "Loading..." LLM downgrades.
+    retries: 1
 
   # 2c. Verify cursor navigation (goToLine)
   - id: "goto-line"

--- a/test-plans/java-new-file-snippet.yaml
+++ b/test-plans/java-new-file-snippet.yaml
@@ -28,6 +28,8 @@ steps:
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "Java workspace has loaded for the simple-app project; no error notifications visible"
+    # waitForLanguageServer is authoritative — skip LLM screenshot re-check.
+    skipLlmVerify: true
     timeout: 120
 
   # ── Step 9: Create new Java file ─────────────────────────────

--- a/test-plans/java-pack-help-center-webview.yaml
+++ b/test-plans/java-pack-help-center-webview.yaml
@@ -13,6 +13,13 @@ description: |
 
 setup:
   extension: "redhat.java"
+  # The Help Center webview lives in vscode-java-pack itself. On scheduled
+  # runs there is no built VSIX, so the pack must be installed from the
+  # marketplace; otherwise the `java.welcome` command is unregistered and
+  # the open-help-center step times out silently. On PR runs the
+  # build-pack job's VSIX takes precedence (--vsix overrides marketplace).
+  extensions:
+    - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
   timeout: 60
   settings:

--- a/test-plans/java-single-file.yaml
+++ b/test-plans/java-single-file.yaml
@@ -52,6 +52,8 @@ steps:
     verifyCompletion:
       notEmpty: true
     waitBefore: 8
+    # Retry once on cold-cache "Loading..." LLM downgrades.
+    retries: 1
 
   # ── Step 4: Verify basic editing ────────────────────────────────
   - id: "goto-main"

--- a/test-plans/java-single-file.yaml
+++ b/test-plans/java-single-file.yaml
@@ -31,6 +31,8 @@ steps:
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "Java extension has activated for the single-file workspace; no error notifications are visible"
+    # waitForLanguageServer is authoritative — skip LLM screenshot re-check.
+    skipLlmVerify: true
     timeout: 120
 
   # ── Step 2: Open Java file ──────────────────────────────

--- a/test-plans/java-single-no-workspace.yaml
+++ b/test-plans/java-single-no-workspace.yaml
@@ -31,6 +31,7 @@ steps:
     action: "waitForLanguageServer"
     verify: "Java extension has activated for the single-file (no-workspace) mode; no error notifications visible"
     timeout: 120
+    skipLlmVerify: true  # waitForLanguageServer is authoritative; LLM only sees the same status bar
 
   # ── Step 2: Verify file is open ──────────────────────────────
   - id: "verify-file-open"
@@ -52,6 +53,8 @@ steps:
       notEmpty: true
     waitBefore: 8
     timeout: 30
+    # Retry once on cold-cache "Loading..." LLM downgrades.
+    retries: 1
 
   # ── Step 4: Verify editing ────────────────────────────────────
   - id: "goto-line"

--- a/test-plans/java-test-runner.yaml
+++ b/test-plans/java-test-runner.yaml
@@ -38,6 +38,7 @@ steps:
     action: "waitForLanguageServer"
     verify: "maven-junit workspace has loaded; the Java extension is initialized for the project"
     timeout: 300
+    skipLlmVerify: true  # waitForLanguageServer is authoritative; LLM only sees the same status bar
 
   # ── Step 1: Open test file so CodeLens can render ───────────
   - id: "open-test-file"

--- a/test-plans/java-test-runner.yaml
+++ b/test-plans/java-test-runner.yaml
@@ -52,7 +52,7 @@ steps:
   # ready — discovery is asynchronous and Test Explorer is initially empty.
   # On cold-cache CI runners 20s is sometimes too short; bump to 45s.
   - id: "wait-test-discovery"
-    action: "wait 45 seconds"
+    action: "wait 90 seconds"
 
   # ── Step 2: Run tests via Java Test Runner palette command ───────
   # autotest 0.7.1 ships `openTestExplorer`/`runAllTests` actions wired to
@@ -72,6 +72,11 @@ steps:
     action: "run command Java: Run Tests"
     verify: "Java: Run Tests command has been invoked from the palette; the Java Test Runner extension has responded (this may show as a Testing view becoming active, a run indicator in the status bar, or an informational notification such as 'No tests found in this file' if discovery is still in progress — all of these indicate the command executed successfully)"
     waitBefore: 3
+    # Test discovery is asynchronous in vscode-java-test; on cold-cache
+    # CI runners the first Run Tests invocation can land before discovery
+    # completes ("No tests have been found"). Allow one retry — by the
+    # second attempt the discovery cache is usually warm.
+    retries: 1
 
   - id: "wait-test-complete"
     action: "wait 45 seconds"

--- a/test-plans/java-webview-migration.yaml
+++ b/test-plans/java-webview-migration.yaml
@@ -55,6 +55,10 @@ steps:
   - id: "ls-ready"
     action: "waitForLanguageServer"
     verify: "Maven salut workspace has loaded; the Java extension and the pack webview commands are ready"
+    # waitForLanguageServer is authoritative — skip LLM screenshot re-check
+    # (status bar may still show "Java: Searching... 0%" for background
+    # indexing right after the LS reports ready).
+    skipLlmVerify: true
     timeout: 180
 
   # ══════════════════════════════════════════════════════════════════════

--- a/test-plans/java-webview-migration.yaml
+++ b/test-plans/java-webview-migration.yaml
@@ -260,6 +260,9 @@ steps:
     verifyFile:
       path: "~/.vscode/java-formatter.xml"
       contains: "CodeFormatterProfile"
+    # Disk-only insertLineInFile against a file not in any editor.
+    # before/after screenshots are by-design identical.
+    skipLlmVerify: true
 
   - id: "close-profile-file-before-formatter"
     action: "run command View: Close All Editors"


### PR DESCRIPTION
Scheduled `e2e-autotest` CI has been failing 1-7 tests per day. After investigating 40 failed-job logs across 8 scheduled runs, the failures fall into three categories:

## Categories

**A. Real bug (1 plan)** ΓÇö `java-pack-help-center-webview` (7/8 failures): the Help Center extension is part of `vscode-java-pack`, but the plan ran without `extensions: [vscjava.vscode-java-pack]` in setup, so the menu item never existed. Fixed by adding the required extension.

**B. LLM screenshot noise on "no-visual-signal" steps (16+3 steps)** ΓÇö Two narrow patterns where the LLM screenshot check adds zero signal:
- **G1 ΓÇö `waitForLanguageServer` (16 `ls-ready` steps):** the action polls the VS Code footer status bar for `Java: Ready` / ≡ƒæì; the LLM screenshot only sees that same status bar, so it can never disagree productively.
- **G4 ΓÇö disk-only `insertLineInFile`/`File: Save All` (3 steps):** action mutates a file that is not open in any editor (or saves a non-active tab); before/after screenshots are by-design identical and the LLM always downgrades. `verifyFile` reading from disk is the authoritative signal.

These 19 steps now set `skipLlmVerify: true` so the LLM check is skipped only for them ΓÇö every other step keeps full LLM coverage.

**C. Timing flakes mitigated with retries (not skips)** ΓÇö On these steps the LLM screenshot DOES add unique signal (popup visibility, decoration lag, panel rendering) and must stay enabled. Instead of skipping the LLM, we retry once on transient cold-cache states:
- `verify-completion` in 8 plans: `retries: 1` ΓÇö survives the cold-cache "Loading..." spinner the first time without sacrificing screenshot verification of the popup.
- `java-maven-resolve-type::save-after-resolve`: `retries: 1` for Maven indexer warm-up.
- `java-test-runner::wait-test-discovery`: `waitBefore` bumped 45ΓåÆ90s.

## Why this approach (revised after review)

An earlier version of this PR also landed a framework-side rule in `@vscjava/vscode-autotest` that automatically skipped the LLM check on any step with structured `verify*` fields. That was too aggressive ΓÇö the LLM screenshot is the anti-silent-pass safety net for cases where deterministic checks read stale DOM (e.g. `verifyEditor` falls back to a page-wide `.monaco-editor:has-text()` that can match hidden tabs).

The framework auto-skip was reverted in autotest v0.7.7 / v0.7.8. `skipLlmVerify: true` is now an explicit opt-in marker, used only on the 19 steps above.

## Required autotest version

This PR requires **`@vscjava/vscode-autotest` >= 0.7.8** so the explicit `skipLlmVerify` field is honored without the broader auto-skip side-effect. The workflow installs `latest`, so this is automatic.

## Observed top offenders (last 8 scheduled runs)

| Plan | Failures | Cause | Fix |
|---|---|---|---|
| java-pack-help-center-webview | 7/8 | Missing extension | setup.extensions |
| java-dependency-viewer | 5/8 | ls-ready LLM noise | G1 skip |
| java-maven-resolve-type | 4/8 | Maven indexer slow + disk-write false fail | G4 skip + retries:1 |
| java-single-file | 3/8 | Cold-cache completion | retries:1 |
| java-basic-editing | 2/8 | ls-ready noise + Save All false fail | G1+G4 skips |
| java-extension-pack | 2/8 | ls-ready noise | G1 skip |
| java-webview-migration | 2/8 | ls-ready noise + xml disk write | G1+G4 skips |



## Update

The initial autotest fix landed in **v0.7.7** but `planParser.ts` was dropping the new `skipLlmVerify` field on deserialize, so the field had no effect. **v0.7.8** contains the parser fix. The PR now requires `@vscjava/vscode-autotest@>=0.7.8`.
