### PR TITLE
Add Content Security Policy to webviews

### DIFF
--- a/src/beginner-tips/index.ts
+++ b/src/beginner-tips/index.ts
@@ -109,11 +109,13 @@ class BeginnerTipsPage {
 
 		// Use a nonce to whitelist which scripts can be run
 		const nonce = getNonce();
+		const cspSource = this._panel!.webview.cspSource;
 
 		return `<!DOCTYPE html>
 			<html lang="en">
 			<head>
 				<meta charset="utf-8">
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; script-src 'nonce-${nonce}'; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource} https: data:;">
 				<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 				<meta name="theme-color" content="#000000">
 				<title>${WEBVIEW_TITLE}</title>

--- a/src/ext-guide/index.ts
+++ b/src/ext-guide/index.ts
@@ -74,10 +74,12 @@ function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string
 
   // Use a nonce to whitelist which scripts can be run
   const nonce = getNonce();
+  const cspSource = webviewPanel.webview.cspSource;
   return `<!DOCTYPE html>
   <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; script-src 'nonce-${nonce}'; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource} https: data:;">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <title>Java Extensions Guide</title>

--- a/src/formatter-settings/index.ts
+++ b/src/formatter-settings/index.ts
@@ -158,10 +158,12 @@ export class JavaFormatterSettingsEditorProvider implements vscode.CustomTextEdi
 
         // Use a nonce to whitelist which scripts can be run
         const nonce = getNonce();
+        const cspSource = this.webviewPanel!.webview.cspSource;
         return `<!DOCTYPE html>
           <html lang="en">
           <head>
             <meta charset="utf-8">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; script-src 'nonce-${nonce}'; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource} https: data:;">
             <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
             <meta name="theme-color" content="#000000">
             <title>Java Formatter Settings</title>

--- a/src/install-jdk/index.ts
+++ b/src/install-jdk/index.ts
@@ -143,11 +143,13 @@ class InstallJdkPage {
 
 		// Use a nonce to whitelist which scripts can be run
 		const nonce = getNonce();
+		const cspSource = this._panel!.webview.cspSource;
 
 		return `<!DOCTYPE html>
 			<html lang="en">
 			<head>
 				<meta charset="utf-8">
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; script-src 'nonce-${nonce}'; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource} https: data:;">
 				<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 				<meta name="theme-color" content="#000000">
 				<title>React App</title>

--- a/src/java-runtime/index.ts
+++ b/src/java-runtime/index.ts
@@ -165,11 +165,13 @@ function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string
 
   // Use a nonce to whitelist which scripts can be run
   const nonce = getNonce();
+  const cspSource = webviewPanel.webview.cspSource;
 
   return `<!DOCTYPE html>
   <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; script-src 'nonce-${nonce}'; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource} https: data:;">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <title>Configure Java Runtime</title>

--- a/src/overview/index.ts
+++ b/src/overview/index.ts
@@ -114,11 +114,13 @@ function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string
 
   // Use a nonce to whitelist which scripts can be run
   const nonce = getNonce();
+  const cspSource = webviewPanel.webview.cspSource;
 
   return `<!DOCTYPE html>
   <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; script-src 'nonce-${nonce}'; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource} https: data:;">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <title>Java Overview</title>

--- a/src/project-settings/projectSettingsView.ts
+++ b/src/project-settings/projectSettingsView.ts
@@ -195,10 +195,12 @@ class ProjectSettingView {
 
         // Use a nonce to whitelist which scripts can be run
         const nonce = getNonce();
+        const cspSource = webview.cspSource;
         return `<!DOCTYPE html>
         <html lang="en">
         <head>
             <meta charset="utf-8">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; script-src 'nonce-${nonce}'; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource} https: data:;">
             <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
             <meta name="theme-color" content="#000000">
             <title>Project Settings</title>

--- a/src/welcome/index.ts
+++ b/src/welcome/index.ts
@@ -104,10 +104,12 @@ function getHtmlForWebview(webviewPanel: vscode.WebviewPanel, scriptPath: string
 
     // Use a nonce to whitelist which scripts can be run
     const nonce = getNonce();
+    const cspSource = webviewPanel.webview.cspSource;
     return `<!DOCTYPE html>
     <html lang="en">
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; script-src 'nonce-${nonce}'; style-src ${cspSource} 'unsafe-inline'; font-src ${cspSource} https: data:;">
         <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
         <meta name="theme-color" content="#000000">
         <title>Java Help Center</title>


### PR DESCRIPTION
Fixes #171

## Problem

Issue #171 (filed by the VS Code webview API owner) reported that the extension's webviews do not set a [Content Security Policy](https://code.visualstudio.com/api/extension-guides/webview#content-security-policy). After the webview refactor, all webviews wired up a `nonce` on their `<script>` tag, but none declared a CSP `<meta>` tag — so the nonce had no effect and no CSP was enforced.

## Change

Added a `Content-Security-Policy` meta tag to all 8 webviews. Each `getHtmlForWebview` now reads `webview.cspSource` and injects:

```html
<meta http-equiv="Content-Security-Policy"
      content="default-src 'none';
               img-src ${cspSource} https: data:;
               script-src 'nonce-${nonce}';
               style-src ${cspSource} 'unsafe-inline';
               font-src ${cspSource} https: data:;">
```

### Policy rationale

- `default-src 'none'` — deny by default.
- `script-src 'nonce-${nonce}'` — only the bundled, nonce-tagged script runs. This activates the existing (previously inert) nonce mechanism.
- `style-src ${cspSource} 'unsafe-inline'` — these React/bundled webviews inject inline `<style>` tags via style-loader, so `'unsafe-inline'` is required (matches the VS Code docs example).
- `img-src` / `font-src` allow `${cspSource}`, `https:`, and `data:` — needed because pages such as the Overview and Extensions Guide load extension icons and remote images.

### Webviews updated

| Webview | File |
|---------|------|
| Overview | `src/overview/index.ts` |
| Help Center / Welcome | `src/welcome/index.ts` |
| Extensions Guide | `src/ext-guide/index.ts` |
| Beginner Tips | `src/beginner-tips/index.ts` |
| Configure Java Runtime | `src/java-runtime/index.ts` |
| Install JDK | `src/install-jdk/index.ts` |
| Formatter Settings | `src/formatter-settings/index.ts` |
| Project Settings | `src/project-settings/projectSettingsView.ts` |

## Verification

- `npx tsc --noEmit` passes with no errors.

## Notes

- `'unsafe-inline'` for styles is the pragmatic choice given how CSS is currently injected; tightening to nonce/hash-based styles would require build-side changes.
- Recommend a runtime pass opening each webview and checking devtools for CSP violations, in case any page loads a resource from an origin not covered above.
