### PR TITLE
fix: bundle codicon font in Java Help Center webview

### DIFF
--- a/src/welcome/assets/style.scss
+++ b/src/welcome/assets/style.scss
@@ -1,4 +1,5 @@
 @import "../../assets/vscode.scss";
+@import "../../../node_modules/@vscode/codicons/dist/codicon.css";
 
 // Custom styles dedicated to this webview:
 


### PR DESCRIPTION
## Problem

Fixes #1390

In the Java Help Center (the `welcome` webview), some icons render as empty boxes/blanks on Linux. The affected icons are the **codicon** glyphs used in the navigation tabs and links:

- `NavigationPanel.tsx` — `codicon-gear`, `codicon-globe`, `codicon-mortar-board`, `codicon-rocket`
- `SocialMediaPanel.tsx` — `codicon-book`, `codicon-github-inverted`

The image-based icons (logo, tour screenshots, done checkmark) render fine because they are inlined as base64 by webpack.

## Root cause

The welcome page stylesheet (`src/welcome/assets/style.scss`) only *styles* `.codicon` (size/margins) but never imports the codicon **font** CSS. It silently relied on the `codicon` font that VS Code auto-injects into webviews, which is not reliably present across platforms — so on Linux the glyphs fail to resolve.

Every other icon-using webview in this repo imports the font explicitly (e.g. `project-settings`, `java-runtime`, `install-jdk`, `beginner-tips`), so the welcome page was the lone exception.

## Fix

Import `@vscode/codicons/dist/codicon.css` in the welcome stylesheet. The webpack config already inlines `.ttf` fonts as `asset/inline`, so the font is embedded directly into the bundle and works consistently on Linux, Windows, and macOS — independent of VS Code's injected font. The webview CSP already permits `font-src ... data:`.

```scss
@import "../../assets/vscode.scss";
@import "../../../node_modules/@vscode/codicons/dist/codicon.css";
```

## Verification

- `webpack --config-name assets` builds with no errors.
- The output `out/assets/welcome/index.js` now contains an `@font-face { font-family: "codicon"; ... format("truetype") }` declaration with the font inlined as a base64 `font/ttf` data URL.
