### PR TITLE
fix: restore TLS certificate validation

### DIFF
--- a/src/utils/adoptiumApi.ts
+++ b/src/utils/adoptiumApi.ts
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 import axios from "axios";
-import * as https from "https";
-
-// workaround: certificate expired, will be fixed when vscode adopts Electron v15.1.0
-// see: https://github.com/node-fetch/node-fetch/issues/568#issuecomment-932435180
-https.globalAgent.options.rejectUnauthorized = false;
 
 /**
  * 


### PR DESCRIPTION
## Summary

Remove the obsolete `https.globalAgent.options.rejectUnauthorized = false` workaround from the Adoptium API module.

The mutation disables TLS certificate validation for every default-agent HTTPS request in the shared extension-host process. Current VS Code/Electron versions no longer require the expired-certificate workaround.

## Validation

- `npm run build`
- Confirmed the generated extension bundle contains no `rejectUnauthorized` override