### PR TITLE
ci:  Carry the CFS npm redirect in the environment

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -2,8 +2,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -2,8 +2,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 schedules:
   - cron: 0 0 * * *
     branches:

--- a/.azure-pipelines/npm-cfs-variables.yml
+++ b/.azure-pipelines/npm-cfs-variables.yml
@@ -1,0 +1,28 @@
+# Variables required to route npm package restore through the Central Feed Service
+# (CFS). Consumed by every pipeline in this directory alongside the npm-cfs.yml steps
+# template, which is where these values are actually applied.
+#
+# Both are declared here rather than in each pipeline so the feed URL exists in
+# exactly one place.
+#
+# npm_config_registry is not redundant with the registry written into the generated
+# .npmrc. npm resolves configuration in the order cli > environment > project .npmrc
+# > user .npmrc, so a registry supplied only through the user config is outranked by
+# anything the agent image already configures -- Microsoft hosted images ship a user
+# level .npmrc pointing at an internal proxy, and a pool that exports
+# npm_config_registry would win outright. Restore would then quietly resolve from
+# somewhere other than CFS while the build still reported success. Declaring the
+# variable here puts the redirect at environment precedence, where only an explicit
+# command line flag can override it.
+#
+# npm matches npm_config_* environment variables case insensitively, so the
+# uppercased form that Azure Pipelines exports applies to every step on every OS.
+# That matters because package restore here is not driven by a single task: `npm
+# install`, `npx json`, `npx @vscode/vsce` and the vsce invocation inside AzureCLI@2
+# all inherit the agent environment rather than reading a task input.
+
+variables:
+  - name: npm_config_registry
+    value: https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc

--- a/.azure-pipelines/npm-cfs.yml
+++ b/.azure-pipelines/npm-cfs.yml
@@ -1,6 +1,12 @@
-# Single source of truth for routing npm package restore through the Central Feed
-# Service (CFS), as required by SFI Network Isolation. Every build pipeline in this
-# directory consumes this template, so the feed URL is declared exactly once.
+# Routes npm package restore through the Central Feed Service (CFS), as required by
+# SFI Network Isolation. Consumed by every build pipeline in this directory.
+#
+# Pipelines must also include the companion variables template:
+#   variables:
+#     - template: /.azure-pipelines/npm-cfs-variables.yml@self
+# which declares the feed URL and the generated .npmrc path. The redirect itself is
+# carried by the npm_config_registry environment variable that template exports; see
+# its header for why the generated .npmrc alone is not enough.
 #
 # The .npmrc is generated at build time into the agent temp directory rather than
 # being committed to the repository, so that:
@@ -11,10 +17,9 @@
 #   * the configuration does not depend on the repository being checked out, so
 #     release jobs consuming a prebuilt artifact work the same way as build jobs.
 #
-# Pipelines consuming this template must also declare the pipeline level variable
-#   npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
-# npm matches npm_config_* environment variables case insensitively, so the
-# uppercased form that Azure Pipelines exports applies to every step on every OS.
+# The registry is still written into that file because NpmAuthenticate discovers the
+# registries to authenticate by reading it. npm then takes the URL from the
+# environment and the matching credential from this file.
 #
 # The file is written with `npm config set` rather than a shell redirect because the
 # pipelines span both Windows (VSEng-MicroBuildVSStable) and Linux
@@ -26,14 +31,14 @@
 # This template must run after the Node install task, and before any step that
 # restores packages -- including `npx`, which resolves downloads through the
 # configured registry.
-
-parameters:
-  - name: npmrcPath
-    type: string
-    default: $(Agent.TempDirectory)/.npmrc
+#
+# Consumers must reference this file as `/.azure-pipelines/npm-cfs.yml@self`. A
+# relative path is resolved against the file doing the including, which for these
+# pipelines is the 1ES extends template in another repository, so the unqualified
+# form is looked up in 1ESPipelineTemplates and fails YAML compilation.
 
 steps:
-  - script: npm config set registry https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/ --location=user --userconfig="${{ parameters.npmrcPath }}"
+  - script: npm config set registry $(npm_config_registry) --location=user --userconfig="$(npm_config_userconfig)"
     displayName: Configure CFS npm registry
 
   # Appends `//pkgs.dev.azure.com/.../registry/:_authToken=<token>` for every registry
@@ -42,4 +47,13 @@ steps:
   - task: NpmAuthenticate@0
     displayName: Authenticate to CFS feed
     inputs:
-      workingFile: ${{ parameters.npmrcPath }}
+      workingFile: $(npm_config_userconfig)
+
+  # Restore silently falling back to the public registry is the failure mode this
+  # whole template exists to prevent, and it leaves no trace in the build log, so it
+  # is asserted rather than assumed. Written in node, which the preceding Node
+  # install task guarantees, to avoid shell differences between the Linux and
+  # Windows pools.
+  - script: >-
+      node -e "const cp=require('child_process');const r=cp.execSync('npm config get registry').toString().trim();console.log('npm registry -> '+r);if(!r.startsWith('https://pkgs.dev.azure.com/')){console.error('##vso[task.logissue type=error]npm is not configured against the CFS feed');process.exit(1);}"
+    displayName: Verify CFS npm registry

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -2,8 +2,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/release-nightly.yml
+++ b/.azure-pipelines/release-nightly.yml
@@ -8,8 +8,7 @@ name: $(Date:yyyyMMdd).$(Rev:r) # Use the current date and a revision number for
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -8,8 +8,7 @@ name: $(Date:yyyyMMdd).$(Rev:r) # Use the current date and a revision number for
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self


### PR DESCRIPTION
Follow up to #1708 and #1711, applying what the equivalent change in [microsoft/vscode-gradle#1901](https://github.com/microsoft/vscode-gradle/pull/1901) turned up once it actually ran.

## Problem

#1708 routed npm through CFS by generating a user level `.npmrc` in the agent temp directory. npm resolves configuration in the order

```
cli > environment > project .npmrc > user .npmrc > global > builtin > default
```

so a registry supplied only through the user config sits at the second lowest precedence and is displaced by anything the agent image already configures. Microsoft hosted images do ship a user level `.npmrc` pointing at an internal proxy, and a pool exporting `npm_config_registry` would override us outright.

The consequence is not a build failure. Restore resolves from somewhere other than CFS, the packages install, and the build goes green — npm never logs which registry it used, and the package counts are identical either way.

This is not hypothetical. In vscode-gradle the same configuration produced a build that restored 718 packages against a CFS feed that had cached **nothing**. The only way to notice was to inspect the feed afterwards.

## Change

**Move the redirect to environment precedence.** `npm_config_registry` is declared as a pipeline variable, so only an explicit command line flag can displace it. npm matches `npm_config_*` case insensitively, so the uppercased form Azure Pipelines exports applies on both the Windows (`VSEng-MicroBuildVSStable`) and Linux (`1ES_JavaTooling_Ubuntu-2004`) pools, and to every restore path in these pipelines — `npm install`, `npx json@9.0.6`, `npx @vscode/vsce`, and the `vsce publish` inside `AzureCLI@2`. None of those read a task input, so a variable is the only lever that reaches all of them.

**Keep generating the `.npmrc`.** `NpmAuthenticate@0` discovers the registries to authenticate by reading that file, so it still needs the registry written into it. npm now takes the URL from the environment and the matching credential from the file. Still nothing is committed, so outside contributors and `.github/workflows/ci.yml` are unaffected and the token never lands in the workspace.

**Assert the outcome.** A new `Verify CFS npm registry` step fails the build if npm is not pointed at the feed by the time restore begins. Silent fallback is the one failure this template exists to prevent and it leaves no trace in the log, so it is checked rather than assumed. Written in node — guaranteed by the preceding `NodeTool@0` — to avoid shell differences between the two pools.

**Consolidate the variables** into `npm-cfs-variables.yml` so the feed URL keeps living in exactly one place now that two variables describe it.

## Validation

Template expansion, via the pipelines preview API on this branch. No builds queued.

| Definition | Id | Result |
| --- | --- | --- |
| 1ES-Nightly | 16482 | compiles, 3 CFS steps |
| 1ES-RC | 16483 | compiles, 3 CFS steps |
| JavaPack-Release-Nightly | 21191 | compiles, 3 CFS steps |
| JavaPack-Release | 21192 | compiles, 3 CFS steps |

1ES-CI (16481) is currently disabled and cannot be previewed. It carries the same two template references as the others.

Expanded step order on `1ES-Nightly`:

```
Use Node 20.x -> Configure CFS npm registry -> Authenticate to CFS feed
              -> Verify CFS npm registry -> npm install -> npx json -> VSCE package
```

and the expanded variable block:

```yaml
variables:
- name: Codeql.Enabled
  value: true
- name: npm_config_registry
  value: https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/
- name: npm_config_userconfig
  value: $(Agent.TempDirectory)/.npmrc
```

The verify script was run under `cmd.exe` against both outcomes. With the machine's own user `.npmrc` in effect it reports `https://packagefeedproxy.microsoft.io/npm/` and exits 1; with `npm_config_registry` set it reports the CFS feed and exits 0 — which also demonstrates the environment variable overriding a preconfigured user `.npmrc`, the exact case this change exists for.

Runtime evidence comes from vscode-gradle, which carries the identical templates: after this change its build cached **525 of 525** npm packages into the `vscjava` feed within the build window, against a feed that held zero beforehand.

`package.json` and `package-lock.json` are untouched, and no npm or npx command line changes.

## Not covered

- Feed authentication uses `Project Collection Build Service (mseng)`, which holds contributor on `vscjava` — confirmed, since all five definitions run with `jobAuthScope=projectCollection`.
- `NodeTool@0` / `UseNode@1`, `APIScan@2` with `toolVersion: Latest`, and the MicroBuild `MicroBuildToolset` NuGet feed are separate outbound fetches and are not addressed here.
- The SR21 seven day lock-in cannot be satisfied by waiting: `rc`, `release` and `release-nightly` are `trigger: none`, and 1ES-CI is disabled, so only `nightly` runs on its own.
