### PR TITLE
Add MCP diagnostics to IssueLens workflow

### DIFF
--- a/.github/workflows/issueLens-run.yml
+++ b/.github/workflows/issueLens-run.yml
@@ -74,6 +74,10 @@ jobs:
         run: |
           set -euo pipefail
           mcp_config="$RUNNER_TEMP/mcp-config.json"
+          copilot_log_dir="$RUNNER_TEMP/copilot-logs"
+          output_file="$RUNNER_TEMP/issuelens-output.txt"
+          mkdir -p "$copilot_log_dir"
+          trap 'rm -f "$mcp_config"; rm -rf "$copilot_log_dir"' EXIT
           jq -n --arg javatooling_url "$JAVATOOLING_INDEX_URL" '
             {
               mcpServers: {
@@ -122,6 +126,8 @@ jobs:
             }
           ' > "$mcp_config"
 
+          copilot --version
+          set +e
           copilot \
             --agent=issuelens \
             --prompt="Triage issue #$ISSUE_NUMBER in repository $GITHUB_REPOSITORY." \
@@ -134,12 +140,22 @@ jobs:
             --no-custom-instructions \
             --no-experimental \
             --no-remote-export \
-            --log-level=none \
+            --log-dir="$copilot_log_dir" \
+            --log-level=info \
             --no-color \
             --output-format=text \
             --stream=off \
-            --silent \
-            > "$RUNNER_TEMP/issuelens-output.txt"
+            | tee "$output_file"
+          copilot_status=$?
+          set -e
+
+          echo "::group::Copilot MCP diagnostics"
+          find "$copilot_log_dir" -type f -name '*.log' -exec \
+            grep -hE '\[(INFO|WARN|ERROR)\].*(MCP|mcp|rmcp|Service initialized as client)' {} + \
+            || true
+          echo "::endgroup::"
+
+          exit "$copilot_status"
 
       - name: Upload IssueLens output
         if: always()


### PR DESCRIPTION
## Summary

- enable info-level Copilot logs in a temporary directory for IssueLens runs
- surface only MCP-related lifecycle entries in a collapsed Actions log group
- preserve the IssueLens output artifact and Copilot exit status while cleaning up diagnostic files
- print the Copilot CLI version to make future failures reproducible

This makes MCP registration failures diagnosable without uploading raw Copilot logs or changing the constrained tool configuration. The previous production failure could not be diagnosed because `--silent --log-level=none` discarded the relevant lifecycle errors.

## Validation

- workflow YAML diagnostics report no errors
- `git diff --check`
- exercised the equivalent Bash flow with all three configured MCP servers
- confirmed the filtered logs contain MCP lifecycle entries and do not expose the supplied GitHub token or mailing endpoint