### PR TITLE
test: add Go to Super Implementation autotest plan (vscode-java#4438)

### DIFF
--- a/test-fixtures/super-implementation/README.md
+++ b/test-fixtures/super-implementation/README.md
@@ -1,0 +1,14 @@
+# Go to Super Implementation — Test Fixture
+
+This fixture is consumed by `test-plans/java-go-to-super-implementation.yaml`.
+
+It is a minimal self-contained Maven project intentionally configured with
+JDK 11 compliance (`<release>11</release>`), so JDT runs full semantic
+analysis under the JDK 21 toolchain that the E2E workflow installs.
+
+`Derived` extends `Base` and overrides `greet()`. Hovering the overriding
+`greet()` method renders vscode-java's "Go to super implementation" hover
+link; the test plan clicks it and verifies navigation to `Base#greet()`.
+
+Regression coverage for redhat-developer/vscode-java#4438, where the
+"Go to super implementation" hover link was not a clickable link.

--- a/test-fixtures/super-implementation/pom.xml
+++ b/test-fixtures/super-implementation/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>super-implementation</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-fixtures/super-implementation/src/main/java/com/example/Base.java
+++ b/test-fixtures/super-implementation/src/main/java/com/example/Base.java
@@ -1,0 +1,12 @@
+package com.example;
+
+/**
+ * Base class declaring the method that Derived overrides. The hover-link
+ * "Go to super implementation" on Derived#greet() must navigate here.
+ */
+public class Base {
+
+    public void greet() {
+        System.out.println("Hello from Base");
+    }
+}

--- a/test-fixtures/super-implementation/src/main/java/com/example/Derived.java
+++ b/test-fixtures/super-implementation/src/main/java/com/example/Derived.java
@@ -1,0 +1,14 @@
+package com.example;
+
+/**
+ * Derived overrides the base method. Hovering the override shows the
+ * "Go to super implementation" link that vscode-java contributes; clicking
+ * it should jump to the base class.
+ */
+public class Derived extends Base {
+
+    @Override
+    public void greet() {
+        System.out.println("Hello from Derived");
+    }
+}

--- a/test-plans/java-go-to-super-implementation.yaml
+++ b/test-plans/java-go-to-super-implementation.yaml
@@ -1,0 +1,84 @@
+# Test Plan: Go to Super Implementation (hover link)
+#
+# Regression coverage for redhat-developer/vscode-java#4438 — the
+# "Go to super implementation" link in the hover popup of an overriding
+# method was not clickable in 1.55.0. This plan hovers the overriding
+# method, clicks the hover link, and verifies the editor navigates to the
+# super (base-class) implementation.
+#
+# Verifies: LS ready -> hover overriding method -> "Go to super
+# implementation" hover link is present and clickable -> editor opens
+# Base.java at Base#greet().
+#
+# Prerequisites:
+#   - JDK 11+ installed and available on PATH (the workflow installs JDK 21)
+#
+# Usage: autotest run test-plans/java-go-to-super-implementation.yaml
+
+name: "Java Navigation — Go to Super Implementation (hover link)"
+description: |
+  Validates the "Go to super implementation" hover link contributed by
+  vscode-java. Derived extends Base and overrides greet(); hovering the
+  overriding greet() shows a clickable link that navigates to Base#greet().
+
+setup:
+  extension: "redhat.java"
+  extensions:
+    - "vscjava.vscode-java-pack"
+  vscodeVersion: "stable"
+  workspace: "../test-fixtures/super-implementation"
+  timeout: 300
+  workspaceSettings:
+    java.configuration.updateBuildConfiguration: "automatic"
+    java.import.maven.enabled: true
+    editor.hover.sticky: true
+    editor.hover.delay: 100
+
+steps:
+  # ── Wait for LS ready ─────────────────────────────────────────
+  - id: "ls-ready"
+    action: "waitForLanguageServer"
+    verify: "super-implementation project has been imported; the Java extension is activated and pom.xml is visible in the Explorer"
+    timeout: 300
+    waitBefore: 10
+    # waitForLanguageServer is authoritative — skip LLM screenshot re-check.
+    skipLlmVerify: true
+
+  # ── Open the overriding subclass ──────────────────────────────
+  - id: "open-derived"
+    action: "open file Derived.java"
+    verify: "Derived.java is open in the editor and shows the overriding greet() method"
+    verifyEditor:
+      contains: "public void greet"
+    waitBefore: 5
+    timeout: 15
+
+  # ── Hover the overriding method ───────────────────────────────
+  # The first "greet" occurrence in the visible editor is the overriding
+  # declaration. Hovering it renders vscode-java's hover popup which
+  # includes the "Go to super implementation" link. The after-step
+  # screenshot captures the open popup; the LLM verify confirms the link
+  # is actually shown (the regression for #4438 is exactly this link
+  # being absent / not rendered as a clickable link).
+  - id: "hover-greet"
+    action: "hoverOnText greet"
+    verify: "A hover popup is open over the overriding greet() method and it contains a clickable 'Go to super implementation' link"
+    waitBefore: 5
+    timeout: 30
+
+  # ── Click the hover link ──────────────────────────────────────
+  # This is the regression assertion for #4438: the link must be a
+  # clickable element that triggers navigation to the super method.
+  - id: "click-super-link"
+    action: "clickHoverAction Go to super implementation"
+    verify: "The 'Go to super implementation' hover link was clicked and the editor navigated from Derived.java to the base class — Base.java is now opening with the cursor moving onto Base#greet()"
+    timeout: 15
+
+  # ── Verify navigation landed on Base#greet() ──────────────────
+  - id: "verify-base-open"
+    action: "wait 2 seconds"
+    verify: "Base.java is the active editor tab and the cursor sits on the base greet() method (Hello from Base body visible) — navigation to the super implementation succeeded via the hover link"
+    verifyEditor:
+      fileName: "Base.java"
+      contains: "Hello from Base"
+    timeout: 15


### PR DESCRIPTION
## Summary
Adds a UI autotest plan and fixture covering the **"Go to super implementation"** hover link for overriding methods. Regression coverage for redhat-developer/vscode-java#4438, where the link was no longer clickable in 1.55.0.

## Changes
- test-plans/java-go-to-super-implementation.yaml — hover the overriding method, click the hover link, verify navigation to the base implementation (LLM-verified each step).
- test-fixtures/super-implementation/ — minimal Maven project: Derived extends Base overriding greet().

## Verification
- vscode-java 1.54.0: 5/5 pass (link clickable, jumps to Base#greet()).
- vscode-java 1.55.0: fails at hover-link step (regression reproduced).

Requires the new clickHoverAction action in vscjava/vscode-autotest.
