### PR TITLE
fix: Project Settings UI update the absolute path

### DIFF
--- a/src/project-settings/assets/classpath/features/components/Libraries.tsx
+++ b/src/project-settings/assets/classpath/features/components/Libraries.tsx
@@ -11,11 +11,12 @@ import { removeReferencedLibrary, addLibraries } from "../classpathConfiguration
 import { ClasspathRequest } from "../../../vscode/utils";
 
 import { ClasspathEntry, ClasspathEntryKind } from "../../../../types";
-import { ProjectType } from "../../../../../utils/webview";
+import { isProjectType } from "../../../../../utils/webview";
 
 const Libraries = (): JSX.Element => {
 
   const [hoveredRow, setHoveredRow] = useState<string | null>(null);
+  const addLibraryBtnRef = useRef<HTMLElement>(null);
   const activeProjectIndex: number = useSelector((state: any) => state.commonConfig.ui.activeProjectIndex);
   const activeProjectIndexRef = useRef(activeProjectIndex);
   useEffect(() => {
@@ -23,7 +24,8 @@ const Libraries = (): JSX.Element => {
   }, [activeProjectIndex]);
 
   const libraries: ClasspathEntry[] = useSelector((state: any) => state.classpathConfig.data.libraries[activeProjectIndex]);
-  const projectType: ProjectType = useSelector((state: any) => state.commonConfig.data.projectType[activeProjectIndex]);
+  const projectType: unknown = useSelector((state: any) => state.commonConfig.data.projectType[activeProjectIndex]);
+  const canAddLibrary = isProjectType(projectType);
   const dispatch: Dispatch<any> = useDispatch();
 
   const handleRemove = (index: number) => {
@@ -34,8 +36,21 @@ const Libraries = (): JSX.Element => {
   };
 
   const handleAdd = () => {
+    if (!canAddLibrary) {
+      return;
+    }
     ClasspathRequest.onWillSelectLibraries(projectType);
   };
+
+  useEffect(() => {
+    const el = addLibraryBtnRef.current;
+    if (!el) return;
+    if (canAddLibrary) {
+      el.removeAttribute("disabled");
+    } else {
+      el.setAttribute("disabled", "");
+    }
+  }, [canAddLibrary]);
 
   const onDidAddLibraries = (event: OnDidAddLibrariesEvent) => {
     const {data} = event;
@@ -112,7 +127,7 @@ const Libraries = (): JSX.Element => {
     <div className="setting-section">
       <div>
         <div id="list-actions" className="flex-center setting-list-actions">
-          <vscode-button class="ghost-button" onClick={() => handleAdd()}>
+          <vscode-button ref={addLibraryBtnRef} class="ghost-button" onClick={() => handleAdd()}>
             <span className="codicon codicon-add mr-1"></span>
             Add Library...
           </vscode-button>

--- a/src/project-settings/assets/classpath/features/components/Libraries.tsx
+++ b/src/project-settings/assets/classpath/features/components/Libraries.tsx
@@ -11,6 +11,7 @@ import { removeReferencedLibrary, addLibraries } from "../classpathConfiguration
 import { ClasspathRequest } from "../../../vscode/utils";
 
 import { ClasspathEntry, ClasspathEntryKind } from "../../../../types";
+import { ProjectType } from "../../../../../utils/webview";
 
 const Libraries = (): JSX.Element => {
 
@@ -22,6 +23,7 @@ const Libraries = (): JSX.Element => {
   }, [activeProjectIndex]);
 
   const libraries: ClasspathEntry[] = useSelector((state: any) => state.classpathConfig.data.libraries[activeProjectIndex]);
+  const projectType: ProjectType = useSelector((state: any) => state.commonConfig.data.projectType[activeProjectIndex]);
   const dispatch: Dispatch<any> = useDispatch();
 
   const handleRemove = (index: number) => {
@@ -32,7 +34,7 @@ const Libraries = (): JSX.Element => {
   };
 
   const handleAdd = () => {
-    ClasspathRequest.onWillSelectLibraries();
+    ClasspathRequest.onWillSelectLibraries(projectType);
   };
 
   const onDidAddLibraries = (event: OnDidAddLibrariesEvent) => {

--- a/src/project-settings/assets/vscode/utils.ts
+++ b/src/project-settings/assets/vscode/utils.ts
@@ -81,9 +81,10 @@ export namespace ClasspathRequest {
         });
     }
 
-    export function onWillSelectLibraries() {
+    export function onWillSelectLibraries(projectType: ProjectType) {
         vscode.postMessage({
-            command: "classpath.onWillSelectLibraries"
+            command: "classpath.onWillSelectLibraries",
+            projectType,
         });
     }
 

--- a/src/project-settings/handlers/ClasspathRequestHandler.ts
+++ b/src/project-settings/handlers/ClasspathRequestHandler.ts
@@ -8,7 +8,7 @@ import { ClasspathComponent, VmInstall, ClasspathEntry, ClasspathEntryKind } fro
 import _ from "lodash";
 import { instrumentOperation, sendError, sendInfo, setUserError } from "vscode-extension-telemetry-wrapper";
 import { getProjectType } from "../../utils/jdt";
-import { ProjectType } from "../../utils/webview";
+import { ProjectType, isProjectType } from "../../utils/webview";
 
 export class ClasspathRequestHandler implements vscode.Disposable {
     private webview: vscode.Webview;
@@ -362,7 +362,7 @@ export class ClasspathRequestHandler implements vscode.Disposable {
         }
     });
 
-    private selectLibraries = instrumentOperation("projectSettings.classpath.selectLibraries", async (_operationId: string, currentProjectRoot: vscode.Uri, projectType: ProjectType) => {
+    private selectLibraries = instrumentOperation("projectSettings.classpath.selectLibraries", async (_operationId: string, currentProjectRoot: vscode.Uri, projectType: unknown) => {
         const jarFiles: vscode.Uri[] | undefined = await vscode.window.showOpenDialog({
             defaultUri: vscode.workspace.workspaceFolders?.[0].uri,
             openLabel: "Select Jar File",
@@ -386,8 +386,8 @@ export class ClasspathRequestHandler implements vscode.Disposable {
         }
     });
 
-    private toLibraryPathForProject(uri: vscode.Uri, currentProjectRoot: vscode.Uri, projectType: ProjectType): string {
-        if (projectType !== ProjectType.UnmanagedFolder) {
+    private toLibraryPathForProject(uri: vscode.Uri, currentProjectRoot: vscode.Uri, projectType: unknown): string {
+        if (isProjectType(projectType) && projectType !== ProjectType.UnmanagedFolder) {
             return uri.fsPath;
         }
 

--- a/src/project-settings/handlers/ClasspathRequestHandler.ts
+++ b/src/project-settings/handlers/ClasspathRequestHandler.ts
@@ -58,7 +58,7 @@ export class ClasspathRequestHandler implements vscode.Disposable {
                 await this.addNewJdk(this.currentProjectRoot);
                 break;
             case "classpath.onWillSelectLibraries":
-                await this.selectLibraries(this.currentProjectRoot);
+                await this.selectLibraries(this.currentProjectRoot, message.projectType);
                 break;
             case "classpath.onClickGotoProjectConfiguration":
                 this.gotoProjectConfigurationFile(message.rootUri, message.projectType);
@@ -197,7 +197,7 @@ export class ClasspathRequestHandler implements vscode.Disposable {
                         path: `org.eclipse.jdt.launching.JRE_CONTAINER/${vmInstallPath}`,
                     });
                 }
-                classpathEntries.push(...libraries);
+                classpathEntries.push(...libraries.map(library => this.toClasspathEntryForUpdate(library, currentProjectRoot)));
                 if (classpathEntries.length > 0) {
                     await vscode.commands.executeCommand(
                         "java.execute.workspaceCommand",
@@ -362,7 +362,7 @@ export class ClasspathRequestHandler implements vscode.Disposable {
         }
     });
 
-    private selectLibraries = instrumentOperation("projectSettings.classpath.selectLibraries", async (_operationId: string, currentProjectRoot: vscode.Uri) => {
+    private selectLibraries = instrumentOperation("projectSettings.classpath.selectLibraries", async (_operationId: string, currentProjectRoot: vscode.Uri, projectType: ProjectType) => {
         const jarFiles: vscode.Uri[] | undefined = await vscode.window.showOpenDialog({
             defaultUri: vscode.workspace.workspaceFolders?.[0].uri,
             openLabel: "Select Jar File",
@@ -374,23 +374,41 @@ export class ClasspathRequestHandler implements vscode.Disposable {
             },
         });
         if (jarFiles) {
-            const jarPaths: string[] = jarFiles.map(uri => {
-                if (uri.fsPath.startsWith(currentProjectRoot.fsPath)) {
-                    return path.relative(currentProjectRoot.fsPath, uri.fsPath);
-                }
-                return uri.fsPath;
-            });
             this.webview.postMessage({
                 command: "classpath.onDidAddLibraries",
-                jars: jarPaths.map(jarPath => {
+                jars: jarFiles.map(uri => {
                     return {
                         kind: ClasspathEntryKind.Library,
-                        path: jarPath,
+                        path: this.toLibraryPathForProject(uri, currentProjectRoot, projectType),
                     };
                 }),
             });
         }
     });
+
+    private toLibraryPathForProject(uri: vscode.Uri, currentProjectRoot: vscode.Uri, projectType: ProjectType): string {
+        if (projectType !== ProjectType.UnmanagedFolder) {
+            return uri.fsPath;
+        }
+
+        const relativePath = path.relative(currentProjectRoot.fsPath, uri.fsPath);
+        if (relativePath && relativePath !== ".." && !relativePath.startsWith(".." + path.sep) && !path.isAbsolute(relativePath)) {
+            return relativePath;
+        }
+
+        return uri.fsPath;
+    }
+
+    private toClasspathEntryForUpdate(entry: ClasspathEntry, currentProjectRoot: vscode.Uri): ClasspathEntry {
+        if (entry.kind === ClasspathEntryKind.Library && !path.isAbsolute(entry.path)) {
+            return {
+                ...entry,
+                path: path.join(currentProjectRoot.fsPath, entry.path),
+            };
+        }
+
+        return entry;
+    }
 
     private updateUnmanagedFolderLibraries = instrumentOperation("projectSettings.classpath.updateUnmanagedFolderLibraries", async (_operationId: string, jarFilePaths: string[]) => {
         const setting = this.getReferencedLibrariesSetting();

--- a/src/utils/webview.ts
+++ b/src/utils/webview.ts
@@ -54,6 +54,14 @@ export enum ProjectType {
   Others = "Others",
 }
 
+export function isProjectType(projectType: unknown): projectType is ProjectType {
+  return projectType === ProjectType.Default ||
+    projectType === ProjectType.UnmanagedFolder ||
+    projectType === ProjectType.Maven ||
+    projectType === ProjectType.Gradle ||
+    projectType === ProjectType.Others;
+}
+
 export enum NatureId {
   Maven = "org.eclipse.m2e.core.maven2Nature",
   Gradle = "org.eclipse.buildship.core.gradleprojectnature",

--- a/test-plans/java-extension-pack.yaml
+++ b/test-plans/java-extension-pack.yaml
@@ -1,10 +1,8 @@
 # Test Plan: Java Extension Pack — Classpath Configuration (from vscode-java-pack.wiki)
 #
 # Source: wiki Test-Plan.md "Java Extension Pack" scenario
-# Verify: Trigger Java: Configure Classpath command → configuration page appears
-#
-# Note: Classpath configuration uses a webview; the current framework has limited support
-#       for webview internal interactions — only verifies the command can be triggered and the page appears.
+# Verify: Trigger Java: Configure Classpath command → configuration page appears;
+#         add a project-local JAR to a non-unmanaged project and apply it.
 #
 # Prerequisites:
 #   - vscode-java repo is cloned locally
@@ -15,14 +13,15 @@
 name: "Java Extension Pack — Classpath Configuration"
 description: |
   Corresponds to the Java Extension Pack scenario in the wiki Test Plan:
-  Trigger the Java: Configure Classpath command and verify the configuration page appears.
+  Trigger the Java: Configure Classpath command, verify the configuration page
+  appears, and cover the non-unmanaged-project Add Library flow.
 
 setup:
   extension: "redhat.java"
   extensions:
     - "vscjava.vscode-java-pack"
   vscodeVersion: "stable"
-  workspace: "../../vscode-java/test/resources/projects/maven/salut"
+  workspace: "../../vscode-java/test/resources/projects/eclipse/simple-app"
   timeout: 90
 
 steps:
@@ -34,6 +33,14 @@ steps:
     # status-bar background indexing can cause spurious LLM downgrades.
     skipLlmVerify: true
     timeout: 120
+
+  - id: "create-project-local-jar"
+    action: "insertLineInFile lib/autotest-lib.jar 1 autotest placeholder jar"
+    verify: "A project-local JAR placeholder exists for the mocked Add Library file picker"
+    verifyFile:
+      path: "~/lib/autotest-lib.jar"
+      exists: true
+    skipLlmVerify: true
 
   # ── Trigger Classpath configuration command ──────────────
   # wiki: "Trigger the command 'Java: Configure Classpath'"
@@ -47,3 +54,35 @@ steps:
   - id: "verify-page"
     action: "wait 5 seconds"
     verify: "Project Settings webview displays the Classpath Configuration UI (sections such as JDK, libraries, sources)"
+    verifyWebview:
+      contains:
+        - "Classpath"
+        - "Libraries"
+
+  - id: "open-libraries-tab"
+    action: "clickInWebview text=Libraries"
+    verify: "The Libraries tab is selected and shows library management actions"
+    verifyWebview:
+      contains: "Add Library..."
+
+  - id: "add-project-local-library"
+    action: "clickInWebview text=Add Library..."
+    verify: "The file picker opens for selecting a JAR"
+
+  - id: "select-project-local-library"
+    action: "fillQuickInput ${workspaceFolder}/lib/autotest-lib.jar"
+    verify: "The project-local JAR is selected and added to the Libraries list"
+    verifyWebview:
+      contains: "autotest-lib.jar"
+
+  - id: "apply-library-change"
+    action: "clickInWebview text=Apply Settings"
+    verify: "Applying the classpath change succeeds and writes the selected JAR into .classpath"
+
+  - id: "verify-library-applied"
+    action: "wait 5 seconds"
+    verify: "The Eclipse .classpath contains the added library entry, proving the Project Settings UI sent a valid absolute library path to JDT LS instead of failing with a relative-path classpath error"
+    verifyFile:
+      path: "~/.classpath"
+      contains: "autotest-lib.jar"
+    skipLlmVerify: true

--- a/test-plans/java-extension-pack.yaml
+++ b/test-plans/java-extension-pack.yaml
@@ -77,7 +77,8 @@ steps:
 
   - id: "apply-library-change"
     action: "clickInWebview text=Apply Settings"
-    verify: "Applying the classpath change succeeds and writes the selected JAR into .classpath"
+    verify: "Apply Settings is clicked; the persisted .classpath update is verified by the next deterministic file assertion"
+    skipLlmVerify: true
 
   - id: "verify-library-applied"
     action: "wait 5 seconds"


### PR DESCRIPTION
## Summary

Fix Project Settings / Configure Classpath failing when adding a workspace-local JAR to a non-unmanaged Java project.

The UI previously converted selected JARs under the project root to project-relative paths. That is valid for unmanaged folders backed by `java.project.referencedLibraries`, but non-unmanaged projects apply library changes through JDT LS `java.project.updateClassPaths`, where `CPE_LIBRARY` entries must use absolute paths. Passing a relative path caused errors such as:

```text
Path for IClasspathEntry must be absolute: lib/foo.jar
```

## Changes

- Keep project-relative library paths only for unmanaged folders.
- Use absolute JAR paths when adding libraries for Maven/Gradle/Eclipse/other non-unmanaged projects.
- Add a defensive conversion before `java.project.updateClassPaths` so relative library entries are resolved against the project root before being sent to JDT LS.
- Extend the Java Extension Pack classpath autotest plan to cover adding a project-local JAR through the Project Settings Libraries UI and applying the classpath change.
- Add test case

## Validation

- `npm run compile`
- `node ../autotest/dist/cli/index.js validate ../vscode-java-pack/test-plans/java-extension-pack.yaml`
- `node ../autotest/dist/cli/index.js run test-plans/java-extension-pack.yaml --no-llm --output test-results/java-extension-pack-final`

Fixes microsoft/vscode-java-pack#1498
Related to microsoft/vscode-java-dependency#966
