### PR TITLE
build: revert Windows signing plugin pin

### DIFF
--- a/.azure-pipelines/nightly.yml
+++ b/.azure-pipelines/nightly.yml
@@ -31,7 +31,11 @@ extends:
             templateContext:
               mb:
                  signing:
-                   enabled: false
+                   enabled: true
+                   signType: real
+                   signWithProd: true
+                   zipSources: false
+                   feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
               outputs:
                 - output: pipelineArtifact
                   artifactName: vsix
@@ -41,19 +45,6 @@ extends:
               - checkout: self
                 clean: true
                 fetchTags: false
-              # Pin the last known-good Windows plugin while the 1.1.1374 client certificate regression is unresolved.
-              - task: NuGetAuthenticate@1
-                displayName: Authenticate MicroBuild feed
-              - task: MicroBuildSigningPlugin@4
-                displayName: Install Signing Plugin 1.1.1330
-                inputs:
-                  signType: real
-                  version: '1.1.1330'
-                  zipSources: false
-                  ConnectedPMEServiceName: '40012d40-9ded-4f75-8476-d60758200346'
-                  feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-                env:
-                  MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
               - task: NodeTool@0
                 displayName: Use Node 20.x
                 inputs:

--- a/.azure-pipelines/rc.yml
+++ b/.azure-pipelines/rc.yml
@@ -26,7 +26,11 @@ extends:
             templateContext:
               mb:
                  signing:
-                   enabled: false
+                   enabled: true
+                   signType: real
+                   signWithProd: true
+                   zipSources: false
+                   feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
               outputs:
                 - output: pipelineArtifact
                   artifactName: vsix
@@ -36,19 +40,6 @@ extends:
               - checkout: self
                 clean: true
                 fetchTags: false
-              # Pin the last known-good Windows plugin while the 1.1.1374 client certificate regression is unresolved.
-              - task: NuGetAuthenticate@1
-                displayName: Authenticate MicroBuild feed
-              - task: MicroBuildSigningPlugin@4
-                displayName: Install Signing Plugin 1.1.1330
-                inputs:
-                  signType: real
-                  version: '1.1.1330'
-                  zipSources: false
-                  ConnectedPMEServiceName: '40012d40-9ded-4f75-8476-d60758200346'
-                  feedSource: 'https://mseng.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-                env:
-                  MicroBuildOutputFolderOverride: '$(Agent.TempDirectory)'
               - task: NodeTool@0
                 displayName: Use Node 20.x
                 inputs:


### PR DESCRIPTION
## Summary

- Revert #1727.
- Restore template-managed MicroBuild signing configuration.
- Remove the temporary explicit signing-plugin pin.

SR21 validation is complete. Follow-up work will update the specific JAR signing path instead of overriding the pipeline-wide signing plugin.

## Validation

- Parsed both affected YAML files with `js-yaml`.
- `git diff --check`
