### PR TITLE
build: use Node 22 for AutoTest workflows

### DIFF
--- a/.github/workflows/e2e-autotest.yml
+++ b/.github/workflows/e2e-autotest.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup Java 25 (for java25 test plans)
         if: contains(matrix.plan, 'java25')
@@ -361,7 +361,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install autotest CLI
         run: npm install -g @vscjava/vscode-autotest


### PR DESCRIPTION
## Summary

- Use Node.js 22 for the E2E AutoTest matrix and aggregate analysis job.
- Continue installing the latest `@vscjava/vscode-autotest` release without pinning a version.

## Reason

AutoTest now requires Node.js 22. With Node.js 20, npm selects an older compatible AutoTest release instead of the latest release.

## Validation

- Parsed the updated workflow as YAML.
- Confirmed the AutoTest install command remains unversioned.