### PR TITLE
Retain IssueLens output artifact

### DIFF
--- a/.github/workflows/issueLens-run.yml
+++ b/.github/workflows/issueLens-run.yml
@@ -134,3 +134,12 @@ jobs:
             --stream=off \
             --silent \
             > "$RUNNER_TEMP/issuelens-output.txt"
+
+      - name: Upload IssueLens output
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: issuelens-output-${{ steps.issue.outputs.number || 'unknown' }}
+          path: ${{ runner.temp }}/issuelens-output.txt
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
Stores the final IssueLens text output as a short-lived workflow artifact for diagnostics.

The upload runs on success or failure and excludes the MCP configuration and environment data.