### PR TITLE
build: Prepare 0.31.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 - Refactor Java Pack webviews to React 19 and `@vscode-elements/elements` in https://github.com/microsoft/vscode-java-pack/pull/1616
 - Fix Project Settings UI absolute path updates in https://github.com/microsoft/vscode-java-pack/pull/1623
-- Add and expand E2E autotest plans, fixtures, and GitHub Actions coverage in https://github.com/microsoft/vscode-java-pack/pull/1605, https://github.com/microsoft/vscode-java-pack/pull/1607, https://github.com/microsoft/vscode-java-pack/pull/1619, https://github.com/microsoft/vscode-java-pack/pull/1621
 - Improve IssueLens automation, labeling rules, and workflow reliability in https://github.com/microsoft/vscode-java-pack/pull/1540, https://github.com/microsoft/vscode-java-pack/pull/1544, https://github.com/microsoft/vscode-java-pack/pull/1598, https://github.com/microsoft/vscode-java-pack/pull/1602
-- Add GitHub Actions CI workflow for PR build verification in https://github.com/microsoft/vscode-java-pack/pull/1563
 - Update runtime dependencies and build tooling, including Axios, Lodash, React DOM, `@xmldom/xmldom`, `@vscode/codicons`, Highlight.js, TypeScript, Webpack, Sass, and related loaders.
 
 ## 0.30.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Refactor Java Pack webviews to React 19 and `@vscode-elements/elements` in https://github.com/microsoft/vscode-java-pack/pull/1616
 - Fix Project Settings UI absolute path updates in https://github.com/microsoft/vscode-java-pack/pull/1623
-- Improve IssueLens automation, labeling rules, and workflow reliability in https://github.com/microsoft/vscode-java-pack/pull/1540, https://github.com/microsoft/vscode-java-pack/pull/1544, https://github.com/microsoft/vscode-java-pack/pull/1598, https://github.com/microsoft/vscode-java-pack/pull/1602
 - Update runtime dependencies and build tooling, including Axios, Lodash, React DOM, `@xmldom/xmldom`, `@vscode/codicons`, Highlight.js, TypeScript, Webpack, Sass, and related loaders.
 
 ## 0.30.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.31.0
+
+- Refactor Java Pack webviews to React 19 and `@vscode-elements/elements` in https://github.com/microsoft/vscode-java-pack/pull/1616
+- Fix Project Settings UI absolute path updates in https://github.com/microsoft/vscode-java-pack/pull/1623
+- Add and expand E2E autotest plans, fixtures, and GitHub Actions coverage in https://github.com/microsoft/vscode-java-pack/pull/1605, https://github.com/microsoft/vscode-java-pack/pull/1607, https://github.com/microsoft/vscode-java-pack/pull/1619, https://github.com/microsoft/vscode-java-pack/pull/1621
+- Improve IssueLens automation, labeling rules, and workflow reliability in https://github.com/microsoft/vscode-java-pack/pull/1540, https://github.com/microsoft/vscode-java-pack/pull/1544, https://github.com/microsoft/vscode-java-pack/pull/1598, https://github.com/microsoft/vscode-java-pack/pull/1602
+- Add GitHub Actions CI workflow for PR build verification in https://github.com/microsoft/vscode-java-pack/pull/1563
+- Update runtime dependencies and build tooling, including Axios, Lodash, React DOM, `@xmldom/xmldom`, `@vscode/codicons`, Highlight.js, TypeScript, Webpack, Sass, and related loaders.
+
 ## 0.30.5
 
 - Remove IntelljCode from Java Pack in https://github.com/microsoft/vscode-java-pack/pull/1538

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Refactor Java Pack webviews to React 19 and `@vscode-elements/elements` in https://github.com/microsoft/vscode-java-pack/pull/1616
 - Fix Project Settings UI absolute path updates in https://github.com/microsoft/vscode-java-pack/pull/1623
-- Update runtime dependencies and build tooling, including Axios, Lodash, React DOM, `@xmldom/xmldom`, `@vscode/codicons`, Highlight.js, TypeScript, Webpack, Sass, and related loaders.
 
 ## 0.30.5
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-java-pack",
-  "version": "0.30.5",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-java-pack",
-      "version": "0.30.5",
+      "version": "0.31.0",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Extension Pack for Java",
   "description": "Popular extensions for Java development that provides Java IntelliSense, debugging, testing, Maven/Gradle support, project management and more",
   "license": "MIT",
-  "version": "0.30.5",
+  "version": "0.31.0",
   "publisher": "vscjava",
   "preview": false,
   "engines": {


### PR DESCRIPTION
## Summary
- Bump extension version from 0.30.5 to 0.31.0 in package.json and package-lock.json.
- Add 0.31.0 changelog covering the webview migration and Project Settings fix.

## Validation
- npm run build