### PR TITLE
chore: Exclude autotest artifacts from VSIX package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -15,3 +15,6 @@ out/**/*.map
 *.vsix
 scripts
 .azure-pipelines/**
+test-fixtures/**
+test-plans/**
+test-results/**


### PR DESCRIPTION
## Summary
- Exclude E2E test fixtures, test plans, and generated test results from VSIX packaging.
- Prevent test-only Maven/JUnit fixture metadata and screenshots from being distributed with the extension.

## Validation
- `npx @vscode/vsce@latest package -o vscode-java-pack-exclude-check.vsix`
- Inspected the generated VSIX and confirmed it contains no `extension/test-fixtures/`, `extension/test-plans/`, `extension/test-results/`, or JUnit entries.