### PR TITLE
fix(deps): bump js-yaml to 4.2.0 (CVE-2026-53550)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,10 +2473,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
Fixes Dependabot alert [#82](https://github.com/microsoft/vscode-java-pack/security/dependabot/82).

## Vulnerability

- **Advisory:** GHSA-h67p-54hq-rp68 / CVE-2026-53550
- **Package:** `js-yaml` (npm, dev dependency, transitive via `cosmiconfig`)
- **Severity:** Medium (CVSS 5.3)
- **Summary:** Quadratic-complexity DoS in merge-key (`<<`) handling via repeated aliases. A crafted YAML document can cause CPU exhaustion when parsed.
- **Vulnerable range:** `<= 4.1.1`
- **Patched version:** `4.2.0`

## Change

Bumped `js-yaml` `4.1.1` -> `4.2.0` in `package-lock.json` (`npm update js-yaml`). `4.2.0` satisfies the existing `^4.1.0` constraint from `cosmiconfig`, so only the lockfile changed.

> Note: `tslint` still pulls in `js-yaml@3.14.2` (constraint `^3.13.1`), which cannot move to the 4.x line. Dependabot raised only alert #82 for the 4.x instance, which this PR resolves.