### PR TITLE
build: prepare 0.31.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 - Add Content Security Policy to webviews in https://github.com/microsoft/vscode-java-pack/pull/1648
 - Fix Project Settings dropdown updates in https://github.com/microsoft/vscode-java-pack/pull/1655
 - Bundle the codicon font in the Java Help Center webview in https://github.com/microsoft/vscode-java-pack/pull/1658
-- Exclude E2E test fixtures, test plans, and generated test results from the VSIX package in https://github.com/microsoft/vscode-java-pack/pull/1659
-- Update dependencies and build tooling.
 
 ## 0.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.31.1
+
+- Exclude E2E test fixtures, test plans, and generated test results from the VSIX package in https://github.com/microsoft/vscode-java-pack/pull/1659
+
 ## 0.31.0
 
 - Refactor Java Pack webviews to React 19 and `@vscode-elements/elements` in https://github.com/microsoft/vscode-java-pack/pull/1616

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 0.31.1
 
+- Add Content Security Policy to webviews in https://github.com/microsoft/vscode-java-pack/pull/1648
+- Fix Project Settings dropdown updates in https://github.com/microsoft/vscode-java-pack/pull/1655
+- Bundle the codicon font in the Java Help Center webview in https://github.com/microsoft/vscode-java-pack/pull/1658
 - Exclude E2E test fixtures, test plans, and generated test results from the VSIX package in https://github.com/microsoft/vscode-java-pack/pull/1659
+- Update dependencies and build tooling.
 
 ## 0.31.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-java-pack",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-java-pack",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Extension Pack for Java",
   "description": "Popular extensions for Java development that provides Java IntelliSense, debugging, testing, Maven/Gradle support, project management and more",
   "license": "MIT",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "publisher": "vscjava",
   "preview": false,
   "engines": {


### PR DESCRIPTION
## Summary
- Bump the extension version to `0.31.1`.
- Add the `0.31.1` changelog entry for notable fixes merged after `0.31.0`, including webview CSP, Project Settings dropdown updates, and Java Help Center codicon font bundling.

## Validation
- `npx @vscode/vsce@latest package -o vscode-java-pack-0.31.1-verify.vsix`
- Inspected the generated VSIX and confirmed version `0.31.1`.
- Confirmed the VSIX contains no `extension/test-fixtures/`, `extension/test-plans/`, `extension/test-results/`, or JUnit entries.