### PR TITLE
fix(deps): update js-yaml to patched releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2406,9 +2406,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3668,9 +3668,9 @@
       }
     },
     "node_modules/tslint/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
Update only [`package-lock.json`](https://github.com/microsoft/vscode-java-pack/blob/2e419e7b83dcb102b80b1ea7a5c241df1e1dc75e/package-lock.json): root `js-yaml` 4.2.0 → 4.3.2 and TSLint's nested copy 3.14.2 → 3.15.2. Both releases satisfy existing cosmiconfig/webpack-cli/TSLint constraints. Preserve lockfile v3 and all 312 entries; only the two packages' version, resolved URL, and integrity fields change. No manifest, override, runtime, or unrelated dependency changes.

## Alert coverage
| Advisory | Open Dependabot alerts |
| --- | --- |
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | [98](https://github.com/microsoft/vscode-java-pack/security/dependabot/98), [97](https://github.com/microsoft/vscode-java-pack/security/dependabot/97) |
| [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | [87](https://github.com/microsoft/vscode-java-pack/security/dependabot/87), [86](https://github.com/microsoft/vscode-java-pack/security/dependabot/86) |
| [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) | [84](https://github.com/microsoft/vscode-java-pack/security/dependabot/84) |

## Validation
- Node 22.15.1 / npm 10.9.2: `npm ci --no-fund` and `npm run build` passed. Build reports three Sass `@import` deprecation warnings and three bundle-size/performance warnings; no errors.
- `npm ls js-yaml --all` passed; all three parent dependency/peer ranges remain satisfied.
- Exact graph comparison confirms no added/removed package entries or unrelated metadata changes. Both locked instances are outside all five freshly fetched alert ranges.
- `npm audit --package-lock-only --ignore-scripts --json`: zero vulnerabilities, down from one affected package covering all five alerts. No audit-only exceptions remain; no alerts were dismissed or reopened. No dedicated lint or test npm script exists.
- Head CI is terminal: [production build](https://github.com/microsoft/vscode-java-pack/actions/runs/34204589481) and [E2E AutoTest](https://github.com/microsoft/vscode-java-pack/actions/runs/34204589494) succeeded; 55 successful checks, one aggregate-analysis job intentionally skipped for pull requests, and no external commit statuses.
- Initial E2E failure was an LLM false negative in [macOS dependency viewer](https://github.com/microsoft/vscode-java-pack/actions/runs/34204589494/job/101991482946): the deterministic expand action passed and the screenshot shows the expanded caret/child, while the LLM downgraded it and then contradicted itself in its analysis. The [same-main baseline](https://github.com/microsoft/vscode-java-pack/actions/runs/34189254335/job/101943769793) passed. A rerun requested for that failed job [passed](https://github.com/microsoft/vscode-java-pack/actions/runs/34204589494/job/101993910933) without code, test-plan, or timeout changes.