### PR TITLE
fix: drive project settings dropdowns via native change events

### DIFF
--- a/src/project-settings/assets/compiler/features/CompilerConfigurationView.tsx
+++ b/src/project-settings/assets/compiler/features/CompilerConfigurationView.tsx
@@ -111,19 +111,21 @@ const CompilerConfigurationView = (): JSX.Element | null => {
   useSelectChange(sourceRef, onChangeSourceLevel);
   useSelectChange(targetRef, onChangeTargetLevel);
 
-  // Keep the rendered selection in sync with the redux state.
+  // Keep the rendered selection in sync with the redux state. Set the value
+  // unconditionally (even when the level is "") so the dropdown always reflects
+  // state instead of keeping the previous project's selection.
   useEffect(() => {
-    if (complianceRef.current && complianceLevel) {
+    if (complianceRef.current) {
       (complianceRef.current as any).value = complianceLevel;
     }
   }, [complianceLevel, availableComplianceLevels]);
   useEffect(() => {
-    if (sourceRef.current && sourceLevel) {
+    if (sourceRef.current) {
       (sourceRef.current as any).value = sourceLevel;
     }
   }, [sourceLevel, availableComplianceLevels]);
   useEffect(() => {
-    if (targetRef.current && targetLevel) {
+    if (targetRef.current) {
       (targetRef.current as any).value = targetLevel;
     }
   }, [targetLevel, availableComplianceLevels]);

--- a/src/project-settings/assets/compiler/features/CompilerConfigurationView.tsx
+++ b/src/project-settings/assets/compiler/features/CompilerConfigurationView.tsx
@@ -11,7 +11,7 @@ import "@vscode-elements/elements/dist/vscode-table-row/index.js";
 import "@vscode-elements/elements/dist/vscode-table-cell/index.js";
 
 
-import { Dispatch, useEffect } from "react";
+import { Dispatch, useCallback, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { updateCompilerSettings, updateAvailableComplianceLevels } from "./compilerConfigurationViewSlice";
 import { CompilerRequest } from "../../vscode/utils";
@@ -54,6 +54,10 @@ const CompilerConfigurationView = (): JSX.Element | null => {
       Number(sourceLevel) > currentJdkComplianceLevel ||
       Number(targetLevel) > currentJdkComplianceLevel;
 
+  const complianceRef = useRef<HTMLElement>(null);
+  const sourceRef = useRef<HTMLElement>(null);
+  const targetRef = useRef<HTMLElement>(null);
+
   const onMessage = (event: any) => {
     const message = event.data;
     if (message.command === "compiler.onDidGetAvailableComplianceLevels") {
@@ -73,7 +77,58 @@ const CompilerConfigurationView = (): JSX.Element | null => {
     }
   }, []);
 
-  const jdkLevels = (selectedLevel: string, label: string, onClick: (value: string) => void) => {
+  // The vscode-single-select element renders its options in the shadow DOM and
+  // only emits a native `change` event on the host element, so the click handlers
+  // on the slotted vscode-option children never fire. Listen to `change` instead.
+  const useSelectChange = (ref: React.RefObject<HTMLElement | null>, onChange: (value: string) => void) => {
+    useEffect(() => {
+      const el = ref.current;
+      if (!el) {
+        return;
+      }
+      const handler = (e: Event) => {
+        const value = (e.target as any).value;
+        if (value) {
+          onChange(value);
+        }
+      };
+      el.addEventListener("change", handler);
+      return () => el.removeEventListener("change", handler);
+    }, [ref, onChange]);
+  };
+
+  const onChangeComplianceLevel = useCallback((value: string) => {
+    dispatch(updateCompilerSettings({ activeProjectIndex, complianceLevel: value }));
+  }, [dispatch, activeProjectIndex]);
+  const onChangeSourceLevel = useCallback((value: string) => {
+    dispatch(updateCompilerSettings({ activeProjectIndex, sourceLevel: value }));
+  }, [dispatch, activeProjectIndex]);
+  const onChangeTargetLevel = useCallback((value: string) => {
+    dispatch(updateCompilerSettings({ activeProjectIndex, targetLevel: value }));
+  }, [dispatch, activeProjectIndex]);
+
+  useSelectChange(complianceRef, onChangeComplianceLevel);
+  useSelectChange(sourceRef, onChangeSourceLevel);
+  useSelectChange(targetRef, onChangeTargetLevel);
+
+  // Keep the rendered selection in sync with the redux state.
+  useEffect(() => {
+    if (complianceRef.current && complianceLevel) {
+      (complianceRef.current as any).value = complianceLevel;
+    }
+  }, [complianceLevel, availableComplianceLevels]);
+  useEffect(() => {
+    if (sourceRef.current && sourceLevel) {
+      (sourceRef.current as any).value = sourceLevel;
+    }
+  }, [sourceLevel, availableComplianceLevels]);
+  useEffect(() => {
+    if (targetRef.current && targetLevel) {
+      (targetRef.current as any).value = targetLevel;
+    }
+  }, [targetLevel, availableComplianceLevels]);
+
+  const jdkLevels = (selectedLevel: string, label: string) => {
     return availableComplianceLevels.map((level) => {
 
       return (
@@ -81,8 +136,7 @@ const CompilerConfigurationView = (): JSX.Element | null => {
           className="setting-section-option"
           key={`${label}-${level}`}
           value={level}
-          selected={level === selectedLevel}
-          onClick={() => onClick(level)}
+          selected={level === selectedLevel ? true : undefined}
         >
           <span>{level}</span>
         </vscode-option>
@@ -101,27 +155,6 @@ const CompilerConfigurationView = (): JSX.Element | null => {
     dispatch(updateCompilerSettings({
       activeProjectIndex,
       enablePreview: e.target.checked
-    }));
-  };
-
-  const onClickComplianceLevel = (value: string) => {
-    dispatch(updateCompilerSettings({
-      activeProjectIndex,
-      complianceLevel: value
-    }));
-  };
-
-  const onClickSourceLevel = (value: string) => {
-    dispatch(updateCompilerSettings({
-      activeProjectIndex,
-      sourceLevel: value
-    }));
-  };
-
-  const onClickTargetLevel = (value: string) => {
-    dispatch(updateCompilerSettings({
-      activeProjectIndex,
-      targetLevel: value
     }));
   };
 
@@ -158,8 +191,8 @@ const CompilerConfigurationView = (): JSX.Element | null => {
                 <span>Bytecode version:</span>
               </vscode-table-cell>
               <vscode-table-cell className="flex-center pl-0 pr-0" >
-                <vscode-single-select value={complianceLevel}>
-                  {jdkLevels(complianceLevel, "compliance", onClickComplianceLevel)}
+                <vscode-single-select ref={complianceRef}>
+                  {jdkLevels(complianceLevel, "compliance")}
                 </vscode-single-select>
               </vscode-table-cell>
             </vscode-table-row>
@@ -168,8 +201,8 @@ const CompilerConfigurationView = (): JSX.Element | null => {
                 <span>Source compatibility:</span>
               </vscode-table-cell>
               <vscode-table-cell className="flex-center pl-0 pr-0" >
-                <vscode-single-select value={sourceLevel}>
-                  {jdkLevels(sourceLevel, "source", onClickSourceLevel)}
+                <vscode-single-select ref={sourceRef}>
+                  {jdkLevels(sourceLevel, "source")}
                 </vscode-single-select>
               </vscode-table-cell>
             </vscode-table-row>
@@ -178,8 +211,8 @@ const CompilerConfigurationView = (): JSX.Element | null => {
                 <span>Target compatibility:</span>
               </vscode-table-cell>
               <vscode-table-cell className="flex-center pl-0 pr-0" >
-                <vscode-single-select value={targetLevel}>
-                  {jdkLevels(targetLevel, "target", onClickTargetLevel)}
+                <vscode-single-select ref={targetRef}>
+                  {jdkLevels(targetLevel, "target")}
                 </vscode-single-select>
               </vscode-table-cell>
             </vscode-table-row>

--- a/src/project-settings/assets/mainpage/features/component/ProjectSelector.tsx
+++ b/src/project-settings/assets/mainpage/features/component/ProjectSelector.tsx
@@ -4,7 +4,7 @@
 import "@vscode-elements/elements/dist/vscode-single-select/index.js";
 import "@vscode-elements/elements/dist/vscode-option/index.js";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { ProjectInfo } from "../../../../types";
 import { Dispatch } from "@reduxjs/toolkit";
@@ -17,10 +17,37 @@ const ProjectSelector = (): JSX.Element | null => {
   const projects: ProjectInfo[] = useSelector((state: any) => state.commonConfig.data.projects);
 
   const dispatch: Dispatch<any> = useDispatch();
+  const selectRef = useRef<HTMLElement>(null);
 
-  const handleActiveProjectChange = (index: number) => {
+  const handleActiveProjectChange = useCallback((index: number) => {
     dispatch(activeProjectChange(index));
-  };
+  }, [dispatch]);
+
+  // The vscode-single-select element renders its options in the shadow DOM and
+  // only emits a native `change` event on the host element, so the click handlers
+  // on the slotted vscode-option children never fire. Listen to `change` instead.
+  useEffect(() => {
+    const el = selectRef.current;
+    if (!el) {
+      return;
+    }
+    const onChange = (e: Event) => {
+      const index = (e.target as any).selectedIndex;
+      if (typeof index === "number" && index >= 0) {
+        handleActiveProjectChange(index);
+      }
+    };
+    el.addEventListener("change", onChange);
+    return () => el.removeEventListener("change", onChange);
+  }, [handleActiveProjectChange]);
+
+  // Keep the rendered selection in sync with the active project index.
+  useEffect(() => {
+    const el = selectRef.current;
+    if (el && projects.length > 0) {
+      (el as any).selectedIndex = activeProjectIndex;
+    }
+  }, [activeProjectIndex, projects]);
 
   useEffect(() => {
     if (projects.length === 0) {
@@ -38,7 +65,12 @@ const ProjectSelector = (): JSX.Element | null => {
     }
 
     return (
-      <vscode-option className="setting-section-option" key={project.rootPath} onClick={() => handleActiveProjectChange(index)}>
+      <vscode-option
+        className="setting-section-option"
+        key={project.rootPath}
+        value={project.rootPath}
+        selected={index === activeProjectIndex ? true : undefined}
+      >
         {project.name}
       </vscode-option>
     );
@@ -48,7 +80,7 @@ const ProjectSelector = (): JSX.Element | null => {
     <div id="project-selector" className="setting-section">
       <div className="flex-center mt-2 mb-2">
         <span className="setting-section-description ml-1 mr-1">Project:</span>
-        <vscode-single-select className="setting-section-dropdown">
+        <vscode-single-select ref={selectRef} className="setting-section-dropdown">
             {projectSelections}
         </vscode-single-select>
       </div>


### PR DESCRIPTION
## Problem

Fixes #1650 — the "Store information about method parameters" project setting (and other per-project compiler settings) could not be changed for individual projects in a multi-root / multi-project workspace. Selecting a different project in **Java: Open Project Settings** had no effect: settings were always read from and written to the **first** project.

## Root cause

The React 19 / `@vscode-elements/elements` migration (#1616, shipped in 0.31.0) replaced the previous dropdowns with the `vscode-single-select` web component. That component renders its options in the **shadow DOM** and only emits a native `change` event on the host element — it does **not** propagate React `onClick` to the slotted light-DOM `vscode-option` children.

As a result:
- `ProjectSelector` — the `onClick` on each `vscode-option` never fired, so `activeProjectIndex` stayed `0`. The whole settings page always targeted `projects[0]`.
- `CompilerConfigurationView` — the compliance / source / target dropdowns had the same broken `onClick` pattern.

This explains both reported symptoms: the method-parameters toggle appeared to apply "to all projects", and a non-default project never received `-parameters`.

## Fix

Switch both components to the working pattern already used by `JdkRuntime.tsx`:
- Attach a `ref` to the `vscode-single-select` host and listen for the native `change` event, reading `selectedIndex` (project selector) / `value` (compiler levels).
- Sync the rendered selection back from redux state via an effect (`selectedIndex` / `value`), and render options with `value` + `selected` instead of `onClick`.

Checkboxes (`vscode-checkbox`) were unaffected and are not changed.

## Verification

Built a VSIX from this branch and verified end-to-end against a multi-project Gradle workspace (`app`, `buildSrc`, `list`, `utilities`):

1. Switched the project dropdown from `app` to `utilities` — `activeProjectIndex` now updates and the Compiler section reloads that project's settings.
2. Toggled **Store information about method parameters** on and clicked **Apply Settings**.
3. `org.eclipse.jdt.core.compiler.codegen.methodParameters=generate` was written to **only** the `utilities` project's JDT prefs; `app`, `list`, and `buildSrc` did **not** receive the key.

Before the fix, the same steps always wrote to `app` regardless of the selected project.