### PR TITLE
build: pin Windows signing plugin to 1.1.1330

### DIFF
--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -31,11 +31,7 @@ extends:
             templateContext:
               mb:
                  signing:
-                   enabled: true
-                   signType: real
-                   signWithProd: true
-                   zipSources: false
-                   feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                   enabled: false
               outputs:
                 - output: pipelineArtifact
                   artifactName: vsix
@@ -45,6 +41,19 @@ extends:
               - checkout: self
                 clean: true
                 fetchTags: false
+              # Pin the last known-good Windows plugin while the 1.1.1374 client certificate regression is unresolved.
+              - task: NuGetAuthenticate@1
+                displayName: Authenticate MicroBuild feed
+              - task: MicroBuildSigningPlugin@4
+                displayName: Install Signing Plugin 1.1.1330
+                inputs:
+                  signType: real
+                  version: '1.1.1330'
+                  zipSources: false
+                  ConnectedPMEServiceName: '40012d40-9ded-4f75-8476-d60758200346'
+                  feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                env:
+                  MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
               - task: NodeTool@0
                 displayName: Use Node 20.x
                 inputs:

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -26,11 +26,7 @@ extends:
             templateContext:
               mb:
                  signing:
-                   enabled: true
-                   signType: real
-                   signWithProd: true
-                   zipSources: false
-                   feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                   enabled: false
               outputs:
                 - output: pipelineArtifact
                   artifactName: vsix
@@ -40,6 +36,19 @@ extends:
               - checkout: self
                 clean: true
                 fetchTags: false
+              # Pin the last known-good Windows plugin while the 1.1.1374 client certificate regression is unresolved.
+              - task: NuGetAuthenticate@1
+                displayName: Authenticate MicroBuild feed
+              - task: MicroBuildSigningPlugin@4
+                displayName: Install Signing Plugin 1.1.1330
+                inputs:
+                  signType: real
+                  version: '1.1.1330'
+                  zipSources: false
+                  ConnectedPMEServiceName: '40012d40-9ded-4f75-8476-d60758200346'
+                  feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                env:
+                  MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
               - task: NodeTool@0
                 displayName: Use Node 20.x
                 inputs:


### PR DESCRIPTION
## Summary
- disable the template-managed signing plugin installation for Windows nightly and RC builds
- explicitly install `MicroBuild.Plugins.Signing` `1.1.1330` using the same MSEng feed and PME service connection
- keep the existing VSIX signing step unchanged

## Context
Build [31919208](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31919208) installed `1.1.1374` and failed in `Sign extension` with `Unable to find certificate ea4022a2-6f71-4214-88b6-18d2bbd6b4cc`. The same `1.1.1330` pin has restored the Windows signing path in vscode-java-test build 31919206.

This is a temporary pin until the MicroBuild Windows client-certificate regression is resolved.

## Validation
- parsed both modified pipeline files with `js-yaml`
- ran `git diff --check`